### PR TITLE
Improve the linting workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+Description of PR that completes issue here...
+
+## Changelog
+
+### Fixed
+
+- Description of changes
+
+### Added
+
+- Description of changes
+
+### Changed
+
+- Description of changes
+
+## Checklist
+
+- [ ] Automated tests pass
+- [ ] Changelog updated
+- [ ] Code style guideline is observed
+
+Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 
 # Run functional regression checks
 name: ci
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,3 +354,21 @@ jobs:
         path: |
           apps/riscv-tests/isa/*.dump
           apps/riscv-tests/isa/*.out32
+
+####################
+#  Clean-up stage  #
+####################
+
+  clean-up:
+    runs-on: ubuntu-latest
+    needs: ["simulate-hello-world", "simulate-imatmul", "simulate-fmatmul", "riscv-tests-spike", "riscv-tests-simv"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Delete artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: |
+            tc-gcc
+            tc-isa-simv
+            tc-verilator
+            compile-ara

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@
 
 # Lint the design
 name: lint
-on: [push]
+on: [push, pull_request]
 
 jobs:
   check-license:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,3 +38,20 @@ jobs:
           ./scripts/run-clang-format.py --clang-format-executable clang-format $file || EXIT_STATUS=$?
         done
         exit $EXIT_STATUS
+
+  check-trailing-whitespaces:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Determine base commit
+      run: |
+        if [[ -n $GITHUB_BASE_REF ]]; then
+          # Make sure we have the latest version of the target branch
+          git fetch origin $GITHUB_BASE_REF
+          echo "base=origin/$GITHUB_BASE_REF" >> $GITHUB_ENV
+        else
+          echo "base=HEAD~1" >> $GITHUB_ENV
+        fi
+
+    - name: Check for trailing whitespaces and tabs
+      run: git diff --check $base HEAD --

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Determine base commit
       run: |
         if [[ -n $GITHUB_BASE_REF ]]; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,25 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.x
-    - name: Install requirements
+    - name: Install Python requirements
       run: pip install -r python-requirements.txt
     - name: Check license
       run: python scripts/licence-checker.py --config scripts/licence-checker.hjson hardware
+
+  check-clang-format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install Python requirements
+      run: pip install -r python-requirements.txt
+    - name: Install clang-format
+      run: sudo apt-get install clang-format
+    - name: Run clang-format
+      run: |
+        for file in `find apps -type f -name "*.[c|h|cpp|hpp]" | grep -vP "apps/riscv-tests"`; do
+          ./scripts/run-clang-format.py --clang-format-executable clang-format $file || EXIT_STATUS=$?
+        done
+        exit $EXIT_STATUS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Vector widening floating-point multiply instructions (vfwmul)
   - Vector widening floating-point fused multiply-add instructions (vfwmacc, vfwnmacc, vfwmsac, vfwnmsac)
 
+### Changed
+
+- Contributing guidelines updated to include commit message and C++ code style guidelines
+
 ## 1.0.0 - 2020-03-10
 
 ### Added

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global owners
-@suehtamacv
+* @suehtamacv @mp-17
 
 # Ariane
 hardware/src/cva6 @nwistoff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,36 @@
 # Styleguides
 
-See [style-guidlines](https://github.com/pulp-platform/style-guidelines)
+We are happy to accept pull requests and issues from any contributors. Please
+note that we try to maintain a consistent quality standard. For a quick overview
+please find some of the most important points below.
+
+## Quick Overview
+
+* Keep a clean commit history. This means no merge commits, and no long series
+  of "fixup" patches (rebase or squash as appropriate). Structure work as a
+  series of logically ordered, atomic patches. `git rebase -i` is your friend.
+* Changes should only be made via pull request, with review. A pull request will
+  be committed by a "committer" (an account listed in `CODEOWNERS`) once it has
+  had an explicit positive review.
+* Make sure you update the [CHANGELOG](CHANGELOG.md) when submitting a MR.
+* When changes are restricted to a specific area, you are recommended to add a
+  tag to the beginning of the first line of the commit message in square
+  brackets e.g., "[apps] Fix bug #157".
+* Do not force push. After rebasing, use `--force-with-lease` instead.
+* Do not attempt to commit code with a non-Apache (or Solderpad for hardware)
+  license without discussing first.
+* If a relevant bug or tracking issue exists, reference it in the pull request
+  and commits.
 
 ## Git Considerations
 
-- Do not push to master, if you want to add a feature do it in your branch.
-- Separate subject from body with a blank line.
-- Limit the subject line to 50 characters.
-- Capitalize the subject line.
-- Do not end the subject line with a period.
-- Use the imperative mood in the subject line.
-- Use the present tense ("Add feature" not "Added feature").
-- Wrap the body at 72 characters.
-- Use the body to explain what and why vs. how.
-- Consider starting the commit message with an applicable emoji:
+* Separate subject from body with a blank line
+* Limit the subject line to 72 characters
+* Capitalize the subject line
+* Do not end the subject line with a period
+* Use the imperative mood in the subject line
+* Use the body to explain what and why vs. how
+* Consider starting the commit message with an applicable emoji:
     * :sparkles: `:sparkles:` When introducing a new feature
     * :art: `:art:` Improving the format/structure of the code
     * :zap: `:zap:` When improving performance
@@ -30,12 +47,21 @@ See [style-guidlines](https://github.com/pulp-platform/style-guidelines)
     * :arrow_down: `:arrow_down:` When downgrading dependencies
     * :rotating_light: `:rotating_light:` When removing linter warnings
     * :pencil2: `:pencil2:` Fixing typos
-    * :recycle: `:scisccor:` Refactoring code.
+    * :recycle: `:recycle:` Refactoring code.
     * :boom: `:boom:` Introducing breaking changes
     * :truck: `:truck:` Moving or renaming files.
     * :space_invader: `:space_invader:` When fixing something synthesis related
-    * :beers: `:beer:` Writing code drunkenly.
     * :ok_hand: `:ok_hand` Updating code due to code review changes
     * :building_construction: `:building_construction:` Making architectural changes.
 
-For a detailed why and how please refer to one of the multiple [resources](https://chris.beams.io/posts/git-commit/) regarding git commit messages.
+For further information please see the excellent
+[guide](https://chris.beams.io/posts/git-commit/) by Chris Beams.
+
+## Code Style
+
+Consistent code style is important. We try to follow existing style conventions
+as much as possible:
+
+* For RTL we use [lowRISC's SystemVerilog style
+  guidelines](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md).
+* For C/C++ we follow [LLVM's style guide](https://llvm.org/docs/CodingStandards.html).

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -25,6 +25,9 @@ The riscv-tests repository is licensed under the BSD license.
 The unit tests can also run on Spike, the RISC-V ISA Simulator, which is also included as a submodule (`toolchain/riscv-isa-sim`).
 This version of Spike is patched to align the behavior of the `vcsr` CSR with the toolchain and with RVV v0.9.
 
+We provide a Python script to run `clang-format` and format the C and C++ files of this repository (`scripts/run-clang-format.py`).
+This file is licensed under the MIT license.
+
 ### Verilator simulations
 
 In order to run Verilator simulations, you will need a modern Verilator installation.

--- a/apps/common/riscv_test.h
+++ b/apps/common/riscv_test.h
@@ -9,84 +9,82 @@
 
 #define RVTEST_RV64U
 
-#define RVTEST_RV64UF                                                   \
-  .globl rvtest_init;                                                   \
-  rvtest_init:                                                          \
-  RVTEST_FP_ENABLE;                                                     \
+#define RVTEST_RV64UF                                                          \
+  .globl rvtest_init;                                                          \
+  rvtest_init:                                                                 \
+  RVTEST_FP_ENABLE;                                                            \
   ret
 
-#define RVTEST_RV64UV                                                   \
-  .globl rvtest_init;                                                   \
-  rvtest_init:                                                          \
+#define RVTEST_RV64UV                                                          \
+  .globl rvtest_init;                                                          \
+  rvtest_init:                                                                 \
   RVTEST_VECTOR_ENABLE;
+ret
+
+#define RVTEST_RV64M                                                           \
+  .globl rvtest_init;                                                          \
+  rvtest_init:                                                                 \
+  RVTEST_ENABLE_MACHINE;                                                       \
   ret
 
-#define RVTEST_RV64M                                                    \
-  .globl rvtest_init;                                                   \
-  rvtest_init:                                                          \
-  RVTEST_ENABLE_MACHINE;                                                \
+#define RVTEST_RV64S                                                           \
+  .globl rvtest_init;                                                          \
+  rvtest_init:                                                                 \
+  RVTEST_ENABLE_SUPERVISOR;                                                    \
   ret
 
-#define RVTEST_RV64S                                                    \
-  .globl rvtest_init;                                                   \
-  rvtest_init:                                                          \
-  RVTEST_ENABLE_SUPERVISOR;                                             \
-  ret
+#define RVTEST_ENABLE_SUPERVISOR                                               \
+  li a0, MSTATUS_MPP &(MSTATUS_MPP >> 1);                                      \
+  csrs mstatus, a0;                                                            \
+  li a0, SIP_SSIP | SIP_STIP;                                                  \
+  csrs mideleg, a0;
 
-#define RVTEST_ENABLE_SUPERVISOR                                        \
-  li a0, MSTATUS_MPP & (MSTATUS_MPP >> 1);                              \
-  csrs mstatus, a0;                                                     \
-  li a0, SIP_SSIP | SIP_STIP;                                           \
-  csrs mideleg, a0;                                                     \
+#define RVTEST_ENABLE_MACHINE                                                  \
+  li a0, MSTATUS_MPP;                                                          \
+  csrs mstatus, a0;
 
-#define RVTEST_ENABLE_MACHINE                                           \
-  li a0, MSTATUS_MPP;                                                   \
-  csrs mstatus, a0;                                                     \
-
-#define RVTEST_FP_ENABLE                                                \
-  li a0, MSTATUS_FS & (MSTATUS_FS >> 1);                                \
-  csrs mstatus, a0;                                                     \
+#define RVTEST_FP_ENABLE                                                       \
+  li a0, MSTATUS_FS &(MSTATUS_FS >> 1);                                        \
+  csrs mstatus, a0;                                                            \
   csrwi fcsr, 0
 
-#define RVTEST_VECTOR_ENABLE                                            \
-  li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) |                             \
-         (MSTATUS_FS & (MSTATUS_FS >> 1));                              \
-  csrs mstatus, a0;                                                     \
-  csrwi fcsr, 0;                                                        \
+#define RVTEST_VECTOR_ENABLE                                                   \
+  li a0, (MSTATUS_VS & (MSTATUS_VS >> 1)) | (MSTATUS_FS & (MSTATUS_FS >> 1));  \
+  csrs mstatus, a0;                                                            \
+  csrwi fcsr, 0;                                                               \
   csrwi vcsr, 0;
 
-#define RISCV_MULTICORE_DISABLE                                         \
-  csrr a0, mhartid;                                                     \
-  1: bnez a0, 1b
+#define RISCV_MULTICORE_DISABLE                                                \
+  csrr a0, mhartid;                                                            \
+  1 : bnez a0, 1b
 
-#define RVTEST_CODE_BEGIN                                               \
-  .globl main;                                                          \
-  .align 2;                                                             \
-  main:                                                                 \
+#define RVTEST_CODE_BEGIN                                                      \
+  .globl main;                                                                 \
+  .align 2;                                                                    \
+  main:
 
 //-----------------------------------------------------------------------
 // End Macro
 //-----------------------------------------------------------------------
 
-#define RVTEST_CODE_END                                                 \
-        unimp
+#define RVTEST_CODE_END unimp
 
 //-----------------------------------------------------------------------
 // Pass/Fail Macro
 //-----------------------------------------------------------------------
 
-#define RVTEST_PASS                                                     \
-        li a0, 0;                                                       \
-        j _eoc
+#define RVTEST_PASS                                                            \
+  li a0, 0;                                                                    \
+  j _eoc
 
 #define TESTNUM gp
-#define RVTEST_FAIL                                                     \
-        fence;                                                          \
-1:      beqz TESTNUM, 1b;                                               \
-        sll TESTNUM, TESTNUM, 1;                                        \
-        or TESTNUM, TESTNUM, 1;                                         \
-        addi a0, TESTNUM, 0;                                            \
-        j _fail
+#define RVTEST_FAIL                                                            \
+  fence;                                                                       \
+  1 : beqz TESTNUM, 1b;                                                        \
+  sll TESTNUM, TESTNUM, 1;                                                     \
+  or TESTNUM, TESTNUM, 1;                                                      \
+  addi a0, TESTNUM, 0;                                                         \
+  j _fail
 
 //-----------------------------------------------------------------------
 // Data Section Macro

--- a/apps/common/runtime.h
+++ b/apps/common/runtime.h
@@ -8,21 +8,16 @@ extern int64_t timer;
 // Return the current value of the cycle counter
 inline int64_t get_cycle_count() {
   int64_t cycle_count;
-  asm volatile ("csrr %[cycle_count], cycle" : [cycle_count] "=r" (cycle_count));
+  asm volatile("csrr %[cycle_count], cycle"
+               : [ cycle_count ] "=r"(cycle_count));
   return cycle_count;
 };
 
 // Start and stop the counter
-inline void start_timer() {
-  timer = -get_cycle_count();
-}
-inline void stop_timer() {
-  timer += get_cycle_count();
-}
+inline void start_timer() { timer = -get_cycle_count(); }
+inline void stop_timer() { timer += get_cycle_count(); }
 
 // Get the value of the timer
-inline int64_t get_timer() {
-  return timer;
-}
+inline int64_t get_timer() { return timer; }
 
 #endif // _RUNTIME_H_

--- a/apps/fmatmul/kernel/matmul.c
+++ b/apps/fmatmul/kernel/matmul.c
@@ -19,9 +19,10 @@
 
 #include "matmul.h"
 
-#define MIN(a,b) ((a)<(b)?(a):(b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-void matmul(double *c, const double *a, const double *b, int64_t M, int64_t N, int64_t P) {
+void matmul(double *c, const double *a, const double *b, int64_t M, int64_t N,
+            int64_t P) {
   if (M <= 4) {
     matmul_4x4(c, a, b, M, N, P);
   } else if (M <= 8) {
@@ -35,13 +36,14 @@ void matmul(double *c, const double *a, const double *b, int64_t M, int64_t N, i
 // 4x4
 // ---------------
 
-void matmul_4x4(double *c, const double *a, const double *b, int64_t M, int64_t N, int64_t P) {
+void matmul_4x4(double *c, const double *a, const double *b, int64_t M,
+                int64_t N, int64_t P) {
   // We work on 4 rows of the matrix at once
   int64_t block_size = 4;
   int64_t block_size_p;
 
   // Set the vector configuration
-  asm volatile ("vsetvli %0, %1, e64, m4" : "=r" (block_size_p) : "r" (P));
+  asm volatile("vsetvli %0, %1, e64, m4" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
   for (int64_t p = 0; p < P; p += block_size_p) {
@@ -52,13 +54,13 @@ void matmul_4x4(double *c, const double *a, const double *b, int64_t M, int64_t 
     const double *b_ = b + p;
     double *c_ = c + p;
 
-    asm volatile ("vsetvli zero, %0, e64, m4" :: "r" (p_));
+    asm volatile("vsetvli zero, %0, e64, m4" ::"r"(p_));
 
     // Iterate over the rows
     for (int64_t m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
-      const double *a_ = a + m*N;
-      double *c__ = c_ + m*P;
+      const double *a_ = a + m * N;
+      double *c__ = c_ + m * P;
 
       matmul_vec_4x4_slice_init();
       matmul_vec_4x4(c__, a_, b_, N, P);
@@ -67,13 +69,14 @@ void matmul_4x4(double *c, const double *a, const double *b, int64_t M, int64_t 
 }
 
 void matmul_vec_4x4_slice_init() {
-  asm volatile ("vmv.v.i v0,  0");
-  asm volatile ("vmv.v.i v4,  0");
-  asm volatile ("vmv.v.i v8,  0");
-  asm volatile ("vmv.v.i v12, 0");
+  asm volatile("vmv.v.i v0,  0");
+  asm volatile("vmv.v.i v4,  0");
+  asm volatile("vmv.v.i v8,  0");
+  asm volatile("vmv.v.i v12, 0");
 }
 
-void matmul_vec_4x4(double *c, const double *a, const double *b, int64_t N, int64_t P) {
+void matmul_vec_4x4(double *c, const double *a, const double *b, int64_t N,
+                    int64_t P) {
   // Temporary variables
   double t0, t1, t2, t3;
 
@@ -81,75 +84,91 @@ void matmul_vec_4x4(double *c, const double *a, const double *b, int64_t N, int6
   const double *a_ = a;
 
   // Prefetch one row of matrix B
-  asm volatile ("vle64.v v16, (%0);" :: "r" (b)); b += P;
+  asm volatile("vle64.v v16, (%0);" ::"r"(b));
+  b += P;
 
   // Prefetch one row of scalar values
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3) : [a] "r" (a));
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
 
   // Compute the multiplication
   int64_t n = 0;
 
   while (n < N) {
     // Calculate pointer to the matrix A
-    a = (const double*)a_ + ++n;
+    a = (const double *)a_ + ++n;
 
-    asm volatile ("vfmacc.vf v0, %0, v16" :: "f" (t0));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vfmacc.vf v0, %0, v16" ::"f"(t0));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v20, (%0);" :: "r" (b)); b += P;
+    asm volatile("vle64.v v20, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vfmacc.vf v4, %0, v16" :: "f" (t1));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v8, %0, v16" :: "f" (t2));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v12, %0, v16" :: "f" (t3));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3) : [a] "r" (a));
+    asm volatile("vfmacc.vf v4, %0, v16" ::"f"(t1));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v8, %0, v16" ::"f"(t2));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v12, %0, v16" ::"f"(t3));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
 
-    if (n == N-1)
+    if (n == N - 1)
       break;
 
-    a = (const double*) a_ + ++n;
+    a = (const double *)a_ + ++n;
 
-    asm volatile ("vfmacc.vf v0, %0, v20" :: "f" (t0));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vfmacc.vf v0, %0, v20" ::"f"(t0));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v16, (%0);" :: "r" (b)); b += P;
+    asm volatile("vle64.v v16, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vfmacc.vf v4, %0, v20" :: "f" (t1));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v8, %0, v20" :: "f" (t2));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v12, %0, v20" :: "f" (t3));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3) : [a] "r" (a));
+    asm volatile("vfmacc.vf v4, %0, v20" ::"f"(t1));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v8, %0, v20" ::"f"(t2));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v12, %0, v20" ::"f"(t3));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
   }
 
   // Last iteration: store results
-  asm volatile ("vfmacc.vf v0, %0, v20" :: "f" (t0));
-  asm volatile ("vse64.v v0, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v4, %0, v20" :: "f" (t1));
-  asm volatile ("vse64.v v4, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v8, %0, v20" :: "f" (t2));
-  asm volatile ("vse64.v v8, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v12, %0, v20" :: "f" (t3));
-  asm volatile ("vse64.v v12, (%0);" :: "r" (c));
+  asm volatile("vfmacc.vf v0, %0, v20" ::"f"(t0));
+  asm volatile("vse64.v v0, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v4, %0, v20" ::"f"(t1));
+  asm volatile("vse64.v v4, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v8, %0, v20" ::"f"(t2));
+  asm volatile("vse64.v v8, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v12, %0, v20" ::"f"(t3));
+  asm volatile("vse64.v v12, (%0);" ::"r"(c));
 }
 
 // ---------------
 // 8x8
 // ---------------
 
-void matmul_8x8(double *c, const double *a, const double *b, int64_t M, int64_t N, int64_t P) {
+void matmul_8x8(double *c, const double *a, const double *b, int64_t M,
+                int64_t N, int64_t P) {
   // We work on 4 rows of the matrix at once
   int64_t block_size = 8;
   int64_t block_size_p;
 
   // Set the vector configuration
-  asm volatile ("vsetvli %0, %1, e64, m2" : "=r" (block_size_p) : "r" (P));
+  asm volatile("vsetvli %0, %1, e64, m2" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
   for (int64_t p = 0; p < P; p += block_size_p) {
@@ -160,13 +179,13 @@ void matmul_8x8(double *c, const double *a, const double *b, int64_t M, int64_t 
     const double *b_ = b + p;
     double *c_ = c + p;
 
-    asm volatile ("vsetvli zero, %0, e64, m2" :: "r" (p_));
+    asm volatile("vsetvli zero, %0, e64, m2" ::"r"(p_));
 
     // Iterate over the rows
     for (int64_t m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
-      const double *a_ = a + m*N;
-      double *c__ = c_ + m*P;
+      const double *a_ = a + m * N;
+      double *c__ = c_ + m * P;
 
       matmul_vec_8x8_slice_init();
       matmul_vec_8x8(c__, a_, b_, N, P);
@@ -175,17 +194,18 @@ void matmul_8x8(double *c, const double *a, const double *b, int64_t M, int64_t 
 }
 
 void matmul_vec_8x8_slice_init() {
-  asm volatile ("vmv.v.i v0,  0");
-  asm volatile ("vmv.v.i v2,  0");
-  asm volatile ("vmv.v.i v4,  0");
-  asm volatile ("vmv.v.i v6,  0");
-  asm volatile ("vmv.v.i v8,  0");
-  asm volatile ("vmv.v.i v10, 0");
-  asm volatile ("vmv.v.i v12, 0");
-  asm volatile ("vmv.v.i v14, 0");
+  asm volatile("vmv.v.i v0,  0");
+  asm volatile("vmv.v.i v2,  0");
+  asm volatile("vmv.v.i v4,  0");
+  asm volatile("vmv.v.i v6,  0");
+  asm volatile("vmv.v.i v8,  0");
+  asm volatile("vmv.v.i v10, 0");
+  asm volatile("vmv.v.i v12, 0");
+  asm volatile("vmv.v.i v14, 0");
 }
 
-void matmul_vec_8x8(double *c, const double *a, const double *b, int64_t N, int64_t P) {
+void matmul_vec_8x8(double *c, const double *a, const double *b, int64_t N,
+                    int64_t P) {
   // Temporary variables
   double t0, t1, t2, t3, t4, t5, t6, t7;
 
@@ -193,103 +213,135 @@ void matmul_vec_8x8(double *c, const double *a, const double *b, int64_t N, int6
   const double *a_ = a;
 
   // Prefetch one row of matrix B
-  asm volatile ("vle64.v v18, (%0);" :: "r" (b)); b += P;
+  asm volatile("vle64.v v18, (%0);" ::"r"(b));
+  b += P;
 
   // Prefetch one row of scalar values
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t4) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t5) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t6) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t7) : [a] "r" (a));
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t4) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t5) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t6) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t7) : [ a ] "r"(a));
 
   // Compute the multiplication
   int64_t n = 0;
 
   while (n < N) {
     // Calculate pointer to the matrix A
-    a = (const double*)a_ + ++n;
+    a = (const double *)a_ + ++n;
 
-    asm volatile ("vfmacc.vf v0, %0, v18" :: "f" (t0));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vfmacc.vf v0, %0, v18" ::"f"(t0));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v20, (%0);" ::  "r" (b)); b += P;
+    asm volatile("vle64.v v20, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vfmacc.vf v2, %0, v18" :: "f" (t1));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v4, %0, v18" :: "f" (t2));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v6, %0, v18" :: "f" (t3));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v8, %0, v18" :: "f" (t4));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t4) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v10, %0, v18" :: "f" (t5));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t5) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v12, %0, v18" :: "f" (t6));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t6) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v14, %0, v18" :: "f" (t7));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t7) : [a] "r" (a));
+    asm volatile("vfmacc.vf v2, %0, v18" ::"f"(t1));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v4, %0, v18" ::"f"(t2));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v6, %0, v18" ::"f"(t3));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v8, %0, v18" ::"f"(t4));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t4) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v10, %0, v18" ::"f"(t5));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t5) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v12, %0, v18" ::"f"(t6));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t6) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v14, %0, v18" ::"f"(t7));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t7) : [ a ] "r"(a));
 
-    if (n == N-1)
+    if (n == N - 1)
       break;
 
-    a = (const double*) a_ + ++n;
+    a = (const double *)a_ + ++n;
 
-    asm volatile ("vfmacc.vf v0, %0, v20" :: "f" (t0));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vfmacc.vf v0, %0, v20" ::"f"(t0));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v18, (%0);" :: "r" (b)); b += P;
+    asm volatile("vle64.v v18, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vfmacc.vf v2, %0, v20" :: "f" (t1));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v4, %0, v20" :: "f" (t2));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v6, %0, v20" :: "f" (t3));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v8, %0, v20" :: "f" (t4));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t4) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v10, %0, v20" :: "f" (t5));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t5) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v12, %0, v20" :: "f" (t6));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t6) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v14, %0, v20" :: "f" (t7));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t7) : [a] "r" (a));
+    asm volatile("vfmacc.vf v2, %0, v20" ::"f"(t1));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v4, %0, v20" ::"f"(t2));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v6, %0, v20" ::"f"(t3));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v8, %0, v20" ::"f"(t4));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t4) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v10, %0, v20" ::"f"(t5));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t5) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v12, %0, v20" ::"f"(t6));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t6) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v14, %0, v20" ::"f"(t7));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t7) : [ a ] "r"(a));
   }
 
   // Last iteration: store results
-  asm volatile ("vfmacc.vf v0, %0, v20" :: "f" (t0));
-  asm volatile ("vse64.v v0, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v2, %0, v20" :: "f" (t1));
-  asm volatile ("vse64.v v2, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v4, %0, v20" :: "f" (t2));
-  asm volatile ("vse64.v v4, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v6, %0, v20" :: "f" (t3));
-  asm volatile ("vse64.v v6, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v8, %0, v20" :: "f" (t4));
-  asm volatile ("vse64.v v8, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v10, %0, v20" :: "f" (t5));
-  asm volatile ("vse64.v v10, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v12, %0, v20" :: "f" (t6));
-  asm volatile ("vse64.v v12, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v14, %0, v20" :: "f" (t7));
-  asm volatile ("vse64.v v14, (%0);" :: "r" (c));
+  asm volatile("vfmacc.vf v0, %0, v20" ::"f"(t0));
+  asm volatile("vse64.v v0, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v2, %0, v20" ::"f"(t1));
+  asm volatile("vse64.v v2, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v4, %0, v20" ::"f"(t2));
+  asm volatile("vse64.v v4, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v6, %0, v20" ::"f"(t3));
+  asm volatile("vse64.v v6, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v8, %0, v20" ::"f"(t4));
+  asm volatile("vse64.v v8, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v10, %0, v20" ::"f"(t5));
+  asm volatile("vse64.v v10, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v12, %0, v20" ::"f"(t6));
+  asm volatile("vse64.v v12, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v14, %0, v20" ::"f"(t7));
+  asm volatile("vse64.v v14, (%0);" ::"r"(c));
 }
 
 // ---------------
 // 16x16
 // ---------------
 
-void matmul_16x16(double *c, const double *a, const double *b, int64_t M, int64_t N, int64_t P) {
+void matmul_16x16(double *c, const double *a, const double *b, int64_t M,
+                  int64_t N, int64_t P) {
   // We work on 4 rows of the matrix at once
   int64_t block_size = 16;
   int64_t block_size_p;
 
   // Set the vector configuration
-  asm volatile ("vsetvli %0, %1, e64, m1" : "=r" (block_size_p) : "r" (P));
+  asm volatile("vsetvli %0, %1, e64, m1" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
   for (int64_t p = 0; p < P; p += block_size_p) {
@@ -300,13 +352,13 @@ void matmul_16x16(double *c, const double *a, const double *b, int64_t M, int64_
     const double *b_ = b + p;
     double *c_ = c + p;
 
-    asm volatile ("vsetvli zero, %0, e64, m1" :: "r" (p_));
+    asm volatile("vsetvli zero, %0, e64, m1" ::"r"(p_));
 
     // Iterate over the rows
     for (int64_t m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
-      const double *a_ = a + m*N;
-      double *c__ = c_ + m*P;
+      const double *a_ = a + m * N;
+      double *c__ = c_ + m * P;
 
       matmul_vec_16x16_slice_init();
       matmul_vec_16x16(c__, a_, b_, N, P);
@@ -315,25 +367,26 @@ void matmul_16x16(double *c, const double *a, const double *b, int64_t M, int64_
 }
 
 void matmul_vec_16x16_slice_init() {
-  asm volatile ("vmv.v.i v0,  0");
-  asm volatile ("vmv.v.i v1,  0");
-  asm volatile ("vmv.v.i v2,  0");
-  asm volatile ("vmv.v.i v3,  0");
-  asm volatile ("vmv.v.i v4,  0");
-  asm volatile ("vmv.v.i v5,  0");
-  asm volatile ("vmv.v.i v6,  0");
-  asm volatile ("vmv.v.i v7,  0");
-  asm volatile ("vmv.v.i v8,  0");
-  asm volatile ("vmv.v.i v9,  0");
-  asm volatile ("vmv.v.i v10, 0");
-  asm volatile ("vmv.v.i v11, 0");
-  asm volatile ("vmv.v.i v12, 0");
-  asm volatile ("vmv.v.i v13, 0");
-  asm volatile ("vmv.v.i v14, 0");
-  asm volatile ("vmv.v.i v15, 0");
+  asm volatile("vmv.v.i v0,  0");
+  asm volatile("vmv.v.i v1,  0");
+  asm volatile("vmv.v.i v2,  0");
+  asm volatile("vmv.v.i v3,  0");
+  asm volatile("vmv.v.i v4,  0");
+  asm volatile("vmv.v.i v5,  0");
+  asm volatile("vmv.v.i v6,  0");
+  asm volatile("vmv.v.i v7,  0");
+  asm volatile("vmv.v.i v8,  0");
+  asm volatile("vmv.v.i v9,  0");
+  asm volatile("vmv.v.i v10, 0");
+  asm volatile("vmv.v.i v11, 0");
+  asm volatile("vmv.v.i v12, 0");
+  asm volatile("vmv.v.i v13, 0");
+  asm volatile("vmv.v.i v14, 0");
+  asm volatile("vmv.v.i v15, 0");
 }
 
-void matmul_vec_16x16(double *c, const double *a, const double *b, int64_t N, int64_t P) {
+void matmul_vec_16x16(double *c, const double *a, const double *b, int64_t N,
+                      int64_t P) {
   // Temporary variables
   double t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15;
 
@@ -341,144 +394,207 @@ void matmul_vec_16x16(double *c, const double *a, const double *b, int64_t N, in
   const double *a_ = a;
 
   // Prefetch one row of matrix B
-  asm volatile ("vle64.v v16, (%0);" :: "r" (b)); b += P;
+  asm volatile("vle64.v v16, (%0);" ::"r"(b));
+  b += P;
 
   // Prefetch one row of scalar values
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t4)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t5)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t6)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t7)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t8)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t9)  : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t10) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t11) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t12) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t13) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t14) : [a] "r" (a)); a += N;
-  asm volatile ("fld %[t], (%[a])" : [t] "=f" (t15) : [a] "r" (a));
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t4) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t5) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t6) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t7) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t8) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t9) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t10) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t11) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t12) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t13) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t14) : [ a ] "r"(a));
+  a += N;
+  asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t15) : [ a ] "r"(a));
 
   // Compute the multiplication
   int64_t n = 0;
 
   while (n < N) {
     // Calculate pointer to the matrix A
-    a = (const double*)a_ + ++n;
+    a = (const double *)a_ + ++n;
 
-    asm volatile ("vfmacc.vf v0, %0, v16" :: "f" (t0));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vfmacc.vf v0, %0, v16" ::"f"(t0));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v17, (%0);" ::  "r" (b)); b += P;
+    asm volatile("vle64.v v17, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vfmacc.vf v1, %0, v16" :: "f" (t1));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v2, %0, v16" :: "f" (t2));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v3, %0, v16" :: "f" (t3));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v4, %0, v16" :: "f" (t4));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t4) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v5, %0, v16" :: "f" (t5));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t5) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v6, %0, v16" :: "f" (t6));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t6) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v7, %0, v16" :: "f" (t7));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t7) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v8, %0, v16" :: "f" (t8));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t8) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v9, %0, v16" :: "f" (t9));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t9) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v10, %0, v16" :: "f" (t10));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t10) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v11, %0, v16" :: "f" (t11));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t11) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v12, %0, v16" :: "f" (t12));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t12) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v13, %0, v16" :: "f" (t13));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t13) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v14, %0, v16" :: "f" (t14));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t14) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v15, %0, v16" :: "f" (t15));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t15) : [a] "r" (a));
+    asm volatile("vfmacc.vf v1, %0, v16" ::"f"(t1));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v2, %0, v16" ::"f"(t2));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v3, %0, v16" ::"f"(t3));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v4, %0, v16" ::"f"(t4));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t4) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v5, %0, v16" ::"f"(t5));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t5) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v6, %0, v16" ::"f"(t6));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t6) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v7, %0, v16" ::"f"(t7));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t7) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v8, %0, v16" ::"f"(t8));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t8) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v9, %0, v16" ::"f"(t9));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t9) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v10, %0, v16" ::"f"(t10));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t10) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v11, %0, v16" ::"f"(t11));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t11) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v12, %0, v16" ::"f"(t12));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t12) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v13, %0, v16" ::"f"(t13));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t13) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v14, %0, v16" ::"f"(t14));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t14) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v15, %0, v16" ::"f"(t15));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t15) : [ a ] "r"(a));
 
-    if (n == N-1)
+    if (n == N - 1)
       break;
 
-    a = (const double*) a_ + ++n;
+    a = (const double *)a_ + ++n;
 
-    asm volatile ("vfmacc.vf v0, %0, v17" :: "f" (t0));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vfmacc.vf v0, %0, v17" ::"f"(t0));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v16, (%0);" :: "r" (b)); b += P;
+    asm volatile("vle64.v v16, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vfmacc.vf v1, %0, v17" :: "f" (t1));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v2, %0, v17" :: "f" (t2));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v3, %0, v17" :: "f" (t3));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t3) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v4, %0, v17" :: "f" (t4));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t4) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v5, %0, v17" :: "f" (t5));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t5) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v6, %0, v17" :: "f" (t6));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t6) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v7, %0, v17" :: "f" (t7));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t7) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v8, %0, v17" :: "f" (t8));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t8) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v9, %0, v17" :: "f" (t9));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t9) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v10, %0, v17" :: "f" (t10));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t10) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v11, %0, v17" :: "f" (t11));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t11) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v12, %0, v17" :: "f" (t12));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t12) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v13, %0, v17" :: "f" (t13));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t13) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v14, %0, v17" :: "f" (t14));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t14) : [a] "r" (a)); a += N;
-    asm volatile ("vfmacc.vf v15, %0, v17" :: "f" (t15));
-    asm volatile ("fld %[t], (%[a])" : [t] "=f" (t15) : [a] "r" (a));
+    asm volatile("vfmacc.vf v1, %0, v17" ::"f"(t1));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v2, %0, v17" ::"f"(t2));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v3, %0, v17" ::"f"(t3));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t3) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v4, %0, v17" ::"f"(t4));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t4) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v5, %0, v17" ::"f"(t5));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t5) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v6, %0, v17" ::"f"(t6));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t6) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v7, %0, v17" ::"f"(t7));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t7) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v8, %0, v17" ::"f"(t8));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t8) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v9, %0, v17" ::"f"(t9));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t9) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v10, %0, v17" ::"f"(t10));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t10) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v11, %0, v17" ::"f"(t11));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t11) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v12, %0, v17" ::"f"(t12));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t12) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v13, %0, v17" ::"f"(t13));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t13) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v14, %0, v17" ::"f"(t14));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t14) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vfmacc.vf v15, %0, v17" ::"f"(t15));
+    asm volatile("fld %[t], (%[a])" : [ t ] "=f"(t15) : [ a ] "r"(a));
   }
 
   // Last iteration: store results
-  asm volatile ("vfmacc.vf v0, %0, v17" :: "f" (t0));
-  asm volatile ("vse64.v v0, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v1, %0, v17" :: "f" (t1));
-  asm volatile ("vse64.v v1, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v2, %0, v17" :: "f" (t2));
-  asm volatile ("vse64.v v2, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v3, %0, v17" :: "f" (t3));
-  asm volatile ("vse64.v v3, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v4, %0, v17" :: "f" (t4));
-  asm volatile ("vse64.v v4, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v5, %0, v17" :: "f" (t5));
-  asm volatile ("vse64.v v5, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v6, %0, v17" :: "f" (t6));
-  asm volatile ("vse64.v v6, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v7, %0, v17" :: "f" (t7));
-  asm volatile ("vse64.v v7, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v8, %0, v17" :: "f" (t8));
-  asm volatile ("vse64.v v8, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v9, %0, v17" :: "f" (t9));
-  asm volatile ("vse64.v v9, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v10, %0, v17" :: "f" (t10));
-  asm volatile ("vse64.v v10, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v11, %0, v17" :: "f" (t11));
-  asm volatile ("vse64.v v11, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v12, %0, v17" :: "f" (t12));
-  asm volatile ("vse64.v v12, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v13, %0, v17" :: "f" (t13));
-  asm volatile ("vse64.v v13, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v14, %0, v17" :: "f" (t14));
-  asm volatile ("vse64.v v14, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vfmacc.vf v15, %0, v17" :: "f" (t15));
-  asm volatile ("vse64.v v15, (%0);" :: "r" (c));
+  asm volatile("vfmacc.vf v0, %0, v17" ::"f"(t0));
+  asm volatile("vse64.v v0, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v1, %0, v17" ::"f"(t1));
+  asm volatile("vse64.v v1, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v2, %0, v17" ::"f"(t2));
+  asm volatile("vse64.v v2, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v3, %0, v17" ::"f"(t3));
+  asm volatile("vse64.v v3, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v4, %0, v17" ::"f"(t4));
+  asm volatile("vse64.v v4, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v5, %0, v17" ::"f"(t5));
+  asm volatile("vse64.v v5, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v6, %0, v17" ::"f"(t6));
+  asm volatile("vse64.v v6, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v7, %0, v17" ::"f"(t7));
+  asm volatile("vse64.v v7, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v8, %0, v17" ::"f"(t8));
+  asm volatile("vse64.v v8, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v9, %0, v17" ::"f"(t9));
+  asm volatile("vse64.v v9, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v10, %0, v17" ::"f"(t10));
+  asm volatile("vse64.v v10, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v11, %0, v17" ::"f"(t11));
+  asm volatile("vse64.v v11, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v12, %0, v17" ::"f"(t12));
+  asm volatile("vse64.v v12, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v13, %0, v17" ::"f"(t13));
+  asm volatile("vse64.v v13, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v14, %0, v17" ::"f"(t14));
+  asm volatile("vse64.v v14, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vfmacc.vf v15, %0, v17" ::"f"(t15));
+  asm volatile("vse64.v v15, (%0);" ::"r"(c));
 }

--- a/apps/fmatmul/kernel/matmul.h
+++ b/apps/fmatmul/kernel/matmul.h
@@ -22,18 +22,25 @@
 
 #include <stdint.h>
 
-void matmul(double *c, const double *a, const double *b, int64_t m, int64_t n, int64_t p);
+void matmul(double *c, const double *a, const double *b, int64_t m, int64_t n,
+            int64_t p);
 
-void matmul_4x4(double *c, const double *a, const double *b, int64_t m, int64_t n, int64_t p);
+void matmul_4x4(double *c, const double *a, const double *b, int64_t m,
+                int64_t n, int64_t p);
 void matmul_vec_4x4_slice_init();
-void matmul_vec_4x4(double *c, const double *a, const double *b, int64_t n, int64_t p);
+void matmul_vec_4x4(double *c, const double *a, const double *b, int64_t n,
+                    int64_t p);
 
-void matmul_8x8(double *c, const double *a, const double *b, int64_t m, int64_t n, int64_t p);
+void matmul_8x8(double *c, const double *a, const double *b, int64_t m,
+                int64_t n, int64_t p);
 void matmul_vec_8x8_slice_init();
-void matmul_vec_8x8(double *c, const double *a, const double *b, int64_t n, int64_t p);
+void matmul_vec_8x8(double *c, const double *a, const double *b, int64_t n,
+                    int64_t p);
 
-void matmul_16x16(double *c, const double *a, const double *b, int64_t m, int64_t n, int64_t p);
+void matmul_16x16(double *c, const double *a, const double *b, int64_t m,
+                  int64_t n, int64_t p);
 void matmul_vec_16x16_slice_init();
-void matmul_vec_16x16(double *c, const double *a, const double *b, int64_t n, int64_t p);
+void matmul_vec_16x16(double *c, const double *a, const double *b, int64_t n,
+                      int64_t p);
 
 #endif

--- a/apps/fmatmul/main.c
+++ b/apps/fmatmul/main.c
@@ -20,9 +20,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "kernel/matmul.h"
 #include "printf.h"
 #include "runtime.h"
-#include "kernel/matmul.h"
 
 // Define Matrix dimensions:
 // C = AB with A=[MxN], B=[NxP], C=[MxP]
@@ -46,9 +46,9 @@
 #define B_b 1
 #define B_c 16
 
-double a[M * N] __attribute__((aligned(32*NR_LANES), section(".l2")));
-double b[N * P] __attribute__((aligned(32*NR_LANES), section(".l2")));
-double c[M * P] __attribute__((aligned(32*NR_LANES), section(".l2")));
+double a[M * N] __attribute__((aligned(32 * NR_LANES), section(".l2")));
+double b[N * P] __attribute__((aligned(32 * NR_LANES), section(".l2")));
+double c[M * P] __attribute__((aligned(32 * NR_LANES), section(".l2")));
 
 // Define half of the range for FP comparison on the results
 #define DELTA 0.001
@@ -64,12 +64,13 @@ void init_matrix(double *matrix, uint64_t num_rows, uint64_t num_columns,
 }
 
 // Verify the matrices
-int verify_matrix(double *matrix, int64_t m, int64_t n, int64_t p,
-                  double aa, double ab, double ac, double ba, double bb, double bc) {
+int verify_matrix(double *matrix, int64_t m, int64_t n, int64_t p, double aa,
+                  double ab, double ac, double ba, double bb, double bc) {
   for (int64_t i = 0; i < (int64_t)m; ++i) {
     for (int64_t j = 0; j < (int64_t)p; ++j) {
       double lin = (aa * bb * i * j + aa * bc * i + ac * bb * j + ac * bc) * n;
-      double qua = ((aa * ba * i + ab * bb * j + ab * bc + ba * ac) * (n * (n - 1))) / 2;
+      double qua =
+          ((aa * ba * i + ab * bb * j + ab * bc + ba * ac) * (n * (n - 1))) / 2;
       double cub = ((ab * ba) * (n * (n - 1) * (2 * n - 1))) / 6;
       double golden = lin + qua + cub;
       if (matrix[i * (int64_t)p + j] != golden) {
@@ -81,7 +82,8 @@ int verify_matrix(double *matrix, int64_t m, int64_t n, int64_t p,
   return 0;
 }
 
-void print_matrix(double const *matrix, uint64_t num_rows, uint64_t num_columns) {
+void print_matrix(double const *matrix, uint64_t num_rows,
+                  uint64_t num_columns) {
   printf("0x%8X\n", (uint64_t)matrix);
   for (uint64_t i = 0; i < num_rows; ++i) {
     for (uint64_t j = 0; j < num_columns; ++j) {
@@ -102,7 +104,8 @@ int main() {
   for (int s = 4; s <= M; s *= 2) {
     printf("\n");
     printf("------------------------------------------------------------\n");
-    printf("Calculating a (%d x %d) x (%d x %d) matrix multiplication...\n", s, s, s, s);
+    printf("Calculating a (%d x %d) x (%d x %d) matrix multiplication...\n", s,
+           s, s, s);
     printf("------------------------------------------------------------\n");
     printf("\n");
 
@@ -118,12 +121,13 @@ int main() {
     stop_timer();
 
     // Metrics
-    int64_t   runtime = get_timer();
-    float performance = 2.0*s*s*s/runtime;
+    int64_t runtime = get_timer();
+    float performance = 2.0 * s * s * s / runtime;
     float utilization = 100 * performance / (2.0 * NR_LANES);
 
     printf("The execution took %d cycles.\n", runtime);
-    printf("The performance is %f FLOP/cycle (%f%% utilization).\n", performance, utilization);
+    printf("The performance is %f FLOP/cycle (%f%% utilization).\n",
+           performance, utilization);
 
     // Verify the result
     printf("Verifying result...\n");

--- a/apps/imatmul/kernel/matmul.c
+++ b/apps/imatmul/kernel/matmul.c
@@ -19,9 +19,10 @@
 
 #include "matmul.h"
 
-#define MIN(a,b) ((a)<(b)?(a):(b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-void matmul(int64_t *c, const int64_t *a, const int64_t *b, int64_t M, int64_t N, int64_t P) {
+void matmul(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
+            int64_t N, int64_t P) {
   if (M <= 4) {
     matmul_4x4(c, a, b, M, N, P);
   } else {
@@ -33,13 +34,14 @@ void matmul(int64_t *c, const int64_t *a, const int64_t *b, int64_t M, int64_t N
 // 4x4
 // ---------------
 
-void matmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t M, int64_t N, int64_t P) {
+void matmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
+                int64_t N, int64_t P) {
   // We work on 4 rows of the matrix at once
   int64_t block_size = 4;
   int64_t block_size_p;
 
   // Set the vector configuration
-  asm volatile ("vsetvli %0, %1, e64, m4" : "=r" (block_size_p) : "r" (P));
+  asm volatile("vsetvli %0, %1, e64, m4" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
   for (int64_t p = 0; p < P; p += block_size_p) {
@@ -50,13 +52,13 @@ void matmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t M, int64
     const int64_t *b_ = b + p;
     int64_t *c_ = c + p;
 
-    asm volatile ("vsetvli zero, %0, e64, m4" :: "r" (p_));
+    asm volatile("vsetvli zero, %0, e64, m4" ::"r"(p_));
 
     // Iterate over the rows
     for (int64_t m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
-      const int64_t *a_ = a + m*N;
-      int64_t *c__ = c_ + m*P;
+      const int64_t *a_ = a + m * N;
+      int64_t *c__ = c_ + m * P;
 
       matmul_vec_4x4_slice_init();
       matmul_vec_4x4(c__, a_, b_, N, P);
@@ -65,13 +67,14 @@ void matmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t M, int64
 }
 
 void matmul_vec_4x4_slice_init() {
-  asm volatile ("vmv.v.i v0,  0");
-  asm volatile ("vmv.v.i v4,  0");
-  asm volatile ("vmv.v.i v8,  0");
-  asm volatile ("vmv.v.i v12, 0");
+  asm volatile("vmv.v.i v0,  0");
+  asm volatile("vmv.v.i v4,  0");
+  asm volatile("vmv.v.i v8,  0");
+  asm volatile("vmv.v.i v12, 0");
 }
 
-void matmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t N, int64_t P) {
+void matmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t N,
+                    int64_t P) {
   // Temporary variables
   int64_t t0, t1, t2, t3;
 
@@ -79,75 +82,91 @@ void matmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t N, i
   const int64_t *a_ = a;
 
   // Prefetch one row of matrix B
-  asm volatile ("vle64.v v16, (%0);" :: "r" (b)); b += P;
+  asm volatile("vle64.v v16, (%0);" ::"r"(b));
+  b += P;
 
   // Prefetch one row of scalar values
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t0) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t1) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t2) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t3) : [a] "r" (a));
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t0) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t1) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t2) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t3) : [ a ] "r"(a));
 
   // Compute the multiplication
   int64_t n = 0;
 
   while (n < N) {
     // Calculate pointer to the matrix A
-    a = (const int64_t*)a_ + ++n;
+    a = (const int64_t *)a_ + ++n;
 
-    asm volatile ("vmacc.vx v0, %0, v16" :: "r" (t0));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vmacc.vx v0, %0, v16" ::"r"(t0));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v20, (%0);" :: "r" (b)); b += P;
+    asm volatile("vle64.v v20, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vmacc.vx v4, %0, v16" :: "r" (t1));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v8, %0, v16" :: "r" (t2));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v12, %0, v16" :: "r" (t3));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t3) : [a] "r" (a));
+    asm volatile("vmacc.vx v4, %0, v16" ::"r"(t1));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v8, %0, v16" ::"r"(t2));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v12, %0, v16" ::"r"(t3));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t3) : [ a ] "r"(a));
 
-    if (n == N-1)
+    if (n == N - 1)
       break;
 
-    a = (const int64_t*) a_ + ++n;
+    a = (const int64_t *)a_ + ++n;
 
-    asm volatile ("vmacc.vx v0, %0, v20" :: "r" (t0));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vmacc.vx v0, %0, v20" ::"r"(t0));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v16, (%0);" :: "r" (b)); b += P;
+    asm volatile("vle64.v v16, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vmacc.vx v4, %0, v20" :: "r" (t1));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v8, %0, v20" :: "r" (t2));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v12, %0, v20" :: "r" (t3));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t3) : [a] "r" (a));
+    asm volatile("vmacc.vx v4, %0, v20" ::"r"(t1));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v8, %0, v20" ::"r"(t2));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v12, %0, v20" ::"r"(t3));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t3) : [ a ] "r"(a));
   }
 
   // Last iteration: store results
-  asm volatile ("vmacc.vx v0, %0, v20" :: "r" (t0));
-  asm volatile ("vse64.v v0, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v4, %0, v20" :: "r" (t1));
-  asm volatile ("vse64.v v4, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v8, %0, v20" :: "r" (t2));
-  asm volatile ("vse64.v v8, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v12, %0, v20" :: "r" (t3));
-  asm volatile ("vse64.v v12, (%0);" :: "r" (c));
+  asm volatile("vmacc.vx v0, %0, v20" ::"r"(t0));
+  asm volatile("vse64.v v0, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v4, %0, v20" ::"r"(t1));
+  asm volatile("vse64.v v4, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v8, %0, v20" ::"r"(t2));
+  asm volatile("vse64.v v8, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v12, %0, v20" ::"r"(t3));
+  asm volatile("vse64.v v12, (%0);" ::"r"(c));
 }
 
 // ---------------
 // 8x8
 // ---------------
 
-void matmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t M, int64_t N, int64_t P) {
+void matmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
+                int64_t N, int64_t P) {
   // We work on 4 rows of the matrix at once
   int64_t block_size = 8;
   int64_t block_size_p;
 
   // Set the vector configuration
-  asm volatile ("vsetvli %0, %1, e64, m2" : "=r" (block_size_p) : "r" (P));
+  asm volatile("vsetvli %0, %1, e64, m2" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
   for (int64_t p = 0; p < P; p += block_size_p) {
@@ -158,13 +177,13 @@ void matmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t M, int64
     const int64_t *b_ = b + p;
     int64_t *c_ = c + p;
 
-    asm volatile ("vsetvli zero, %0, e64, m2" :: "r" (p_));
+    asm volatile("vsetvli zero, %0, e64, m2" ::"r"(p_));
 
     // Iterate over the rows
     for (int64_t m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
-      const int64_t *a_ = a + m*N;
-      int64_t *c__ = c_ + m*P;
+      const int64_t *a_ = a + m * N;
+      int64_t *c__ = c_ + m * P;
 
       matmul_vec_8x8_slice_init();
       matmul_vec_8x8(c__, a_, b_, N, P);
@@ -173,17 +192,18 @@ void matmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t M, int64
 }
 
 void matmul_vec_8x8_slice_init() {
-  asm volatile ("vmv.v.i v0,  0");
-  asm volatile ("vmv.v.i v2,  0");
-  asm volatile ("vmv.v.i v4,  0");
-  asm volatile ("vmv.v.i v6,  0");
-  asm volatile ("vmv.v.i v8,  0");
-  asm volatile ("vmv.v.i v10, 0");
-  asm volatile ("vmv.v.i v12, 0");
-  asm volatile ("vmv.v.i v14, 0");
+  asm volatile("vmv.v.i v0,  0");
+  asm volatile("vmv.v.i v2,  0");
+  asm volatile("vmv.v.i v4,  0");
+  asm volatile("vmv.v.i v6,  0");
+  asm volatile("vmv.v.i v8,  0");
+  asm volatile("vmv.v.i v10, 0");
+  asm volatile("vmv.v.i v12, 0");
+  asm volatile("vmv.v.i v14, 0");
 }
 
-void matmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t N, int64_t P) {
+void matmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t N,
+                    int64_t P) {
   // Temporary variables
   int64_t t0, t1, t2, t3, t4, t5, t6, t7;
 
@@ -191,88 +211,119 @@ void matmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t N, i
   const int64_t *a_ = a;
 
   // Prefetch one row of matrix B
-  asm volatile ("vle64.v v18, (%0);" :: "r" (b)); b += P;
+  asm volatile("vle64.v v18, (%0);" ::"r"(b));
+  b += P;
 
   // Prefetch one row of scalar values
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t0) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t1) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t2) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t3) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t4) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t5) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t6) : [a] "r" (a)); a += N;
-  asm volatile ("ld %[t], (%[a])" : [t] "=r" (t7) : [a] "r" (a));
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t0) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t1) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t2) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t3) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t4) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t5) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t6) : [ a ] "r"(a));
+  a += N;
+  asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t7) : [ a ] "r"(a));
 
   // Compute the multiplication
   int64_t n = 0;
 
   while (n < N) {
     // Calculate pointer to the matrix A
-    a = (const int64_t*)a_ + ++n;
+    a = (const int64_t *)a_ + ++n;
 
-    asm volatile ("vmacc.vx v0, %0, v18" :: "r" (t0));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vmacc.vx v0, %0, v18" ::"r"(t0));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v20, (%0);" ::  "r" (b)); b += P;
+    asm volatile("vle64.v v20, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vmacc.vx v2, %0, v18" :: "r" (t1));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v4, %0, v18" :: "r" (t2));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v6, %0, v18" :: "r" (t3));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t3) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v8, %0, v18" :: "r" (t4));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t4) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v10, %0, v18" :: "r" (t5));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t5) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v12, %0, v18" :: "r" (t6));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t6) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v14, %0, v18" :: "r" (t7));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t7) : [a] "r" (a));
+    asm volatile("vmacc.vx v2, %0, v18" ::"r"(t1));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v4, %0, v18" ::"r"(t2));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v6, %0, v18" ::"r"(t3));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t3) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v8, %0, v18" ::"r"(t4));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t4) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v10, %0, v18" ::"r"(t5));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t5) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v12, %0, v18" ::"r"(t6));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t6) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v14, %0, v18" ::"r"(t7));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t7) : [ a ] "r"(a));
 
-    if (n == N-1)
+    if (n == N - 1)
       break;
 
-    a = (const int64_t*) a_ + ++n;
+    a = (const int64_t *)a_ + ++n;
 
-    asm volatile ("vmacc.vx v0, %0, v20" :: "r" (t0));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t0) : [a] "r" (a)); a += N;
+    asm volatile("vmacc.vx v0, %0, v20" ::"r"(t0));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t0) : [ a ] "r"(a));
+    a += N;
 
     // Load one row of B
-    asm volatile ("vle64.v v18, (%0);" :: "r" (b)); b += P;
+    asm volatile("vle64.v v18, (%0);" ::"r"(b));
+    b += P;
 
-    asm volatile ("vmacc.vx v2, %0, v20" :: "r" (t1));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t1) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v4, %0, v20" :: "r" (t2));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t2) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v6, %0, v20" :: "r" (t3));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t3) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v8, %0, v20" :: "r" (t4));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t4) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v10, %0, v20" :: "r" (t5));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t5) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v12, %0, v20" :: "r" (t6));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t6) : [a] "r" (a)); a += N;
-    asm volatile ("vmacc.vx v14, %0, v20" :: "r" (t7));
-    asm volatile ("ld %[t], (%[a])" : [t] "=r" (t7) : [a] "r" (a));
+    asm volatile("vmacc.vx v2, %0, v20" ::"r"(t1));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t1) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v4, %0, v20" ::"r"(t2));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t2) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v6, %0, v20" ::"r"(t3));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t3) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v8, %0, v20" ::"r"(t4));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t4) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v10, %0, v20" ::"r"(t5));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t5) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v12, %0, v20" ::"r"(t6));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t6) : [ a ] "r"(a));
+    a += N;
+    asm volatile("vmacc.vx v14, %0, v20" ::"r"(t7));
+    asm volatile("ld %[t], (%[a])" : [ t ] "=r"(t7) : [ a ] "r"(a));
   }
 
   // Last iteration: store results
-  asm volatile ("vmacc.vx v0, %0, v20" :: "r" (t0));
-  asm volatile ("vse64.v v0, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v2, %0, v20" :: "r" (t1));
-  asm volatile ("vse64.v v2, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v4, %0, v20" :: "r" (t2));
-  asm volatile ("vse64.v v4, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v6, %0, v20" :: "r" (t3));
-  asm volatile ("vse64.v v6, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v8, %0, v20" :: "r" (t4));
-  asm volatile ("vse64.v v8, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v10, %0, v20" :: "r" (t5));
-  asm volatile ("vse64.v v10, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v12, %0, v20" :: "r" (t6));
-  asm volatile ("vse64.v v12, (%0);" :: "r" (c)); c += P;
-  asm volatile ("vmacc.vx v14, %0, v20" :: "r" (t7));
-  asm volatile ("vse64.v v14, (%0);" :: "r" (c));
+  asm volatile("vmacc.vx v0, %0, v20" ::"r"(t0));
+  asm volatile("vse64.v v0, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v2, %0, v20" ::"r"(t1));
+  asm volatile("vse64.v v2, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v4, %0, v20" ::"r"(t2));
+  asm volatile("vse64.v v4, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v6, %0, v20" ::"r"(t3));
+  asm volatile("vse64.v v6, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v8, %0, v20" ::"r"(t4));
+  asm volatile("vse64.v v8, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v10, %0, v20" ::"r"(t5));
+  asm volatile("vse64.v v10, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v12, %0, v20" ::"r"(t6));
+  asm volatile("vse64.v v12, (%0);" ::"r"(c));
+  c += P;
+  asm volatile("vmacc.vx v14, %0, v20" ::"r"(t7));
+  asm volatile("vse64.v v14, (%0);" ::"r"(c));
 }

--- a/apps/imatmul/kernel/matmul.h
+++ b/apps/imatmul/kernel/matmul.h
@@ -22,14 +22,19 @@
 
 #include <stdint.h>
 
-void matmul(int64_t *c, const int64_t *a, const int64_t *b, int64_t m, int64_t n, int64_t p);
+void matmul(int64_t *c, const int64_t *a, const int64_t *b, int64_t m,
+            int64_t n, int64_t p);
 
-void matmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t m, int64_t n, int64_t p);
+void matmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t m,
+                int64_t n, int64_t p);
 void matmul_vec_4x4_slice_init();
-void matmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t n, int64_t p);
+void matmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t n,
+                    int64_t p);
 
-void matmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t m, int64_t n, int64_t p);
+void matmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t m,
+                int64_t n, int64_t p);
 void matmul_vec_8x8_slice_init();
-void matmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t n, int64_t p);
+void matmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t n,
+                    int64_t p);
 
 #endif

--- a/apps/imatmul/main.c
+++ b/apps/imatmul/main.c
@@ -20,9 +20,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "kernel/matmul.h"
 #include "printf.h"
 #include "runtime.h"
-#include "kernel/matmul.h"
 
 // Define Matrix dimensions:
 // C = AB with A=[MxN], B=[NxP], C=[MxP]
@@ -46,9 +46,9 @@
 #define B_b 1
 #define B_c 16
 
-int64_t a[M * N] __attribute__((aligned(32*NR_LANES), section(".l2")));
-int64_t b[N * P] __attribute__((aligned(32*NR_LANES), section(".l2")));
-int64_t c[M * P] __attribute__((aligned(32*NR_LANES), section(".l2")));
+int64_t a[M * N] __attribute__((aligned(32 * NR_LANES), section(".l2")));
+int64_t b[N * P] __attribute__((aligned(32 * NR_LANES), section(".l2")));
+int64_t c[M * P] __attribute__((aligned(32 * NR_LANES), section(".l2")));
 
 // Initialize the matrices
 void init_matrix(int64_t *matrix, uint64_t num_rows, uint64_t num_columns,
@@ -61,12 +61,13 @@ void init_matrix(int64_t *matrix, uint64_t num_rows, uint64_t num_columns,
 }
 
 // Verify the matrices
-int verify_matrix(int64_t *matrix, int64_t m, int64_t n, int64_t p,
-                  int64_t aa, int64_t ab, int64_t ac, int64_t ba, int64_t bb, int64_t bc) {
+int verify_matrix(int64_t *matrix, int64_t m, int64_t n, int64_t p, int64_t aa,
+                  int64_t ab, int64_t ac, int64_t ba, int64_t bb, int64_t bc) {
   for (int64_t i = 0; i < (int64_t)m; ++i) {
     for (int64_t j = 0; j < (int64_t)p; ++j) {
       int64_t lin = (aa * bb * i * j + aa * bc * i + ac * bb * j + ac * bc) * n;
-      int64_t qua = ((aa * ba * i + ab * bb * j + ab * bc + ba * ac) * (n * (n - 1))) / 2;
+      int64_t qua =
+          ((aa * ba * i + ab * bb * j + ab * bc + ba * ac) * (n * (n - 1))) / 2;
       int64_t cub = ((ab * ba) * (n * (n - 1) * (2 * n - 1))) / 6;
       int64_t golden = lin + qua + cub;
       if (matrix[i * (int64_t)p + j] != golden) {
@@ -78,7 +79,8 @@ int verify_matrix(int64_t *matrix, int64_t m, int64_t n, int64_t p,
   return 0;
 }
 
-void print_matrix(int64_t const *matrix, uint64_t num_rows, uint64_t num_columns) {
+void print_matrix(int64_t const *matrix, uint64_t num_rows,
+                  uint64_t num_columns) {
   printf("0x%8X\n", (uint64_t)matrix);
   for (uint64_t i = 0; i < num_rows; ++i) {
     for (uint64_t j = 0; j < num_columns; ++j) {
@@ -87,7 +89,6 @@ void print_matrix(int64_t const *matrix, uint64_t num_rows, uint64_t num_columns
     printf("\n");
   }
 }
-
 
 int main() {
   printf("\n");
@@ -100,7 +101,8 @@ int main() {
   for (int s = 4; s <= M; s *= 2) {
     printf("\n");
     printf("------------------------------------------------------------\n");
-    printf("Calculating a (%d x %d) x (%d x %d) matrix multiplication...\n", s, s, s, s);
+    printf("Calculating a (%d x %d) x (%d x %d) matrix multiplication...\n", s,
+           s, s, s);
     printf("------------------------------------------------------------\n");
     printf("\n");
 
@@ -116,12 +118,13 @@ int main() {
     stop_timer();
 
     // Metrics
-    int64_t   runtime = get_timer();
-    float performance = 2.0*s*s*s/runtime;
+    int64_t runtime = get_timer();
+    float performance = 2.0 * s * s * s / runtime;
     float utilization = 100 * performance / (2.0 * NR_LANES);
 
     printf("The execution took %d cycles.\n", runtime);
-    printf("The performance is %f FLOP/cycle (%f%% utilization).\n", performance, utilization);
+    printf("The performance is %f FLOP/cycle (%f%% utilization).\n",
+           performance, utilization);
 
     // Verify the result
     printf("Verifying result...\n");

--- a/scripts/run-clang-format.py
+++ b/scripts/run-clang-format.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+
+# MIT License
+
+# Copyright (c) 2017 Guillaume Papin
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Taken from: https://github.com/Sarcasm/run-clang-format
+# SPDX-License-Identifier: MIT
+
+"""A wrapper script around clang-format, suitable for linting multiple files
+and to use for continuous integration.
+
+This is an alternative API for the clang-format command line.
+It runs over multiple files and directories in parallel.
+A diff output is produced and a sensible exit code is returned.
+
+"""
+
+from __future__ import print_function, unicode_literals
+
+import argparse
+import codecs
+import difflib
+import fnmatch
+import io
+import errno
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import traceback
+
+from functools import partial
+
+try:
+    from subprocess import DEVNULL  # py3k
+except ImportError:
+    DEVNULL = open(os.devnull, "wb")
+
+
+DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
+DEFAULT_CLANG_FORMAT_IGNORE = '.clang-format-ignore'
+
+
+class ExitStatus:
+    SUCCESS = 0
+    DIFF = 1
+    TROUBLE = 2
+
+def excludes_from_file(ignore_file):
+    excludes = []
+    try:
+        with io.open(ignore_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                if line.startswith('#'):
+                    # ignore comments
+                    continue
+                pattern = line.rstrip()
+                if not pattern:
+                    # allow empty lines
+                    continue
+                excludes.append(pattern)
+    except EnvironmentError as e:
+        if e.errno != errno.ENOENT:
+            raise
+    return excludes;
+
+def list_files(files, recursive=False, extensions=None, exclude=None):
+    if extensions is None:
+        extensions = []
+    if exclude is None:
+        exclude = []
+
+    out = []
+    for file in files:
+        if recursive and os.path.isdir(file):
+            for dirpath, dnames, fnames in os.walk(file):
+                fpaths = [os.path.join(dirpath, fname) for fname in fnames]
+                for pattern in exclude:
+                    # os.walk() supports trimming down the dnames list
+                    # by modifying it in-place,
+                    # to avoid unnecessary directory listings.
+                    dnames[:] = [
+                        x for x in dnames
+                        if
+                        not fnmatch.fnmatch(os.path.join(dirpath, x), pattern)
+                    ]
+                    fpaths = [
+                        x for x in fpaths if not fnmatch.fnmatch(x, pattern)
+                    ]
+                for f in fpaths:
+                    ext = os.path.splitext(f)[1][1:]
+                    if ext in extensions:
+                        out.append(f)
+        else:
+            out.append(file)
+    return out
+
+
+def make_diff(file, original, reformatted):
+    return list(
+        difflib.unified_diff(
+            original,
+            reformatted,
+            fromfile='{}\t(original)'.format(file),
+            tofile='{}\t(reformatted)'.format(file),
+            n=3))
+
+
+class DiffError(Exception):
+    def __init__(self, message, errs=None):
+        super(DiffError, self).__init__(message)
+        self.errs = errs or []
+
+
+class UnexpectedError(Exception):
+    def __init__(self, message, exc=None):
+        super(UnexpectedError, self).__init__(message)
+        self.formatted_traceback = traceback.format_exc()
+        self.exc = exc
+
+
+def run_clang_format_diff_wrapper(args, file):
+    try:
+        ret = run_clang_format_diff(args, file)
+        return ret
+    except DiffError:
+        raise
+    except Exception as e:
+        raise UnexpectedError('{}: {}: {}'.format(file, e.__class__.__name__,
+                                                  e), e)
+
+
+def run_clang_format_diff(args, file):
+    try:
+        with io.open(file, 'r', encoding='utf-8') as f:
+            original = f.readlines()
+    except IOError as exc:
+        raise DiffError(str(exc))
+
+    if args.in_place:
+        invocation = [args.clang_format_executable, '-i', file]
+    else:
+        invocation = [args.clang_format_executable, file]
+
+    if args.dry_run:
+        print(" ".join(invocation))
+        return [], []
+
+    # Use of utf-8 to decode the process output.
+    #
+    # Hopefully, this is the correct thing to do.
+    #
+    # It's done due to the following assumptions (which may be incorrect):
+    # - clang-format will returns the bytes read from the files as-is,
+    #   without conversion, and it is already assumed that the files use utf-8.
+    # - if the diagnostics were internationalized, they would use utf-8:
+    #   > Adding Translations to Clang
+    #   >
+    #   > Not possible yet!
+    #   > Diagnostic strings should be written in UTF-8,
+    #   > the client can translate to the relevant code page if needed.
+    #   > Each translation completely replaces the format string
+    #   > for the diagnostic.
+    #   > -- http://clang.llvm.org/docs/InternalsManual.html#internals-diag-translation
+    #
+    # It's not pretty, due to Python 2 & 3 compatibility.
+    encoding_py3 = {}
+    if sys.version_info[0] >= 3:
+        encoding_py3['encoding'] = 'utf-8'
+
+    try:
+        proc = subprocess.Popen(
+            invocation,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            **encoding_py3)
+    except OSError as exc:
+        raise DiffError(
+            "Command '{}' failed to start: {}".format(
+                subprocess.list2cmdline(invocation), exc
+            )
+        )
+    proc_stdout = proc.stdout
+    proc_stderr = proc.stderr
+    if sys.version_info[0] < 3:
+        # make the pipes compatible with Python 3,
+        # reading lines should output unicode
+        encoding = 'utf-8'
+        proc_stdout = codecs.getreader(encoding)(proc_stdout)
+        proc_stderr = codecs.getreader(encoding)(proc_stderr)
+    # hopefully the stderr pipe won't get full and block the process
+    outs = list(proc_stdout.readlines())
+    errs = list(proc_stderr.readlines())
+    proc.wait()
+    if proc.returncode:
+        raise DiffError(
+            "Command '{}' returned non-zero exit status {}".format(
+                subprocess.list2cmdline(invocation), proc.returncode
+            ),
+            errs,
+        )
+    if args.in_place:
+        return [], errs
+    return make_diff(file, original, outs), errs
+
+
+def bold_red(s):
+    return '\x1b[1m\x1b[31m' + s + '\x1b[0m'
+
+
+def colorize(diff_lines):
+    def bold(s):
+        return '\x1b[1m' + s + '\x1b[0m'
+
+    def cyan(s):
+        return '\x1b[36m' + s + '\x1b[0m'
+
+    def green(s):
+        return '\x1b[32m' + s + '\x1b[0m'
+
+    def red(s):
+        return '\x1b[31m' + s + '\x1b[0m'
+
+    for line in diff_lines:
+        if line[:4] in ['--- ', '+++ ']:
+            yield bold(line)
+        elif line.startswith('@@ '):
+            yield cyan(line)
+        elif line.startswith('+'):
+            yield green(line)
+        elif line.startswith('-'):
+            yield red(line)
+        else:
+            yield line
+
+
+def print_diff(diff_lines, use_color):
+    if use_color:
+        diff_lines = colorize(diff_lines)
+    if sys.version_info[0] < 3:
+        sys.stdout.writelines((l.encode('utf-8') for l in diff_lines))
+    else:
+        sys.stdout.writelines(diff_lines)
+
+
+def print_trouble(prog, message, use_colors):
+    error_text = 'error:'
+    if use_colors:
+        error_text = bold_red(error_text)
+    print("{}: {} {}".format(prog, error_text, message), file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--clang-format-executable',
+        metavar='EXECUTABLE',
+        help='path to the clang-format executable',
+        default='clang-format')
+    parser.add_argument(
+        '--extensions',
+        help='comma separated list of file extensions (default: {})'.format(
+            DEFAULT_EXTENSIONS),
+        default=DEFAULT_EXTENSIONS)
+    parser.add_argument(
+        '-r',
+        '--recursive',
+        action='store_true',
+        help='run recursively over directories')
+    parser.add_argument(
+        '-d',
+        '--dry-run',
+        action='store_true',
+        help='just print the list of files')
+    parser.add_argument(
+        '-i',
+        '--in-place',
+        action='store_true',
+        help='format file instead of printing differences')
+    parser.add_argument('files', metavar='file', nargs='+')
+    parser.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true',
+        help="disable output, useful for the exit code")
+    parser.add_argument(
+        '-j',
+        metavar='N',
+        type=int,
+        default=0,
+        help='run N clang-format jobs in parallel'
+        ' (default number of cpus + 1)')
+    parser.add_argument(
+        '--color',
+        default='auto',
+        choices=['auto', 'always', 'never'],
+        help='show colored diff (default: auto)')
+    parser.add_argument(
+        '-e',
+        '--exclude',
+        metavar='PATTERN',
+        action='append',
+        default=[],
+        help='exclude paths matching the given glob-like pattern(s)'
+        ' from recursive search')
+
+    args = parser.parse_args()
+
+    # use default signal handling, like diff return SIGINT value on ^C
+    # https://bugs.python.org/issue14229#msg156446
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    try:
+        signal.SIGPIPE
+    except AttributeError:
+        # compatibility, SIGPIPE does not exist on Windows
+        pass
+    else:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    colored_stdout = False
+    colored_stderr = False
+    if args.color == 'always':
+        colored_stdout = True
+        colored_stderr = True
+    elif args.color == 'auto':
+        colored_stdout = sys.stdout.isatty()
+        colored_stderr = sys.stderr.isatty()
+
+    version_invocation = [args.clang_format_executable, str("--version")]
+    try:
+        subprocess.check_call(version_invocation, stdout=DEVNULL)
+    except subprocess.CalledProcessError as e:
+        print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+        return ExitStatus.TROUBLE
+    except OSError as e:
+        print_trouble(
+            parser.prog,
+            "Command '{}' failed to start: {}".format(
+                subprocess.list2cmdline(version_invocation), e
+            ),
+            use_colors=colored_stderr,
+        )
+        return ExitStatus.TROUBLE
+
+    retcode = ExitStatus.SUCCESS
+
+    excludes = excludes_from_file(DEFAULT_CLANG_FORMAT_IGNORE)
+    excludes.extend(args.exclude)
+
+    files = list_files(
+        args.files,
+        recursive=args.recursive,
+        exclude=excludes,
+        extensions=args.extensions.split(','))
+
+    if not files:
+        return
+
+    njobs = args.j
+    if njobs == 0:
+        njobs = multiprocessing.cpu_count() + 1
+    njobs = min(len(files), njobs)
+
+    if njobs == 1:
+        # execute directly instead of in a pool,
+        # less overhead, simpler stacktraces
+        it = (run_clang_format_diff_wrapper(args, file) for file in files)
+        pool = None
+    else:
+        pool = multiprocessing.Pool(njobs)
+        it = pool.imap_unordered(
+            partial(run_clang_format_diff_wrapper, args), files)
+        pool.close()
+    while True:
+        try:
+            outs, errs = next(it)
+        except StopIteration:
+            break
+        except DiffError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            retcode = ExitStatus.TROUBLE
+            sys.stderr.writelines(e.errs)
+        except UnexpectedError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            sys.stderr.write(e.formatted_traceback)
+            retcode = ExitStatus.TROUBLE
+            # stop at the first unexpected error,
+            # something could be very wrong,
+            # don't process all files unnecessarily
+            if pool:
+                pool.terminate()
+            break
+        else:
+            sys.stderr.writelines(errs)
+            if outs == []:
+                continue
+            if not args.quiet:
+                print_diff(outs, use_color=colored_stdout)
+            if retcode == ExitStatus.SUCCESS:
+                retcode = ExitStatus.DIFF
+    if pool:
+        pool.join()
+    return retcode
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This MR updates the contribution guidelines, and improves the linting CI workflow. The applications in the `apps` folder are now checked against `clang-format`. The CI workflow also checks for trailing whitespace and tabs.