### PR TITLE
following lowRISC coding style for sv section parameterized-objects-m…

### DIFF
--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -21,7 +21,7 @@ module ara import ara_pkg::*; #(
     parameter type          axi_resp_t   = logic,
     // Dependant parameters. DO NOT CHANGE!
     // Ara has NrLanes + 3 processing elements: each one of the lanes, the vector load unit, the vector store unit, the slide unit, and the mask unit.
-    parameter int  unsigned NrPEs        = NrLanes + 4
+    localparam int  unsigned NrPEs       = NrLanes + 4
   ) (
     // Clock and Reset
     input  logic              clk_i,

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -15,11 +15,11 @@ module ara_soc import axi_pkg::*; #(
     parameter int  unsigned AxiUserWidth = 1,
     parameter int  unsigned AxiIdWidth   = 6,
     // Dependant parameters. DO NOT CHANGE!
-    parameter type          axi_data_t   = logic [AxiDataWidth-1:0],
-    parameter type          axi_strb_t   = logic [AxiDataWidth/8-1:0],
-    parameter type          axi_addr_t   = logic [AxiAddrWidth-1:0],
-    parameter type          axi_user_t   = logic [AxiUserWidth-1:0],
-    parameter type          axi_id_t     = logic [AxiIdWidth-1:0]
+    localparam type          axi_data_t   = logic [AxiDataWidth-1:0],
+    localparam type          axi_strb_t   = logic [AxiDataWidth/8-1:0],
+    localparam type          axi_addr_t   = logic [AxiAddrWidth-1:0],
+    localparam type          axi_user_t   = logic [AxiUserWidth-1:0],
+    localparam type          axi_id_t     = logic [AxiIdWidth-1:0]
   ) (
     input  logic             clk_i,
     input  logic             rst_ni,

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -8,16 +8,16 @@
 // together with the execution units.
 
 module lane import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int  unsigned NrLanes         = 1,                                   // Number of lanes
+    parameter int  unsigned NrLanes          = 1,                                   // Number of lanes
     // Dependant parameters. DO NOT CHANGE!
     // VRF Parameters
-    parameter int  unsigned MaxVLenPerLane  = VLEN / NrLanes,                      // In bits
-    parameter int  unsigned MaxVLenBPerLane = VLENB / NrLanes,                     // In bytes
-    parameter int  unsigned VRFSizePerLane  = MaxVLenPerLane * 32,                 // In bits
-    parameter int  unsigned VRFBSizePerLane = MaxVLenBPerLane * 32,                // In bytes
-    parameter type          vaddr_t         = logic [$clog2(VRFBSizePerLane)-1:0], // Address of an element in the lane's VRF
-    parameter int  unsigned DataWidth       = $bits(elen_t),                       // Width of the lane datapath
-    parameter type          strb_t          = logic [DataWidth/8-1:0]              // Byte-strobe type
+    localparam int  unsigned MaxVLenPerLane  = VLEN / NrLanes,                      // In bits
+    localparam int  unsigned MaxVLenBPerLane = VLENB / NrLanes,                     // In bytes
+    localparam int  unsigned VRFSizePerLane  = MaxVLenPerLane * 32,                 // In bits
+    localparam int  unsigned VRFBSizePerLane = MaxVLenBPerLane * 32,                // In bytes
+    localparam type          vaddr_t         = logic [$clog2(VRFBSizePerLane)-1:0], // Address of an element in the lane's VRF
+    localparam int  unsigned DataWidth       = $bits(elen_t),                       // Width of the lane datapath
+    localparam type          strb_t          = logic [DataWidth/8-1:0]              // Byte-strobe type
   ) (
     input  logic                                           clk_i,
     input  logic                                           rst_ni,

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -16,8 +16,8 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
     parameter logic          SupportIntExt4 = 1'b0,
     parameter logic          SupportIntExt8 = 1'b0,
     // Dependant parameters. DO NOT CHANGE!
-    parameter int   unsigned DataWidth      = $bits(elen_t),
-    parameter int   unsigned StrbWidth      = DataWidth/8
+    localparam int   unsigned DataWidth     = $bits(elen_t),
+    localparam int   unsigned StrbWidth     = DataWidth/8
   ) (
     input  logic                              clk_i,
     input  logic                              rst_ni,

--- a/hardware/src/lane/operand_requester.sv
+++ b/hardware/src/lane/operand_requester.sv
@@ -13,7 +13,7 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
     parameter int  unsigned NrBanks = 0,                         // Number of banks in the vector register file
     parameter type          vaddr_t = logic,                     // Type used to address vector register file elements
     // Dependant parameters. DO NOT CHANGE!
-    parameter type          strb_t  = logic[$bits(elen_t)/8-1:0]
+    localparam type          strb_t = logic[$bits(elen_t)/8-1:0]
   ) (
     input  logic                                       clk_i,
     input  logic                                       rst_ni,

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -8,9 +8,9 @@
 
 module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     // Dependant parameters. DO NOT CHANGE!
-    parameter int  unsigned DataWidth = $bits(elen_t),
-    parameter int  unsigned StrbWidth = DataWidth/8,
-    parameter type          strb_t    = logic [StrbWidth-1:0]
+    localparam int  unsigned DataWidth = $bits(elen_t),
+    localparam int  unsigned StrbWidth = DataWidth/8,
+    localparam type          strb_t    = logic [StrbWidth-1:0]
   ) (
     input  elen_t   operand_a_i,
     input  elen_t   operand_b_i,

--- a/hardware/src/lane/simd_div.sv
+++ b/hardware/src/lane/simd_div.sv
@@ -9,9 +9,9 @@
 
 module simd_div import ara_pkg::*; import rvv_pkg::*; #(
     // Dependant parameters. DO NOT CHANGE!
-    parameter int  unsigned DataWidth = $bits(elen_t),
-    parameter int  unsigned StrbWidth = DataWidth/8,
-    parameter type          strb_t    = logic [DataWidth/8-1:0]
+    localparam int  unsigned DataWidth = $bits(elen_t),
+    localparam int  unsigned StrbWidth = DataWidth/8,
+    localparam type          strb_t    = logic [DataWidth/8-1:0]
   ) (
     input  logic    clk_i,
     input  logic    rst_ni,

--- a/hardware/src/lane/simd_mul.sv
+++ b/hardware/src/lane/simd_mul.sv
@@ -13,9 +13,9 @@ module simd_mul import ara_pkg::*; import rvv_pkg::*; #(
     parameter int   unsigned NumPipeRegs  = 0,
     parameter vew_e          ElementWidth = EW64,
     // Dependant parameters. DO NOT CHANGE!
-    parameter int   unsigned DataWidth    = $bits(elen_t),
-    parameter int   unsigned StrbWidth    = DataWidth/8,
-    parameter type           strb_t       = logic [DataWidth/8-1:0]
+    localparam int   unsigned DataWidth   = $bits(elen_t),
+    localparam int   unsigned StrbWidth   = DataWidth/8,
+    localparam type           strb_t      = logic [DataWidth/8-1:0]
   ) (
     input  logic    clk_i,
     input  logic    rst_ni,

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -8,13 +8,13 @@
 // in a SIMD fashion, always operating on 64 bits.
 
 module valu import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int  unsigned NrLanes   = 0,
+    parameter int  unsigned NrLanes    = 0,
     // Type used to address vector register file elements
-    parameter type          vaddr_t   = logic,
+    parameter type          vaddr_t    = logic,
     // Dependant parameters. DO NOT CHANGE!
-    parameter int  unsigned DataWidth = $bits(elen_t),
-    parameter int  unsigned StrbWidth = DataWidth/8,
-    parameter type          strb_t    = logic [StrbWidth-1:0]
+    localparam int  unsigned DataWidth = $bits(elen_t),
+    localparam int  unsigned StrbWidth = DataWidth/8,
+    localparam type          strb_t    = logic [StrbWidth-1:0]
   ) (
     input  logic                         clk_i,
     input  logic                         rst_ni,

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -8,12 +8,12 @@
 // of each lane, namely the ALU and the Multiplier/FPU.
 
 module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int  unsigned NrLanes   = 0,
+    parameter int  unsigned NrLanes    = 0,
     // Type used to address vector register file elements
-    parameter type          vaddr_t   = logic,
+    parameter type          vaddr_t    = logic,
     // Dependant parameters. DO NOT CHANGE!
-    parameter int  unsigned DataWidth = $bits(elen_t),
-    parameter type          strb_t    = logic [DataWidth/8-1:0]
+    localparam int  unsigned DataWidth = $bits(elen_t),
+    localparam type          strb_t    = logic [DataWidth/8-1:0]
   ) (
     input  logic                         clk_i,
     input  logic                         rst_ni,

--- a/hardware/src/lane/vector_regfile.sv
+++ b/hardware/src/lane/vector_regfile.sv
@@ -7,13 +7,13 @@
 // This is the vector register file of one lane.
 
 module vector_regfile import ara_pkg::*; #(
-    parameter int  unsigned NrBanks   = 0,                    // Number of banks in the vector register file
-    parameter int  unsigned VRFSize   = 0,                    // Size of the VRF, in bits
+    parameter int  unsigned NrBanks    = 0,                    // Number of banks in the vector register file
+    parameter int  unsigned VRFSize    = 0,                    // Size of the VRF, in bits
     // Dependant parameters. DO NOT CHANGE!
-    parameter int  unsigned DataWidth = $bits(elen_t),
-    parameter int  unsigned StrbWidth = DataWidth / 8,
-    parameter type          vaddr_t   = logic,
-    parameter type          strb_t    = logic [StrbWidth-1:0]
+    localparam int  unsigned DataWidth = $bits(elen_t),
+    localparam int  unsigned StrbWidth = DataWidth / 8,
+    parameter type          vaddr_t    = logic,
+    localparam type          strb_t    = logic [StrbWidth-1:0]
   ) (
     input  logic                           clk_i,
     input  logic                           rst_ni,

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -8,13 +8,13 @@
 // Ara's integer multiplier and floating-point unit.
 
 module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
-    parameter int  unsigned NrLanes   = 0,
+    parameter int  unsigned NrLanes    = 0,
     // Type used to address vector register file elements
-    parameter type          vaddr_t   = logic,
+    parameter type          vaddr_t    = logic,
     // Dependant parameters. DO NOT CHANGE!
-    parameter int  unsigned DataWidth = $bits(elen_t),
-    parameter int  unsigned StrbWidth = DataWidth/8,
-    parameter type          strb_t    = logic [DataWidth/8-1:0]
+    localparam int  unsigned DataWidth = $bits(elen_t),
+    localparam int  unsigned StrbWidth = DataWidth/8,
+    localparam type          strb_t    = logic [DataWidth/8-1:0]
   ) (
     input  logic                         clk_i,
     input  logic                         rst_ni,

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -10,12 +10,12 @@
 // predicated instructions.
 
 module masku import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int  unsigned NrLanes   = 0,
-    parameter type          vaddr_t   = logic,                // Type used to address vector register file elements
+    parameter int  unsigned NrLanes    = 0,
+    parameter type          vaddr_t    = logic,                // Type used to address vector register file elements
     // Dependant parameters. DO NOT CHANGE!
-    parameter int  unsigned DataWidth = $bits(elen_t),        // Width of the lane datapath
-    parameter int  unsigned StrbWidth = DataWidth/8,
-    parameter type          strb_t    = logic [StrbWidth-1:0] // Byte-strobe type
+    localparam int  unsigned DataWidth = $bits(elen_t),        // Width of the lane datapath
+    localparam int  unsigned StrbWidth = DataWidth/8,
+    localparam type          strb_t    = logic [StrbWidth-1:0] // Byte-strobe type
   ) (
     input  logic                        clk_i,
     input  logic                        rst_ni,

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -15,9 +15,9 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     parameter int  unsigned AxiAddrWidth = 0,
     parameter type          axi_r_t      = logic,
     // Dependant parameters. DO NOT CHANGE!
-    parameter int           DataWidth    = $bits(elen_t),
-    parameter type          strb_t       = logic[DataWidth/8-1:0],
-    parameter type          axi_addr_t   = logic [AxiAddrWidth-1:0]
+    localparam int           DataWidth    = $bits(elen_t),
+    localparam type          strb_t       = logic[DataWidth/8-1:0],
+    localparam type          axi_addr_t   = logic [AxiAddrWidth-1:0]
   ) (
     input  logic                           clk_i,
     input  logic                           rst_ni,

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -22,8 +22,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     parameter type          axi_req_t    = logic,
     parameter type          axi_resp_t   = logic,
     // Dependant parameters. DO NOT CHANGE!
-    parameter int  unsigned DataWidth    = $bits(elen_t),
-    parameter type          strb_t       = logic [DataWidth/8-1:0]
+    localparam int  unsigned DataWidth   = $bits(elen_t),
+    localparam type          strb_t      = logic [DataWidth/8-1:0]
   ) (
     input  logic                    clk_i,
     input  logic                    rst_ni,

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -22,9 +22,9 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
     parameter type          axi_w_t      = logic,
     parameter type          axi_b_t      = logic,
     // Dependant parameters. DO NOT CHANGE!
-    parameter int           DataWidth    = $bits(elen_t),
-    parameter type          strb_t       = logic[DataWidth/8-1:0],
-    parameter type          axi_addr_t   = logic [AxiAddrWidth-1:0]
+    localparam int           DataWidth   = $bits(elen_t),
+    localparam type          strb_t      = logic[DataWidth/8-1:0],
+    localparam type          axi_addr_t  = logic [AxiAddrWidth-1:0]
   )(
     input  logic                           clk_i,
     input  logic                           rst_ni,


### PR DESCRIPTION
localparams should be used were there are module-scoped constant. 