### PR TITLE
Improve the GitHub CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 
 # Run functional regression checks
 name: ci
-on: [push, pull_request]
+on: [push]
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@
 
 # Lint the design
 name: lint
-on: [push, pull_request]
+on: [push]
 
 jobs:
   check-license:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ara
 
+[![ci](https://github.com/pulp-platform/ara/actions/workflows/ci.yml/badge.svg)](https://github.com/pulp-platform/ara/actions/workflows/ci.yml)
+
 Ara is a vector unit working as a coprocessor for the CVA6 core.
 It supports the RISC-V Vector Extension, [version 0.9](https://github.com/riscv/riscv-v-spec/releases/tag/0.9).
 


### PR DESCRIPTION
With this PR, we only run the CI upon a push. We also add a badge of the `ci` workflow on the README.