### PR TITLE
Add FP comparison instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+ - Vector floating-point compare instructions (vmfeq, vmfne, vmflt, vmfle, vmfgt, vmfge)
+
 ### Changed
 
 - Alignment with lowRISC's coding guidelines

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -43,6 +43,7 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 - Vector floating-point sign-injection instructions: `vfsgnj`, `vfsgnjn`, `vfsgnjx`
 - Vector floating-point merge instruction: `vfmerge`
 - Vector floating-point move instruction: `vfmv`
+- Vector floating-point compare instructions: `vmfeq`, `vmfne`, `vmflt`, `vmfle`, `vmfgt`, `vmfge`
 
 ## Vector mask instructions
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -85,6 +85,7 @@ rv64uv_sc_tests = vadd \
                   vfsgnjx \
                   vfmerge \
                   vfmv \
+                  vmfeq \
                   vmand \
                   vmnand \
                   vmandnot \
@@ -100,7 +101,7 @@ rv64uv_sc_tests = vadd \
                   vslide1down \
                   vfslide1down
 
-#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfeq vmfge vmfgt vmfle vmflt vmfne vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
+#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmfgt vmfle vmflt vmfne vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
 
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -89,6 +89,7 @@ rv64uv_sc_tests = vadd \
                   vmfne \
                   vmflt \
                   vmfle \
+                  vmfgt \
                   vmand \
                   vmnand \
                   vmandnot \
@@ -104,7 +105,7 @@ rv64uv_sc_tests = vadd \
                   vslide1down \
                   vfslide1down
 
-#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmfgt vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
+#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
 
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -86,6 +86,7 @@ rv64uv_sc_tests = vadd \
                   vfmerge \
                   vfmv \
                   vmfeq \
+                  vmfne \
                   vmand \
                   vmnand \
                   vmandnot \
@@ -101,7 +102,7 @@ rv64uv_sc_tests = vadd \
                   vslide1down \
                   vfslide1down
 
-#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmfgt vmfle vmflt vmfne vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
+#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmfgt vmfle vmflt vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
 
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -90,6 +90,7 @@ rv64uv_sc_tests = vadd \
                   vmflt \
                   vmfle \
                   vmfgt \
+                  vmfge \
                   vmand \
                   vmnand \
                   vmandnot \
@@ -105,7 +106,7 @@ rv64uv_sc_tests = vadd \
                   vslide1down \
                   vfslide1down
 
-#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
+#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
 
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -88,6 +88,7 @@ rv64uv_sc_tests = vadd \
                   vmfeq \
                   vmfne \
                   vmflt \
+                  vmfle \
                   vmand \
                   vmnand \
                   vmandnot \
@@ -103,7 +104,7 @@ rv64uv_sc_tests = vadd \
                   vslide1down \
                   vfslide1down
 
-#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmfgt vmfle vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
+#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmfgt vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
 
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -87,6 +87,7 @@ rv64uv_sc_tests = vadd \
                   vfmv \
                   vmfeq \
                   vmfne \
+                  vmflt \
                   vmand \
                   vmnand \
                   vmandnot \
@@ -102,7 +103,7 @@ rv64uv_sc_tests = vadd \
                   vslide1down \
                   vfslide1down
 
-#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmfgt vmfle vmflt vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
+#rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfclass vfcvt vfdiv vfirst vfmerge vfmv vfncvt vfrdiv vfsqrt vfsub vfwadd vfwcvt vfwmacc vfwmsac vfwmul vfwnmacc vfwnmsac vfwsub vid viota vl1r vl vlff vl_nocheck vls vlx vmfge vmfgt vmfle vmsbf vmsif vmsof vpopc_m vrgather vs1r vsadd vsaddu vs vsetvl vsetvli vsmul vss vssra vssrl vssub vssubu vsux vsx
 
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))
 

--- a/apps/riscv-tests/isa/rv64uv/vmfeq.c
+++ b/apps/riscv-tests/isa/rv64uv/vmfeq.c
@@ -4,56 +4,284 @@
 //
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 #include "vector_macros.h"
+#include "float_macros.h"
 
-void TEST_CASE1() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  VLOAD_F32(v3,_f(3.14159265).i,_f(-0.779).i,_f(-2000).i,_f(-5667.2346).i);
-  CLEAR(v1);
-  __asm__ volatile("vmfeq.vv v1, v2, v3");
-  VEC_CMP_U32(1,v1,9,0,0,0);
-}
+// This instruction writes a mask to a register, with a layout of elements as described in section "Mask Register Layout"
+void TEST_CASE1(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.0590,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x39db,  0x2b8c,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3041,  0xbb98);
+  asm volatile("vmfeq.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(1, v1,  0x0);
 
-void TEST_CASE2() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  VLOAD_F32(v3,_f(3.14159265).i,_f(-0.779).i,_f(-2000).i,_f(-5667.2346).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmfeq.vv v1, v2, v3, v0.t");
-  VEC_CMP_U32(2,v1,1,0,0,0);
+  VSET(16, e32, m1);
+  //                       +0,        sNaN, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0xffffffff,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5b88a4);
+  //                       -0,        sNaN,  0.39402914, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633, -0.00670803
+  VLOAD_32(v3,     0x80000000,  0xffffffff,  0x3ec9be30,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0xbbdbcefe);
+  asm volatile("vmfeq.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(2, v1,  0x1);
 
-}
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622,  0.4329957213663693
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0x3fdbb633afa4e520);
+  //              -0.3562510538138417, -0.0135629748736219,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0xbfd6ccd13852f170,  0xbf8bc6e7ac263f80,  0x3fed8915c5665532,  0x3fef0d4f6aafa2f6,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  asm volatile("vmfeq.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(3, v1,  0x4);
+};
 
-void TEST_CASE3() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  CLEAR(v1);
-  __asm__ volatile("vmfeq.vf v1, v2, f10");
-  VEC_CMP_U32(3,v1,1,0,0,0);
-}
+// Simple random test with similar values + 1 subnormal (masked)
+void TEST_CASE2(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.7285,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x39db,  0x39d4,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3507,  0xbb98);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(4, v1,  0x0002);
 
-void TEST_CASE4() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmfeq.vf v1, v2, f10, v0.t");
-  VEC_CMP_U32(4,v1,1,0,0,0);
+  VSET(16, e32, m1);
+  //               0x00000000,  0.09933749, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0x3dcb7174,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5d88a4);
+  //               0x00000000, -0.64782482,  0.39402914, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633,  0.85755372
+  VLOAD_32(v3,     0x00000000,  0xbf25d7d9,  0x3ec9be30,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0x3f5d88a4);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(5, v1,  0x8000);
 
-}
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622, -0.7793965434104730
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0xbfe8f0d105120796);
+  //               0.8643613633211786,  0.4842301798024149,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(6, v1,  0x800a);
+};
 
-int main(void){
-  INIT_CHECK();
+// Simple random test with similar values (vector-scalar)
+void TEST_CASE3(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //              -0.0651,  0.5806,  0.2563, -0.4783,  0.7393, -0.2649, -0.4590,  0.5469, -0.9082,  0.6235, -0.8276, -0.7939, -0.0236, -0.1166,  0.4026,  0.0022
+  VLOAD_16(v2,     0xac2a,  0x38a5,  0x341a,  0xb7a7,  0x39ea,  0xb43d,  0xb758,  0x3860,  0xbb44,  0x38fd,  0xba9f,  0xba5a,  0xa60b,  0xaf76,  0x3671,  0x1896);
+  asm volatile("vmfeq.vf v1, v2, %[A]" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(7, v1,  0x0020);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //              -0.15601152, -0.92020410, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,     0xbe1fc17c,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0xbf4b1daf);
+  asm volatile("vmfeq.vf v1, v2, %[A]" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(8, v1,  0x7ffe);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                0.8852775142880511, -0.1502080091211320, -0.7804423569145378,  0.4585094341291300,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,      0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  asm volatile("vmfeq.vf v1, v2, %[A]" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(9, v1,  0x0008);
+};
+
+// Simple random test with similar values (vector-scalar) (masked)
+void TEST_CASE4(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //               -0.2649,  0.5806, -0.2649, -0.4783, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649,
+  VLOAD_16(v2,      0xb43d,  0x7653,  0xad3d,  0x033d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(10, v1,  0xaaa0);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //                0.80517912,  0.80517912, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,      0x3f4e2038,  0x3f4e2038,  0xbe967703,  0x3f7c66bb,  0x3f61b2e8,  0xbee4905c,  0x3f61c543,  0x3e1b4092,  0xbf4cad78,  0xbd16465d,  0xbec4f07b,  0xbf0c2627,  0x3dcbe820,  0x3e5dbf70,  0xbec04b31,  0xbf4b1daf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(11, v1,  0x0002);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                 0.8852775142880511, -0.1502080091211320, -0.7804423569145378, -0.3394093097660049,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,       0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(12, v1,  0x0008);
+};
+
+// Check if only the correct destination bits are written
+void TEST_CASE5(void) {
+  // Fill 64-bits with 1
+  VSET(1, e64, m1);
+  VLOAD_64(v1, 0xffffffffffffffff);
+  // Perform vmfeq.vv on 16 different elements, and then check that the last (64 - 16 = 48) bits were not overwritten with zeroes
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.0590,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x33ca,  0x2b8c,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3041,  0xbb98);
+  asm volatile("vmfeq.vv v1, v2, v3");
+  VSET(1, e64, m1);
+  VCMP_U64(13, v1,  0xffffffffffff0001);
+
+  // Fill 64-bits with 1
+  VSET(1, e64, m1);
+  VLOAD_64(v1, 0xffffffffffffffff);
+  // Perform vmfeq.vv on 16 different elements, and then check that the last (64 - 16 = 48) bits were not overwritten with zeroes
+  VSET(16, e32, m1);
+  //              -0.72077256,        sNaN, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x70000000,  0xffffffff,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5b88a4);
+  //               0.79994357,        sNaN, -0.34645590, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633, -0.00670803
+  VLOAD_32(v3,     0x80000000,  0xffffffff,  0xbeb162ab,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0xbbdbcefe);
+  asm volatile("vmfeq.vv v1, v2, v3");
+  VSET(1, e64, m1);
+  VCMP_U64(14, v1,  0xffffffffffff0004);
+
+  // Fill 64-bits with 1
+  VSET(1, e64, m1);
+  VLOAD_64(v1, 0xffffffffffffffff);
+  // Perform vmfeq.vv on 16 different elements, and then check that the last (64 - 16 = 48) bits were not overwritten with zeroes
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622,  0.4329957213663693
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0xbf3180f63f75db3c,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0x3fdbb633afa4e520);
+  //               0.8643613633211786, -0.0135629748736219,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0x3feba8d9296c7e74,  0xbf8bc6e7ac263f80,  0x3fed8915c5665532,  0x3fef0d4f6aafa2f6,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  asm volatile("vmfeq.vv v1, v2, v3");
+  VSET(1, e64, m1);
+  VCMP_U64(15, v1,  0xffffffffffff0001);
+};
+
+// Write to v0 during a masked operation, WAR dependency should be respected
+void TEST_CASE6(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241,  0.7241,  0.0027, -0.7114,  0.8701,  0.8701, -0.5786, -0.4229,  0.6968,  0.6968,  0.7217, -0.2842,  0.1659,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3af6,  0x3af6,  0xb8a1,  0xb6c4,  0x3993,  0x3993,  0x39c6,  0xb48c,  0x314f,  0x314f);
+  //               0.2434,  0.7285, -0.2678, -0.2678,  0.0027, -0.7114,  0.2622,  0.2622, -0.5786, -0.4229,  0.5981,  0.5981,  0.7217, -0.2842,  0.1328,  0.1328
+  VLOAD_16(v3,     0x33ca,  0x39d4,  0xb449,  0x39cb,  0x1975,  0xb9b1,  0x3432,  0x3432,  0xb8a1,  0xb6c4,  0x38c9,  0x38c9,  0x39c6,  0xb48c,  0x3040,  0x3040);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v0, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(16, v0,  0x2222);
+
+  VSET(16, e32, m1);
+  //               0x00000000,  0.09933749, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0x3dcb7174,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5d88a4);
+  //               0x00000000,  0.09933749,  0.39402914, -0.81853813,  0.96037650, -0.81018746, -0.44735566, -0.25510681, -0.30920035, -0.31596854,  0.19188073, -0.29310879,  0.22002794,  0.48599416, -0.80913633, -0.30138883
+  VLOAD_32(v3,     0x00000000,  0x3dcb7174,  0x3ec9be30,  0xbf518bb7,  0x3f75db3c,  0xbf4f6872,  0xbee50bcd,  0xbe829d5c,  0xbe9e4f82,  0xbea1c6a1,  0x3e447c62,  0xbe96125b,  0x3e614f01,  0x3ef8d43a,  0xbf4f238f,  0xbe9a4fa3);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v0, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(17, v0,  0x2222);
+
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.8792039527057112, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622, -0.7793965434104730
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfec227053ec5198,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0xbfe8f0d105120796);
+  //               0.8643613633211786,  0.4842301798024149, -0.8792039527057112,  0.9703747829163081, -0.1308855743137316, -0.3798019472030296, -0.8792039527057112, -0.1745056251010144, -0.3736408604742532,  0.4947226024634424, -0.9079294226891812, -0.9490909352855985,  0.6283940115157876,  0.1053912590957002, -0.5927175227484118, -0.3032110323317654
+  VLOAD_64(v3,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0xbfec227053ec5198,  0x9fee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0xbfec227053ec5198,  0xbfc6563348637140,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfe2f78abcff0ede,  0xbfd367cf3ee9af68);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v0, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(18, v0,  0x2222);
+};
+
+// Test sNaN/qNaN behaviour
+void TEST_CASE7(void) {
+  CLEAR_FFLAGS;
+  // First, give only qNaN (no exception is generated)
+  VSET(16, e16, m1);
+  CHECK_FFLAGS(0);
+  VLOAD_16(v2,      qNaNh, qNaNh, 0x39cb, qNaNh,  0x1975,  0xb9b1,  0x3af6,  0x3af6,  0xb8a1,  0xb6c4,  0x3993,  0x3993,   qNaNh, 0xb48c,  qNaNh,  qNaNh);
+  VLOAD_16(v3,     0x33ca, qNaNh,  qNaNh, 0x39cb, 0x1975,  0xb9b1,  0x3432,  0x3432,  0xb8a1,  0xb6c4,  0x38c9,  0x38c9,  0x39c6,  qNaNh,  qNaNh,  0x3040);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v0, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(19, v0,  0x0330);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v2,     0x3f75db3c,       qNaNf,       qNaNf,       qNaNf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  qNaNf,       qNaNf,  0x3f3110b0,  qNaNf);
+  VLOAD_32(v3,     0x3f75db3c,  0x3dcb7174,       qNaNf,  0xbf518bb7,  0x3f75db3c,  0xbf4f6872,  0xbee50bcd,  0xbe829d5c,  0xbe9e4f82,  0xbea1c6a1,  0x3e447c62,  0xbe96125b,  qNaNf,  0x3ef8d43a,       qNaNf,  qNaNf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v0, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(20, v0,  0x0331);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v2,     qNaNd,               qNaNd,  0x3fed8915c5665532,  0xbfec227053ec5198,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  qNaNd,               qNaNd,  0xbfd2cb447b63f610,  qNaNd);
+  VLOAD_64(v3,     qNaNd,  0x3fdefda0947f3460,               qNaNd,  0x9fee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0xbfec227053ec5198,  0xbfc6563348637140,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  qNaNd,  0x3fbafaebeb19acf0,               qNaNd,  qNaNd);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v0, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(21, v0,  0x0330);
+  CHECK_FFLAGS(0);
+
+  // Give sNaN (Invalid operation)
+  VSET(16, e32, m1);
+  VLOAD_32(v2,     0x3f75db3c,       sNaNf,       sNaNf,       qNaNf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  qNaNf,       qNaNf,  0x3f3110b0,  qNaNf);
+  VLOAD_32(v3,     0x3f75db3c,  0x3dcb7174,       qNaNf,  0xbf518bb7,  0x3f75db3c,  0xbf4f6872,  0xbee50bcd,  0xbe829d5c,  0xbe9e4f82,  0xbea1c6a1,  0x3e447c62,  0xbe96125b,  qNaNf,  0x3ef8d43a,       qNaNf,  qNaNf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfeq.vv v0, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(22, v0,  0x0331);
+  CHECK_FFLAGS(NV);
+};
+
+int main(void) {
   enable_vec();
   enable_fp();
+
   TEST_CASE1();
   TEST_CASE2();
   TEST_CASE3();
   TEST_CASE4();
+
+//  TEST_CASE5();
+  TEST_CASE6();
+  TEST_CASE7();
+
   EXIT_CHECK();
 }

--- a/apps/riscv-tests/isa/rv64uv/vmfge.c
+++ b/apps/riscv-tests/isa/rv64uv/vmfge.c
@@ -4,34 +4,89 @@
 //
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 #include "vector_macros.h"
+#include "float_macros.h"
 
-void TEST_CASE1() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  CLEAR(v1);
-  __asm__ volatile("vmfge.vf v1, v2, f10");
-  VEC_CMP_U32(1,v1,5,0,0,0);
-}
+// Simple random test with similar values (vector-scalar)
+void TEST_CASE1(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //              -0.0651,  0.5806,  0.2563, -0.4783,  0.7393, -0.2649, -0.4590,  0.5469, -0.9082,  0.6235, -0.8276, -0.7939, -0.0236, -0.1166,  0.4026,  0.0022
+  VLOAD_16(v2,     0xac2a,  0x38a5,  0x341a,  0xb7a7,  0x39ea,  0xb43d,  0xb758,  0x3860,  0xbb44,  0x38fd,  0xba9f,  0xba5a,  0xa60b,  0xaf76,  0x3671,  0x1896);
+  asm volatile("vmfge.vf v1, v2, %[A]" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(1, v1,  0xf2b7);
 
-void TEST_CASE2() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmfge.vf v1, v2, f10, v0.t");
-  VEC_CMP_U32(2,v1,5,0,0,0);
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //              -0.15601152, -0.92020410, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,     0xbe1fc17c,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0xbf4b1daf);
+  asm volatile("vmfge.vf v1, v2, %[A]" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(2, v1,  0x7ffe);
 
-}
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                0.8852775142880511, -0.1502080091211320, -0.7804423569145378,  0.4585094341291300,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,      0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  asm volatile("vmfge.vf v1, v2, %[A]" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(3, v1,  0x4f7b);
+};
 
-int main(void){
-  INIT_CHECK();
+// Simple random test with similar values (vector-scalar) (masked)
+void TEST_CASE2(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //               -0.2649,  0.5806, -0.2649, -0.4783, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649,
+  VLOAD_16(v2,      0xb43d,  0x7653,  0xad3d,  0x033d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfge.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(4, v1,  0xaaaa);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //                0.80517912,  0.80517912, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,      0x3f4e2038,  0x3f4e2038,  0xbe967703,  0x3f7c66bb,  0x3f61b2e8,  0xbee4905c,  0x3f61c543,  0x3e1b4092,  0xbf4cad78,  0xbd16465d,  0xbec4f07b,  0xbf0c2627,  0x3dcbe820,  0x3e5dbf70,  0xbec04b31,  0xbf4b1daf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfge.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(5, v1,  0x000a);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                 0.8852775142880511, -0.1502080091211320, -0.7804423569145378, -0.3394093097660049,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,       0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfge.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(6, v1,  0x0a2a);
+};
+
+int main(void) {
   enable_vec();
   enable_fp();
+
   TEST_CASE1();
   TEST_CASE2();
+
   EXIT_CHECK();
 }

--- a/apps/riscv-tests/isa/rv64uv/vmfgt.c
+++ b/apps/riscv-tests/isa/rv64uv/vmfgt.c
@@ -4,34 +4,89 @@
 //
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 #include "vector_macros.h"
+#include "float_macros.h"
 
-void TEST_CASE1() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  CLEAR(v1);
-  __asm__ volatile("vmfgt.vf v1, v2, f10");
-  VEC_CMP_U32(1,v1,4,0,0,0);
-}
+// Simple random test with similar values (vector-scalar)
+void TEST_CASE1(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //              -0.0651,  0.5806,  0.2563, -0.4783,  0.7393, -0.2649, -0.4590,  0.5469, -0.9082,  0.6235, -0.8276, -0.7939, -0.0236, -0.1166,  0.4026,  0.0022
+  VLOAD_16(v2,     0xac2a,  0x38a5,  0x341a,  0xb7a7,  0x39ea,  0xb43d,  0xb758,  0x3860,  0xbb44,  0x38fd,  0xba9f,  0xba5a,  0xa60b,  0xaf76,  0x3671,  0x1896);
+  asm volatile("vmfgt.vf v1, v2, %[A]" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(1, v1,  0xf297);
 
-void TEST_CASE2() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmfgt.vf v1, v2, f10, v0.t");
-  VEC_CMP_U32(2,v1,4,0,0,0);
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //              -0.15601152, -0.92020410, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,     0xbe1fc17c,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0xbf4b1daf);
+  asm volatile("vmfgt.vf v1, v2, %[A]" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(2, v1,  0x0000);
 
-}
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                0.8852775142880511, -0.1502080091211320, -0.7804423569145378,  0.4585094341291300,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,      0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  asm volatile("vmfgt.vf v1, v2, %[A]" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(3, v1,  0x4f73);
+};
 
-int main(void){
-  INIT_CHECK();
+// Simple random test with similar values (vector-scalar) (masked)
+void TEST_CASE2(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //               -0.2649,  0.5806, -0.2649, -0.4783, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649,
+  VLOAD_16(v2,      0xb43d,  0x7653,  0xad3d,  0x033d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfgt.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(4, v1,  0x000a);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //                0.80517912,  0.80517912, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,      0x3f4e2038,  0x3f4e2038,  0xbe967703,  0x3f7c66bb,  0x3f61b2e8,  0xbee4905c,  0x3f61c543,  0x3e1b4092,  0xbf4cad78,  0xbd16465d,  0xbec4f07b,  0xbf0c2627,  0x3dcbe820,  0x3e5dbf70,  0xbec04b31,  0xbf4b1daf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfgt.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(5, v1,  0x0008);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                 0.8852775142880511, -0.1502080091211320, -0.7804423569145378, -0.3394093097660049,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,       0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfgt.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(6, v1,  0x0a22);
+};
+
+int main(void) {
   enable_vec();
   enable_fp();
+
   TEST_CASE1();
   TEST_CASE2();
+
   EXIT_CHECK();
 }

--- a/apps/riscv-tests/isa/rv64uv/vmfle.c
+++ b/apps/riscv-tests/isa/rv64uv/vmfle.c
@@ -4,55 +4,156 @@
 //
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 #include "vector_macros.h"
+#include "float_macros.h"
 
-void TEST_CASE1() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(-3000).i,_f(-5667.2346).i);
-  VLOAD_F32(v3,_f(3.14159265).i,_f(-0.779).i,_f(-2000).i,_f(-5667.2346).i);
-  __asm__ volatile("vmfle.vv v1, v2, v3");
-  VEC_CMP_U32(1,v1,13,0,0,0);
-}
+// This instruction writes a mask to a register, with a layout of elements as described in section "Mask Register Layout"
+void TEST_CASE1(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.0590,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x39db,  0x2b8c,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3041,  0xbb98);
+  asm volatile("vmfle.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(1, v1,  0x6325);
 
-void TEST_CASE2() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(-3000).i,_f(-5667.2346).i);
-  VLOAD_F32(v3,_f(3.14159265).i,_f(-0.779).i,_f(-2000).i,_f(-5667.2346).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmfle.vv v1, v2, v3, v0.t");
-  VEC_CMP_U32(2,v1,5,0,0,0);
-  VPRINTF("bla\n");
-}
+  VSET(16, e32, m1);
+  //                       +0,        sNaN, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0xffffffff,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5b88a4);
+  //                       -0,        sNaN,  0.39402914, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633, -0.00670803
+  VLOAD_32(v3,     0x80000000,  0xffffffff,  0x3ec9be30,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0xbbdbcefe);
+  asm volatile("vmfle.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(2, v1,  0x0665);
 
-void TEST_CASE3() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  CLEAR(v1);
-  __asm__ volatile("vmfle.vf v1, v2, f10");
-  VEC_CMP_U32(3,v1,11,0,0,0);
-}
+  VSET(16, e64, m1);
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0x3fdbb633afa4e520);
+  //              -0.3562510538138417, -0.0135629748736219,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0xbfd6ccd13852f170,  0xbf8bc6e7ac263f80,  0x3fed8915c5665532,  0x3fef0d4f6aafa2f6,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  asm volatile("vmfle.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(3, v1,  0x31bc);
+};
 
-void TEST_CASE4() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  VLOAD_U32(v0,5,0,1,0);
-  CLEAR(v1);
-  __asm__ volatile("vmfle.vf v1, v2, f10, v0.t");
-  VEC_CMP_U32(4,v1,1,0,0,0);
+// Simple random test with similar values + 1 subnormal (masked)
+void TEST_CASE2(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.7285,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x39db,  0x39d4,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3507,  0xbb98);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfle.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(4, v1,  0x2222);
 
-}
+  VSET(16, e32, m1);
+  //               0x00000000,  0.09933749, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0x3dcb7174,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5d88a4);
+  //               0x00000000, -0.64782482,  0.39402914, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633,  0.85755372
+  VLOAD_32(v3,     0x00000000,  0xbf25d7d9,  0x3ec9be30,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0x3f5d88a4);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfle.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(5, v1,  0x8220);
 
-int main(void){
-  INIT_CHECK();
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622, -0.7793965434104730
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0xbfe8f0d105120796);
+  //               0.8643613633211786,  0.4842301798024149,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfle.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(6, v1,  0xa0aa);
+};
+
+// Simple random test with similar values (vector-scalar)
+void TEST_CASE3(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //              -0.0651,  0.5806,  0.2563, -0.4783,  0.7393, -0.2649, -0.4590,  0.5469, -0.9082,  0.6235, -0.8276, -0.7939, -0.0236, -0.1166,  0.4026,  0.0022
+  VLOAD_16(v2,     0xac2a,  0x38a5,  0x341a,  0xb7a7,  0x39ea,  0xb43d,  0xb758,  0x3860,  0xbb44,  0x38fd,  0xba9f,  0xba5a,  0xa60b,  0xaf76,  0x3671,  0x1896);
+  asm volatile("vmfle.vf v1, v2, %[A]" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(7, v1,  0x0d68);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //              -0.15601152, -0.92020410, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,     0xbe1fc17c,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0xbf4b1daf);
+  asm volatile("vmfle.vf v1, v2, %[A]" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(8, v1,  0xffff);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                0.8852775142880511, -0.1502080091211320, -0.7804423569145378,  0.4585094341291300,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,      0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  asm volatile("vmfle.vf v1, v2, %[A]" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(9, v1,  0xb08c);
+};
+
+// Simple random test with similar values (vector-scalar) (masked)
+void TEST_CASE4(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //               -0.2649,  0.5806, -0.2649, -0.4783, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649,
+  VLOAD_16(v2,      0xb43d,  0x7653,  0xad3d,  0x033d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfle.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(10, v1,  0xaaa0);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //                0.80517912,  0.80517912, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,      0x3f4e2038,  0x3f4e2038,  0xbe967703,  0x3f7c66bb,  0x3f61b2e8,  0xbee4905c,  0x3f61c543,  0x3e1b4092,  0xbf4cad78,  0xbd16465d,  0xbec4f07b,  0xbf0c2627,  0x3dcbe820,  0x3e5dbf70,  0xbec04b31,  0xbf4b1daf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfle.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(11, v1,  0xaaa2);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                 0.8852775142880511, -0.1502080091211320, -0.7804423569145378, -0.3394093097660049,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,       0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfle.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(12, v1,  0xa088);
+};
+
+int main(void) {
   enable_vec();
   enable_fp();
+
   TEST_CASE1();
   TEST_CASE2();
   TEST_CASE3();
   TEST_CASE4();
+
   EXIT_CHECK();
 }

--- a/apps/riscv-tests/isa/rv64uv/vmflt.c
+++ b/apps/riscv-tests/isa/rv64uv/vmflt.c
@@ -4,56 +4,157 @@
 //
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 #include "vector_macros.h"
+#include "float_macros.h"
 
-void TEST_CASE1() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(-3000).i,_f(-5667.2346).i);
-  VLOAD_F32(v3,_f(3.14159265).i,_f(-0.779).i,_f(-2000).i,_f(-5667.2346).i);
-  CLEAR(v1);
-  __asm__ volatile("vmflt.vv v1, v2, v3");
-  VEC_CMP_U32(1,v1,4,0,0,0);
-}
+// This instruction writes a mask to a register, with a layout of elements as described in section "Mask Register Layout"
+void TEST_CASE1(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.0590,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x39db,  0x2b8c,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3041,  0xbb98);
+  asm volatile("vmflt.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(1, v1,  0x6325);
 
-void TEST_CASE2() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(-3000).i,_f(-5667.2346).i);
-  VLOAD_F32(v3,_f(3.14159265).i,_f(-0.779).i,_f(-2000).i,_f(-5667.2346).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmflt.vv v1, v2, v3, v0.t");
-  VEC_CMP_U32(2,v1,4,0,0,0);
+  VSET(16, e32, m1);
+  //                       +0,        sNaN, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0xffffffff,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5b88a4);
+  //                       -0,        sNaN,  0.39402914, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633, -0.00670803
+  VLOAD_32(v3,     0x80000000,  0xffffffff,  0x3ec9be30,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0xbbdbcefe);
+  asm volatile("vmflt.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(2, v1,  0x0664);
 
-}
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622,  0.4329957213663693
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0x3fdbb633afa4e520);
+  //              -0.3562510538138417, -0.0135629748736219,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0xbfd6ccd13852f170,  0xbf8bc6e7ac263f80,  0x3fed8915c5665532,  0x3fef0d4f6aafa2f6,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  asm volatile("vmflt.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(3, v1,  0x31b8);
+};
 
-void TEST_CASE3() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  CLEAR(v1);
-  __asm__ volatile("vmflt.vf v1, v2, f10");
-  VEC_CMP_U32(3,v1,10,0,0,0);
-}
+// Simple random test with similar values + 1 subnormal (masked)
+void TEST_CASE2(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.7285,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x39db,  0x39d4,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3507,  0xbb98);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmflt.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(4, v1,  0x2220);
 
-void TEST_CASE4() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmflt.vf v1, v2, f10, v0.t");
-  VEC_CMP_U32(4,v1,0,0,0,0);
+  VSET(16, e32, m1);
+  //               0x00000000,  0.09933749, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0x3dcb7174,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5d88a4);
+  //               0x00000000, -0.64782482,  0.39402914, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633,  0.85755372
+  VLOAD_32(v3,     0x00000000,  0xbf25d7d9,  0x3ec9be30,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0x3f5d88a4);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmflt.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(5, v1,  0x0220);
 
-}
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622, -0.7793965434104730
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0xbfe8f0d105120796);
+  //               0.8643613633211786,  0.4842301798024149,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmflt.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(6, v1,  0x20a0);
+};
 
-int main(void){
-  INIT_CHECK();
+// Simple random test with similar values (vector-scalar)
+void TEST_CASE3(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //              -0.0651,  0.5806,  0.2563, -0.4783,  0.7393, -0.2649, -0.4590,  0.5469, -0.9082,  0.6235, -0.8276, -0.7939, -0.0236, -0.1166,  0.4026,  0.0022
+  VLOAD_16(v2,     0xac2a,  0x38a5,  0x341a,  0xb7a7,  0x39ea,  0xb43d,  0xb758,  0x3860,  0xbb44,  0x38fd,  0xba9f,  0xba5a,  0xa60b,  0xaf76,  0x3671,  0x1896);
+  asm volatile("vmflt.vf v1, v2, %[A]" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(7, v1,  0x0d48);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //              -0.15601152, -0.92020410, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,     0xbe1fc17c,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0xbf4b1daf);
+  asm volatile("vmflt.vf v1, v2, %[A]" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(8, v1,  0x8001);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                0.8852775142880511, -0.1502080091211320, -0.7804423569145378,  0.4585094341291300,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,      0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  asm volatile("vmflt.vf v1, v2, %[A]" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(9, v1,  0xb084);
+};
+
+// Simple random test with similar values (vector-scalar) (masked)
+void TEST_CASE4(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //               -0.2649,  0.5806, -0.2649, -0.4783, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649,
+  VLOAD_16(v2,      0xb43d,  0x7653,  0xad3d,  0x033d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmflt.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(10, v1,  0x0000);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //                0.80517912,  0.80517912, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,      0x3f4e2038,  0x3f4e2038,  0xbe967703,  0x3f7c66bb,  0x3f61b2e8,  0xbee4905c,  0x3f61c543,  0x3e1b4092,  0xbf4cad78,  0xbd16465d,  0xbec4f07b,  0xbf0c2627,  0x3dcbe820,  0x3e5dbf70,  0xbec04b31,  0xbf4b1daf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmflt.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(11, v1,  0xaaa0);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                 0.8852775142880511, -0.1502080091211320, -0.7804423569145378, -0.3394093097660049,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,       0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmflt.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(12, v1,  0xa080);
+};
+
+int main(void) {
   enable_vec();
   enable_fp();
+
   TEST_CASE1();
   TEST_CASE2();
   TEST_CASE3();
   TEST_CASE4();
+
   EXIT_CHECK();
 }

--- a/apps/riscv-tests/isa/rv64uv/vmfne.c
+++ b/apps/riscv-tests/isa/rv64uv/vmfne.c
@@ -4,56 +4,284 @@
 //
 // Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
 #include "vector_macros.h"
+#include "float_macros.h"
 
-void TEST_CASE1() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  VLOAD_F32(v3,_f(3.14159265).i,_f(-0.779).i,_f(-2000).i,_f(-5667.2346).i);
-  CLEAR(v1);
-  __asm__ volatile("vmfne.vv v1, v2, v3");
-  VEC_CMP_U32(1,v1,6,0,0,0);
-}
+// This instruction writes a mask to a register, with a layout of elements as described in section "Mask Register Layout"
+void TEST_CASE1(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.0590,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x39db,  0x2b8c,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3041,  0xbb98);
+  asm volatile("vmfne.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(1, v1,  0xffff);
 
-void TEST_CASE2() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  VLOAD_F32(v3,_f(3.14159265).i,_f(-0.779).i,_f(-2000).i,_f(-5667.2346).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmfne.vv v1, v2, v3, v0.t");
-  VEC_CMP_U32(2,v1,4,0,0,0);
+  VSET(16, e32, m1);
+  //                       +0,        sNaN, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0xffffffff,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5b88a4);
+  //                       -0,        sNaN,  0.39402914, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633, -0.00670803
+  VLOAD_32(v3,     0x80000000,  0xffffffff,  0x3ec9be30,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0xbbdbcefe);
+  asm volatile("vmfne.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(2, v1,  0xfffe);
 
-}
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622,  0.4329957213663693
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0x3fdbb633afa4e520);
+  //              -0.3562510538138417, -0.0135629748736219,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0xbfd6ccd13852f170,  0xbf8bc6e7ac263f80,  0x3fed8915c5665532,  0x3fef0d4f6aafa2f6,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  asm volatile("vmfne.vv v1, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(3, v1,  0xfffb);
+};
 
-void TEST_CASE3() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  CLEAR(v1);
-  __asm__ volatile("vmfne.vf v1, v2, f10");
-  VEC_CMP_U32(3,v1,14,0,0,0);
-}
+// Simple random test with similar values + 1 subnormal (masked)
+void TEST_CASE2(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.7285,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x39db,  0x39d4,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3507,  0xbb98);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(4, v1,  0xaaa8);
 
-void TEST_CASE4() {
-  VSET(4,e32,m1);
-  VLOAD_F32(v2,_f(3.14159265).i,_f(-0.778).i,_f(1024).i,_f(-5667.2346).i);
-  FLOAD32(f10,_f(3.14159264).i);
-  VLOAD_U32(v0,5,0,0,0);
-  CLEAR(v1);
-  __asm__ volatile("vmfne.vf v1, v2, f10, v0.t");
-  VEC_CMP_U32(4,v1,4,0,0,0);
+  VSET(16, e32, m1);
+  //               0x00000000,  0.09933749, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0x3dcb7174,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5d88a4);
+  //               0x00000000, -0.64782482,  0.39402914, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633,  0.85755372
+  VLOAD_32(v3,     0x00000000,  0xbf25d7d9,  0x3ec9be30,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0x3f5d88a4);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(5, v1,  0x2aaa);
 
-}
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622, -0.7793965434104730
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0xbfe8f0d105120796);
+  //               0.8643613633211786,  0.4842301798024149,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfee55c27d3d743e,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v1, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(6, v1,  0x2aa0);
+};
 
-int main(void){
-  INIT_CHECK();
+// Simple random test with similar values (vector-scalar)
+void TEST_CASE3(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //              -0.0651,  0.5806,  0.2563, -0.4783,  0.7393, -0.2649, -0.4590,  0.5469, -0.9082,  0.6235, -0.8276, -0.7939, -0.0236, -0.1166,  0.4026,  0.0022
+  VLOAD_16(v2,     0xac2a,  0x38a5,  0x341a,  0xb7a7,  0x39ea,  0xb43d,  0xb758,  0x3860,  0xbb44,  0x38fd,  0xba9f,  0xba5a,  0xa60b,  0xaf76,  0x3671,  0x1896);
+  asm volatile("vmfne.vf v1, v2, %[A]" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(7, v1,  0xffdf);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //              -0.15601152, -0.92020410, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,     0xbe1fc17c,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0x3f4e2038,  0xbf4b1daf);
+  asm volatile("vmfne.vf v1, v2, %[A]" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(8, v1,  0x8001);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                0.8852775142880511, -0.1502080091211320, -0.7804423569145378,  0.4585094341291300,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,      0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  asm volatile("vmfne.vf v1, v2, %[A]" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(9, v1,  0xfff7);
+};
+
+// Simple random test with similar values (vector-scalar) (masked)
+void TEST_CASE4(void) {
+  VSET(16, e16, m1);
+  double dscalar_16;
+  //                             -0.2649
+  BOX_HALF_IN_DOUBLE(dscalar_16,  0xb43d);
+  //               -0.2649,  0.5806, -0.2649, -0.4783, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649, -0.2649,
+  VLOAD_16(v2,      0xb43d,  0x7653,  0xad3d,  0x033d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d,  0xb43d);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_16));
+  VSET(1, e16, m1);
+  VCMP_U16(10, v1,  0x000a);
+
+  VSET(16, e32, m1);
+  double dscalar_32;
+  //                               0.80517912
+  BOX_FLOAT_IN_DOUBLE(dscalar_32,  0x3f4e2038);
+  //                0.80517912,  0.80517912, -0.29387674,  0.98594254,  0.88163614, -0.44641387,  0.88191622,  0.15161350, -0.79952192, -0.03668820, -0.38464722, -0.54745716,  0.09956384,  0.21655059, -0.37557366, -0.79342169
+  VLOAD_32(v2,      0x3f4e2038,  0x3f4e2038,  0xbe967703,  0x3f7c66bb,  0x3f61b2e8,  0xbee4905c,  0x3f61c543,  0x3e1b4092,  0xbf4cad78,  0xbd16465d,  0xbec4f07b,  0xbf0c2627,  0x3dcbe820,  0x3e5dbf70,  0xbec04b31,  0xbf4b1daf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_32));
+  VSET(1, e16, m1);
+  VCMP_U16(11, v1,  0xaaa8);
+
+  VSET(16, e64, m1);
+  double dscalar_64;
+  //                               -0.3394093097660049
+  BOX_DOUBLE_IN_DOUBLE(dscalar_64,  0xbfd5b8e1d359c984);
+  //                 0.8852775142880511, -0.1502080091211320, -0.7804423569145378, -0.3394093097660049,  0.8417440789882031, -0.1215927835809432,  0.9442717441528423, -0.3993868853091622,  0.5719771249018739,  0.0497853851400327,  0.6627817945481365,  0.2150621318612425, -0.8506676370622683, -0.4531982633526939,  0.5943189287417812, -0.5034380636605356
+  VLOAD_64(v2,       0x3fec543182780b14,  0xbfc33a041b62e250,  0xbfe8f9623feb8e20,  0xbfd5b8e1d359c984,  0x3feaef91475b6422,  0xbfbf20b464e8e5d0,  0x3fee377960758bfa,  0xbfd98f8e02b6aa78,  0x3fe24da2f8b06fde,  0x3fa97d7851fd8b80,  0x3fe535822a7efd70,  0x3fcb8727eb79dda0,  0xbfeb38ab561e5658,  0xbfdd013349ed0b50,  0x3fe304a9214adedc,  0xbfe01c2a245f7960);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vf v1, v2, %[A], v0.t" :: [A] "f" (dscalar_64));
+  VSET(1, e16, m1);
+  VCMP_U16(12, v1,  0xaaa2);
+};
+
+// Check if only the correct destination bits are written
+void TEST_CASE5(void) {
+  // Fill 64-bits with 1
+  VSET(1, e64, m1);
+  VLOAD_64(v1, 0xffffffffffffffff);
+  // Perform vmfne.vv on 16 different elements, and then check that the last (64 - 16 = 48) bits were not overwritten with zeroes
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241, -0.2678,  0.0027, -0.7114,  0.2622,  0.8701, -0.5786, -0.4229,  0.5981,  0.6968,  0.7217, -0.2842,  0.1328,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3432,  0x3af6,  0xb8a1,  0xb6c4,  0x38c9,  0x3993,  0x39c6,  0xb48c,  0x3040,  0x314f);
+  //               0.7319,  0.0590,  0.7593, -0.6606, -0.4758,  0.8530,  0.0453,  0.0987,  0.1777,  0.3047,  0.2330, -0.3467, -0.4153,  0.7080,  0.3142, -0.9492
+  VLOAD_16(v3,     0x33ca,  0x2b8c,  0x3a13,  0xb949,  0xb79d,  0x3ad3,  0x29cc,  0x2e51,  0x31b0,  0x34e0,  0x3375,  0xb58c,  0xb6a5,  0x39aa,  0x3041,  0xbb98);
+  asm volatile("vmfne.vv v1, v2, v3");
+  VSET(1, e64, m1);
+  VCMP_U64(13, v1,  0xfffffffffffffffe);
+
+  // Fill 64-bits with 1
+  VSET(1, e64, m1);
+  VLOAD_64(v1, 0xffffffffffffffff);
+  // Perform vmfne.vv on 16 different elements, and then check that the last (64 - 16 = 48) bits were not overwritten with zeroes
+  VSET(16, e32, m1);
+  //              -0.72077256,        sNaN, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x70000000,  0xffffffff,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5b88a4);
+  //               0.79994357,        sNaN, -0.34645590, -0.81853813,  0.24656086, -0.71423489, -0.44735566, -0.25510681, -0.94378990, -0.30138883,  0.19188073, -0.29310879, -0.22981364, -0.58626360, -0.80913633, -0.00670803
+  VLOAD_32(v3,     0x80000000,  0xffffffff,  0xbeb162ab,  0xbf518bb7,  0x3e7c7a73,  0xbf36d819,  0xbee50bcd,  0xbe829d5c,  0xbf719c37,  0xbe9a4fa3,  0x3e447c62,  0xbe96125b,  0xbe6b5444,  0xbf16155f,  0xbf4f238f,  0xbbdbcefe);
+  asm volatile("vmfne.vv v1, v2, v3");
+  VSET(1, e64, m1);
+  VCMP_U64(14, v1,  0xfffffffffffffffb);
+
+  // Fill 64-bits with 1
+  VSET(1, e64, m1);
+  VLOAD_64(v1, 0xffffffffffffffff);
+  // Perform vmfne.vv on 16 different elements, and then check that the last (64 - 16 = 48) bits were not overwritten with zeroes
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.9479687162489723, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622,  0.4329957213663693
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0xbf3180f63f75db3c,  0xbfee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0x3fdbb633afa4e520);
+  //               0.8643613633211786, -0.0135629748736219,  0.6176167733891369,  0.9703747829163081, -0.0909539316920625, -0.1057326828885887, -0.8792039527057112, -0.1745056251010144,  0.3110320594479206,  0.3238986651420683, -0.9079294226891812, -0.9490909352855985,  0.6962970677624296,  0.7585780695949504, -0.5927175227484118, -0.7793965434104730
+  VLOAD_64(v3,     0x3feba8d9296c7e74,  0xbf8bc6e7ac263f80,  0x3fed8915c5665532,  0x3fef0d4f6aafa2f6,  0xbfb748c1c20f5de0,  0xbfbb114c0f1ff4b0,  0xbfec227053ec5198,  0xbfc6563348637140,  0x3fd3e7f302d586b4,  0x3fd4bac177803510,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe64810c9cae3fe,  0x3fe84645840bf0a2,  0xbfe2f78abcff0ede,  0xbfe8f0d105120796);
+  asm volatile("vmfne.vv v1, v2, v3");
+  VSET(1, e64, m1);
+  VCMP_U64(15, v1,  0xfffffffffffffffe);
+};
+
+// Write to v0 during a masked operation, WAR dependency should be respected
+void TEST_CASE6(void) {
+  VSET(16, e16, m1);
+  //               0.2434,  0.7285,  0.7241,  0.7241,  0.0027, -0.7114,  0.8701,  0.8701, -0.5786, -0.4229,  0.6968,  0.6968,  0.7217, -0.2842,  0.1659,  0.1659
+  VLOAD_16(v2,     0x33ca,  0x39d4,  0x39cb,  0xb449,  0x1975,  0xb9b1,  0x3af6,  0x3af6,  0xb8a1,  0xb6c4,  0x3993,  0x3993,  0x39c6,  0xb48c,  0x314f,  0x314f);
+  //               0.2434,  0.7285, -0.2678, -0.2678,  0.0027, -0.7114,  0.2622,  0.2622, -0.5786, -0.4229,  0.5981,  0.5981,  0.7217, -0.2842,  0.1328,  0.1328
+  VLOAD_16(v3,     0x33ca,  0x39d4,  0xb449,  0x39cb,  0x1975,  0xb9b1,  0x3432,  0x3432,  0xb8a1,  0xb6c4,  0x38c9,  0x38c9,  0x39c6,  0xb48c,  0x3040,  0x3040);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v0, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(16, v0,  0x8888);
+
+  VSET(16, e32, m1);
+  //               0x00000000,  0.09933749, -0.34645590, -0.06222415,  0.96037650, -0.81018746, -0.69337404,  0.70466602, -0.30920035, -0.31596854, -0.92116749,  0.51336122,  0.22002794,  0.48599416,  0.69166088,  0.85755372
+  VLOAD_32(v2,     0x00000000,  0x3dcb7174,  0xbeb162ab,  0xbd7edebf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  0x3e614f01,  0x3ef8d43a,  0x3f3110b0,  0x3f5d88a4);
+  //               0x00000000,  0.09933749,  0.39402914, -0.81853813,  0.96037650, -0.81018746, -0.44735566, -0.25510681, -0.30920035, -0.31596854,  0.19188073, -0.29310879,  0.22002794,  0.48599416, -0.80913633, -0.30138883
+  VLOAD_32(v3,     0x00000000,  0x3dcb7174,  0x3ec9be30,  0xbf518bb7,  0x3f75db3c,  0xbf4f6872,  0xbee50bcd,  0xbe829d5c,  0xbe9e4f82,  0xbea1c6a1,  0x3e447c62,  0xbe96125b,  0x3e614f01,  0x3ef8d43a,  0xbf4f238f,  0xbe9a4fa3);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v0, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(17, v0,  0x8888);
+
+  VSET(16, e64, m1);
+  //               0.8643613633211786,  0.4842301798024149,  0.9229840140784857, -0.8792039527057112, -0.1308855743137316, -0.3798019472030296,  0.1570811980936915, -0.7665403705017886, -0.3736408604742532,  0.4947226024634424, -0.3032110323317654,  0.8998114670494881,  0.6283940115157876,  0.1053912590957002, -0.2936564640984622, -0.7793965434104730
+  VLOAD_64(v2,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0x3fed8915c5665532,  0xbfec227053ec5198,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfd2cb447b63f610,  0xbfe8f0d105120796);
+  //               0.8643613633211786,  0.4842301798024149, -0.8792039527057112,  0.9703747829163081, -0.1308855743137316, -0.3798019472030296, -0.8792039527057112, -0.1745056251010144, -0.3736408604742532,  0.4947226024634424, -0.9079294226891812, -0.9490909352855985,  0.6283940115157876,  0.1053912590957002, -0.5927175227484118, -0.3032110323317654
+  VLOAD_64(v3,     0x3feba8d9296c7e74,  0x3fdefda0947f3460,  0xbfec227053ec5198,  0x9fee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0xbfec227053ec5198,  0xbfc6563348637140,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  0x3fe41bcdc20ecd40,  0x3fbafaebeb19acf0,  0xbfe2f78abcff0ede,  0xbfd367cf3ee9af68);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v0, v2, v3, v0.t");
+  VSET(1, e16, m1);
+  VCMP_U16(18, v0,  0x8888);
+};
+
+// Test sNaN/qNaN behaviour
+void TEST_CASE7(void) {
+  CLEAR_FFLAGS;
+  // First, give only qNaN (no exception is generated)
+  VSET(16, e16, m1);
+  CHECK_FFLAGS(0);
+  VLOAD_16(v2,      qNaNh, qNaNh, 0x39cb, qNaNh,  0x1975,  0xb9b1,  0x3af6,  0x3af6,  0xb8a1,  0xb6c4,  0x3993,  0x3993,   qNaNh, 0xb48c,  qNaNh,  qNaNh);
+  VLOAD_16(v3,     0x33ca, qNaNh,  qNaNh, 0x39cb, 0x1975,  0xb9b1,  0x3432,  0x3432,  0xb8a1,  0xb6c4,  0x38c9,  0x38c9,  0x39c6,  qNaNh,  qNaNh,  0x3040);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v0, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(19, v0,  0xfccf);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v2,     0x3f75db3c,       qNaNf,       qNaNf,       qNaNf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  qNaNf,       qNaNf,  0x3f3110b0,  qNaNf);
+  VLOAD_32(v3,     0x3f75db3c,  0x3dcb7174,       qNaNf,  0xbf518bb7,  0x3f75db3c,  0xbf4f6872,  0xbee50bcd,  0xbe829d5c,  0xbe9e4f82,  0xbea1c6a1,  0x3e447c62,  0xbe96125b,  qNaNf,  0x3ef8d43a,       qNaNf,  qNaNf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v0, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(20, v0,  0xfcce);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v2,     qNaNd,               qNaNd,  0x3fed8915c5665532,  0xbfec227053ec5198,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0x3fc41b3c98507fe0,  0xbfe8877fabcbce12,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfd367cf3ee9af68,  0x3feccb416af162fc,  qNaNd,               qNaNd,  0xbfd2cb447b63f610,  qNaNd);
+  VLOAD_64(v3,     qNaNd,  0x3fdefda0947f3460,               qNaNd,  0x9fee55c27d3d743e,  0xbfc0c0dbc6990b38,  0xbfd84eacd38c6ca4,  0xbfec227053ec5198,  0xbfc6563348637140,  0xbfd7e9bb5b0beaf8,  0x3fdfa988fd8b0a24,  0xbfed0dc20130d694,  0xbfee5ef3f3ff6a12,  qNaNd,  0x3fbafaebeb19acf0,               qNaNd,  qNaNd);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v0, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(21, v0,  0xfccf);
+  CHECK_FFLAGS(0);
+
+  // Give sNaN (Invalid operation)
+  VSET(16, e32, m1);
+  VLOAD_32(v2,     0x3f75db3c,       sNaNf,       sNaNf,       qNaNf,  0x3f75db3c,  0xbf4f6872,  0xbf3180f6,  0x3f3464fe,  0xbe9e4f82,  0xbea1c6a1,  0xbf6bd1a2,  0x3f036ba4,  qNaNf,       qNaNf,  0x3f3110b0,  qNaNf);
+  VLOAD_32(v3,     0x3f75db3c,  0x3dcb7174,       qNaNf,  0xbf518bb7,  0x3f75db3c,  0xbf4f6872,  0xbee50bcd,  0xbe829d5c,  0xbe9e4f82,  0xbea1c6a1,  0x3e447c62,  0xbe96125b,  qNaNf,  0x3ef8d43a,       qNaNf,  qNaNf);
+  VLOAD_8(v0, 0xAA, 0xAA);
+  VCLEAR(v1);
+  asm volatile("vmfne.vv v0, v2, v3");
+  VSET(1, e16, m1);
+  VCMP_U16(22, v0,  0xfcce);
+  CHECK_FFLAGS(NV);
+};
+
+int main(void) {
   enable_vec();
   enable_fp();
+
   TEST_CASE1();
   TEST_CASE2();
   TEST_CASE3();
   TEST_CASE4();
+
+//  TEST_CASE5();
+  TEST_CASE6();
+  TEST_CASE7();
+
   EXIT_CHECK();
 }

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -105,7 +105,7 @@ package ara_pkg;
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
     // Floating-point comparison instructions
-    VMFEQ,
+    VMFEQ, VMFLE, VMFLT, VMFNE, VMFGT, VMFGE,
     // Slide instructions
     VSLIDEUP, VSLIDEDOWN,
     // Load instructions

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -104,6 +104,8 @@ package ara_pkg;
     VMSEQ, VMSNE, VMSLTU, VMSLT, VMSLEU, VMSLE, VMSGTU, VMSGT,
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
+    // Floating-point comparison instructions
+    VMFEQ,
     // Slide instructions
     VSLIDEUP, VSLIDEDOWN,
     // Load instructions

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -497,6 +497,15 @@ package ara_pkg;
     endcase
   endfunction : deshuffle_index
 
+  /////////////////////////
+  //  MASKU definitions  //
+  /////////////////////////
+
+  // Which FU should process the mask unit request?
+  typedef enum logic {
+    MaskFUAlu, MaskFUMFpu
+  } masku_fu_e;
+
   ////////////////////////
   //  Lane definitions  //
   ////////////////////////

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -165,6 +165,7 @@ module ara import ara_pkg::*; #(
   elen_t  [NrLanes-1:0][2:0] masku_operand;
   logic   [NrLanes-1:0][2:0] masku_operand_valid;
   logic   [NrLanes-1:0][2:0] masku_operand_ready;
+  masku_fu_e                 masku_operand_fu;
   strb_t  [NrLanes-1:0]      mask;
   logic   [NrLanes-1:0]      mask_valid;
   logic   [NrLanes-1:0]      lane_mask_ready;
@@ -237,6 +238,7 @@ module ara import ara_pkg::*; #(
       .mask_operand_o              (masku_operand[lane]              ),
       .mask_operand_valid_o        (masku_operand_valid[lane]        ),
       .mask_operand_ready_i        (masku_operand_ready[lane]        ),
+      .mask_operand_fu_i           (masku_operand_fu                 ),
       .masku_result_req_i          (masku_result_req[lane]           ),
       .masku_result_addr_i         (masku_result_addr[lane]          ),
       .masku_result_id_i           (masku_result_id[lane]            ),
@@ -364,6 +366,7 @@ module ara import ara_pkg::*; #(
     .masku_operand_i      (masku_operand                   ),
     .masku_operand_valid_i(masku_operand_valid             ),
     .masku_operand_ready_o(masku_operand_ready             ),
+    .masku_operand_fu_o   (masku_operand_fu                ),
     .masku_result_req_o   (masku_result_req                ),
     .masku_result_addr_o  (masku_result_addr               ),
     .masku_result_id_o    (masku_result_id                 ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1286,6 +1286,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001000: ara_req_d.op = ara_pkg::VFSGNJ;
                   6'b001001: ara_req_d.op = ara_pkg::VFSGNJN;
                   6'b001010: ara_req_d.op = ara_pkg::VFSGNJX;
+                  6'b011000: ara_req_d.op = ara_pkg::VMFEQ;
                   6'b100100: ara_req_d.op = ara_pkg::VFMUL;
                   6'b101000: begin
                     ara_req_d.op             = ara_pkg::VFMADD;
@@ -1494,6 +1495,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.stride = 1;
                   end
                   6'b010111: ara_req_d.op = ara_pkg::VMERGE;
+                  6'b011000: ara_req_d.op = ara_pkg::VMFEQ;
                   6'b100100: ara_req_d.op = ara_pkg::VFMUL;
                   6'b100111: begin
                     ara_req_d.op             = ara_pkg::VFRSUB;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1287,6 +1287,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VFSGNJN;
                   6'b001010: ara_req_d.op = ara_pkg::VFSGNJX;
                   6'b011000: ara_req_d.op = ara_pkg::VMFEQ;
+                  6'b011001: ara_req_d.op = ara_pkg::VMFLE;
+                  6'b011011: ara_req_d.op = ara_pkg::VMFLT;
+                  6'b011100: ara_req_d.op = ara_pkg::VMFNE;
                   6'b100100: ara_req_d.op = ara_pkg::VFMUL;
                   6'b101000: begin
                     ara_req_d.op             = ara_pkg::VFMADD;
@@ -1496,6 +1499,11 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   end
                   6'b010111: ara_req_d.op = ara_pkg::VMERGE;
                   6'b011000: ara_req_d.op = ara_pkg::VMFEQ;
+                  6'b011001: ara_req_d.op = ara_pkg::VMFLE;
+                  6'b011011: ara_req_d.op = ara_pkg::VMFLT;
+                  6'b011100: ara_req_d.op = ara_pkg::VMFNE;
+                  6'b011101: ara_req_d.op = ara_pkg::VMFGT;
+                  6'b011111: ara_req_d.op = ara_pkg::VMFGE;
                   6'b100100: ara_req_d.op = ara_pkg::VFMUL;
                   6'b100111: begin
                     ara_req_d.op             = ara_pkg::VFRSUB;

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -97,7 +97,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; #(
     unique case (op) inside
       [VADD:VMERGE]        : vfu = VFU_Alu;
       [VMUL:VFSGNJX]       : vfu = VFU_MFpu;
-      [VMANDNOT:VMSBC]     : vfu = VFU_MaskUnit;
+      [VMANDNOT:VMFEQ]     : vfu = VFU_MaskUnit;
       [VLE:VLXE]           : vfu = VFU_LoadUnit;
       [VSE:VSXE]           : vfu = VFU_StoreUnit;
       [VSLIDEUP:VSLIDEDOWN]: vfu = VFU_SlideUnit;

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -97,7 +97,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; #(
     unique case (op) inside
       [VADD:VMERGE]        : vfu = VFU_Alu;
       [VMUL:VFSGNJX]       : vfu = VFU_MFpu;
-      [VMANDNOT:VMFEQ]     : vfu = VFU_MaskUnit;
+      [VMANDNOT:VMFGE]     : vfu = VFU_MaskUnit;
       [VLE:VLXE]           : vfu = VFU_LoadUnit;
       [VSE:VSXE]           : vfu = VFU_StoreUnit;
       [VSLIDEUP:VSLIDEDOWN]: vfu = VFU_SlideUnit;

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -65,6 +65,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output elen_t    [2:0]                                 mask_operand_o,
     output logic     [2:0]                                 mask_operand_valid_o,
     input  logic     [2:0]                                 mask_operand_ready_i,
+    input  masku_fu_e                                      mask_operand_fu_i,
     input  logic                                           masku_result_req_i,
     input  vid_t                                           masku_result_id_i,
     input  vaddr_t                                         masku_result_addr_i,
@@ -338,6 +339,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .mask_operand_o       (mask_operand_o[1]      ),
     .mask_operand_valid_o (mask_operand_valid_o[1]),
     .mask_operand_ready_i (mask_operand_ready_i[1]),
+    .mask_operand_fu_i    (mask_operand_fu_i      ),
     .mask_i               (mask_i                 ),
     .mask_valid_i         (mask_valid_i           ),
     .mask_ready_o         (mask_ready_o           )

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -465,7 +465,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
               if ((operand_request_i[AluA].vl << (int'(EW64) - int'(pe_req_i.eew_vs1))) * NrLanes !=
                   pe_req_i.vl) operand_request_i[AluA].vl += 1;
             end
-            operand_request_push[AluA] = pe_req_i.use_vs1;
+            operand_request_push[AluA] = (pe_req_i.use_vs1 && !(pe_req_i.op == VMFEQ)) ? 1'b1 : 1'b0;
 
             operand_request_i[AluB] = '{
               id     : pe_req_i.id,
@@ -491,7 +491,34 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
               if ((operand_request_i[AluB].vl << (int'(EW64) - int'(pe_req_i.eew_vs2))) * NrLanes !=
                   pe_req_i.vl) operand_request_i[AluB].vl += 1;
             end
-            operand_request_push[AluB] = pe_req_i.use_vs2;
+            operand_request_push[AluB] = (pe_req_i.use_vs2 && !(pe_req_i.op == VMFEQ)) ? 1'b1 : 1'b0;
+
+            operand_request_i[MulFPUA] = '{
+              id     : pe_req_i.id,
+              vs     : pe_req_i.vs1,
+              eew    : pe_req_i.eew_vs1,
+              vtype  : pe_req_i.vtype,
+              vstart : vfu_operation_d.vstart,
+              hazard : pe_req_i.hazard_vs1 | pe_req_i.hazard_vd,
+              default: '0
+            };
+
+            // This is an operation that runs normally on the ALU, and then gets *condensed* and reshuffled at the Mask Unit.
+            operand_request_i[MulFPUA].vl = (pe_req_i.vl + NrLanes - 1) / NrLanes;
+            operand_request_push[MulFPUA] = (pe_req_i.use_vs1 && pe_req_i.op == VMFEQ) ? 1'b1 : 1'b0;
+
+            operand_request_i[MulFPUB] = '{
+              id     : pe_req_i.id,
+              vs     : pe_req_i.vs2,
+              eew    : pe_req_i.eew_vs2,
+              vtype  : pe_req_i.vtype,
+              vstart : vfu_operation_d.vstart,
+              hazard : pe_req_i.hazard_vs2 | pe_req_i.hazard_vd,
+              default: '0
+            };
+            // This is an operation that runs normally on the ALU, and then gets *condensed* and reshuffled at the Mask Unit.
+            operand_request_i[MulFPUB].vl = (pe_req_i.vl + NrLanes - 1) / NrLanes;
+            operand_request_push[MulFPUB] = (pe_req_i.use_vs2 && pe_req_i.op == VMFEQ) ? 1'b1 : 1'b0;
 
             operand_request_i[MaskB] = '{
               id     : pe_req_i.id,

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -465,7 +465,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
               if ((operand_request_i[AluA].vl << (int'(EW64) - int'(pe_req_i.eew_vs1))) * NrLanes !=
                   pe_req_i.vl) operand_request_i[AluA].vl += 1;
             end
-            operand_request_push[AluA] = (pe_req_i.use_vs1 && !(pe_req_i.op == VMFEQ)) ? 1'b1 : 1'b0;
+            operand_request_push[AluA] = (pe_req_i.use_vs1 && !(pe_req_i.op inside {[VMFEQ:VMFGE]})) ? 1'b1 : 1'b0;
 
             operand_request_i[AluB] = '{
               id     : pe_req_i.id,
@@ -491,7 +491,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
               if ((operand_request_i[AluB].vl << (int'(EW64) - int'(pe_req_i.eew_vs2))) * NrLanes !=
                   pe_req_i.vl) operand_request_i[AluB].vl += 1;
             end
-            operand_request_push[AluB] = (pe_req_i.use_vs2 && !(pe_req_i.op == VMFEQ)) ? 1'b1 : 1'b0;
+            operand_request_push[AluB] = (pe_req_i.use_vs2 && !(pe_req_i.op inside {[VMFEQ:VMFGE]})) ? 1'b1 : 1'b0;
 
             operand_request_i[MulFPUA] = '{
               id     : pe_req_i.id,
@@ -505,7 +505,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
 
             // This is an operation that runs normally on the ALU, and then gets *condensed* and reshuffled at the Mask Unit.
             operand_request_i[MulFPUA].vl = (pe_req_i.vl + NrLanes - 1) / NrLanes;
-            operand_request_push[MulFPUA] = (pe_req_i.use_vs1 && pe_req_i.op == VMFEQ) ? 1'b1 : 1'b0;
+            operand_request_push[MulFPUA] = (pe_req_i.use_vs1 && pe_req_i.op inside {[VMFEQ:VMFGE]}) ? 1'b1 : 1'b0;
 
             operand_request_i[MulFPUB] = '{
               id     : pe_req_i.id,
@@ -518,7 +518,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             };
             // This is an operation that runs normally on the ALU, and then gets *condensed* and reshuffled at the Mask Unit.
             operand_request_i[MulFPUB].vl = (pe_req_i.vl + NrLanes - 1) / NrLanes;
-            operand_request_push[MulFPUB] = (pe_req_i.use_vs2 && pe_req_i.op == VMFEQ) ? 1'b1 : 1'b0;
+            operand_request_push[MulFPUB] = (pe_req_i.use_vs2 && pe_req_i.op inside {[VMFEQ:VMFGE]}) ? 1'b1 : 1'b0;
 
             operand_request_i[MaskB] = '{
               id     : pe_req_i.id,

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -383,7 +383,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
     //////////////////////////////
 
     if (!vinsn_queue_full && vfu_operation_valid_i &&
-      vfu_operation_i.vfu inside {VFU_Alu, VFU_MaskUnit}) begin
+      (vfu_operation_i.vfu == VFU_Alu || vfu_operation_i.op inside {[VMANDNOT:VMSBC]})) begin
       vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt] = vfu_operation_i;
 
       // Initialize counters

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -64,6 +64,10 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
   //  Signals  //
   ///////////////
 
+  // If the mask unit has instruction queue depth > 1, change the following lines.
+  // If we have concurrent masked MUL and ADD operations, mask_i and mask_valid_i are
+  // erroneously broadcasted and accepted to/by both the units. The mask unit must tag its
+  // broadcasted signals if more masked instructions can be in different units at the same time.
   logic alu_mask_ready;
   logic mfpu_mask_ready;
   assign mask_ready_o = alu_mask_ready | mfpu_mask_ready;

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -581,11 +581,11 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
   assign operands_valid = vinsn_issue_q.swap_vs2_vd_op
                         ? ((mfpu_operand_valid_i[2] || !vinsn_issue_q.use_vs2) &&
                            (mfpu_operand_valid_i[1] || !vinsn_issue_q.use_vd_op) &&
-                           (mask_valid_i || vinsn_issue_q.vm || vinsn_issue_q.vfu == VFU_MaskUnit) &&
+                           (mask_valid_i || vinsn_issue_q.vm) &&
                            (mfpu_operand_valid_i[0] || !vinsn_issue_q.use_vs1))
                         : ((mfpu_operand_valid_i[2] || !vinsn_issue_q.use_vd_op) &&
                            (mfpu_operand_valid_i[1] || !vinsn_issue_q.use_vs2) &&
-                           (mask_valid_i || vinsn_issue_q.vm || vinsn_issue_q.vfu == VFU_MaskUnit) &&
+                           (mask_valid_i || vinsn_issue_q.vm) &&
                            (mfpu_operand_valid_i[0] || !vinsn_issue_q.use_vs1));
 
   assign operands_ready = vinsn_issue_q.swap_vs2_vd_op

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -545,8 +545,8 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
       vfpu_processed_result = vfpu_result;
       // After a comparison, send the mask back to the mask unit
       // Encode the mask in the bit after each comparison result
-      if (vinsn_issue_q.op == VMFEQ) begin
-        unique case (vinsn_issue_q.vtype.vsew)
+      if (vinsn_processing.op == VMFEQ) begin
+        unique case (vinsn_processing.vtype.vsew)
           EW16: for (int b = 0; b < 4; b++) vfpu_processed_result[16*b+1] = vfpu_mask[2*b];
           EW32: for (int b = 0; b < 2; b++) vfpu_processed_result[32*b+1] = vfpu_mask[4*b];
           EW64: for (int b = 0; b < 1; b++) vfpu_processed_result[   b+1] = vfpu_mask[8*b];

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -664,7 +664,8 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       end
 
     // Finished committing the results of a vector instruction
-    if (vinsn_commit_valid && commit_cnt_d == '0 && masku_result_gnt_i) begin
+    // When the masku acts as a master for the VRF, wait the grant from the operand requester
+    if (vinsn_commit_valid && commit_cnt_d == '0 && (!(vinsn_issue.op inside {[VMSEQ:VMFGE]}) || masku_result_gnt_i)) begin
       // Mark the vector instruction as being done
       pe_resp.vinsn_done[vinsn_commit.id] = 1'b1;
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -273,7 +273,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       unique case (vinsn_issue.op) inside
         [VMANDNOT:VMXNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
-        [VMSEQ:VMSBC] : begin
+        [VMSEQ:VMFEQ] : begin
           automatic logic [ELEN*NrLanes-1:0] alu_result_flat = '0;
 
           unique case (vinsn_issue.vtype.vsew)
@@ -524,7 +524,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
           end
 
           // Increment the VRF pointer
-          if (vinsn_issue.op inside {[VMSEQ:VMSBC]}) begin
+          if (vinsn_issue.op inside {[VMSEQ:VMFEQ]}) begin
             vrf_pnt_d = vrf_pnt_q + (NrLanes << (int'(EW64) - vinsn_issue.vtype.vsew));
 
             // Filled-up a word, or finished execution

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -29,6 +29,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     input  logic     [NrLanes-1:0][2:0] masku_operand_valid_i,
     output logic     [NrLanes-1:0][2:0] masku_operand_ready_o,
     output logic     [NrLanes-1:0]      masku_result_req_o,
+    output masku_fu_e                   masku_operand_fu_o,
     output vid_t     [NrLanes-1:0]      masku_result_id_o,
     output vaddr_t   [NrLanes-1:0]      masku_result_addr_o,
     output elen_t    [NrLanes-1:0]      masku_result_wdata_o,
@@ -374,6 +375,9 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   // Remaining elements of the current instruction in the commit phase
   vlen_t commit_cnt_d, commit_cnt_q;
 
+  // Always broadcast information about which is the target FU of the request
+  assign masku_operand_fu_o = (vinsn_issue.op == VMFEQ) ? MaskFUMFpu : MaskFUAlu;
+
   always_comb begin: p_masku
     // Maintain state
     vinsn_queue_d = vinsn_queue_q;
@@ -504,7 +508,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             element_cnt_all_lanes = remaining_element_cnt_all_lanes;
 
           // Acknowledge the operands of this instruction.
-          // At this stage, acknowledge only the first operand, "a", coming from the ALU.
+          // At this stage, acknowledge only the first operand, "a", coming from the ALU/VMFpu.
           masku_operand_a_ready_o = masku_operand_a_valid_i;
 
           // Store the result in the operand queue

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -274,7 +274,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       unique case (vinsn_issue.op) inside
         [VMANDNOT:VMXNOR]: alu_result = (masku_operand_a_i & bit_enable_mask) |
           (masku_operand_b_i & ~bit_enable_mask);
-        [VMSEQ:VMFEQ] : begin
+        [VMSEQ:VMFGE] : begin
           automatic logic [ELEN*NrLanes-1:0] alu_result_flat = '0;
 
           unique case (vinsn_issue.vtype.vsew)
@@ -376,7 +376,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   vlen_t commit_cnt_d, commit_cnt_q;
 
   // Always broadcast information about which is the target FU of the request
-  assign masku_operand_fu_o = (vinsn_issue.op == VMFEQ) ? MaskFUMFpu : MaskFUAlu;
+  assign masku_operand_fu_o = (vinsn_issue.op inside {[VMFEQ:VMFGE]}) ? MaskFUMFpu : MaskFUAlu;
 
   always_comb begin: p_masku
     // Maintain state
@@ -528,7 +528,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
           end
 
           // Increment the VRF pointer
-          if (vinsn_issue.op inside {[VMSEQ:VMFEQ]}) begin
+          if (vinsn_issue.op inside {[VMSEQ:VMFGE]}) begin
             vrf_pnt_d = vrf_pnt_q + (NrLanes << (int'(EW64) - vinsn_issue.vtype.vsew));
 
             // Filled-up a word, or finished execution

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -664,7 +664,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       end
 
     // Finished committing the results of a vector instruction
-    if (vinsn_commit_valid && commit_cnt_d == '0) begin
+    if (vinsn_commit_valid && commit_cnt_d == '0 && masku_result_gnt_i) begin
       // Mark the vector instruction as being done
       pe_resp.vinsn_done[vinsn_commit.id] = 1'b1;
 


### PR DESCRIPTION
Add the following instructions, in their .vv, .vf when present, masked and unmasked:

* `vmfeq`
* `vmfne`
* `vmflt`
* `vmfle`
* `vmfgt`
* `vmfge`

**Notes**:
One specific test for both VMFEQ and VMFNE is currently commented, as it triggers this bug: https://github.com/pulp-platform/ara/issues/18.