### PR TITLE
Add parametrization for FPU and FPU-specific formats support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Parametrization for FPU and FPU-specific formats support
+- Parametrization for FPU and FPU-specific formats support, through the `FPUSupport` ara_soc parameter
 
 ## 1.1.0 - 2020-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Parametrization for FPU and FPU-specific formats support
+
 ## 1.1.0 - 2020-03-18
 
 ### Added

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -30,6 +30,13 @@ package ara_pkg;
   // Maximum number of lanes that Ara can support.
   localparam int unsigned MaxNrLanes = 16;
 
+  // Ara Features.
+  localparam bit RVV_FP = 1'b1; // Support for floating-point vector instructions
+  // Ara cannot support 16-bit float if the scalar core (CVA6) does not support them
+  localparam bit RVVH = 1'b1 & ariane_pkg::XF16; // Is H extension enabled for vectors?
+  localparam bit RVVF = 1'b1; // Is F extension enabled for vectors?
+  localparam bit RVVD = 1'b1; // Is D extension enabled for vectors?
+
   // Multiplier latencies.
   localparam int unsigned LatMultiplierEW64 = 1;
   localparam int unsigned LatMultiplierEW32 = 1;

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -31,21 +31,29 @@ package ara_pkg;
   localparam int unsigned MaxNrLanes = 16;
 
   // Ara Features.
-  localparam bit RVV_FP = 1'b1; // Support for floating-point vector instructions
-  // Ara cannot support 16-bit float if the scalar core (CVA6) does not support them
-  localparam bit RVVH = 1'b1 & ariane_pkg::XF16; // Is H extension enabled for vectors?
-  localparam bit RVVF = 1'b1 & ariane_pkg::RVF;  // Is F extension enabled for vectors?
-  localparam bit RVVD = 1'b1 & ariane_pkg::RVD;  // Is D extension enabled for vectors?
-  // FPU support enum type
-  typedef enum bit [2:0] {
-    FPU_16       = 3'b100,
-    FPU_16_32    = 3'b110,
-    FPU_32       = 3'b010,
-    FPU_32_64    = 3'b011,
-    FPU_64       = 3'b001,
-    FPU_16_32_64 = 3'b111
+
+  // The three bits correspond to {RVVD, RVVF, RVVH}
+  typedef enum logic [2:0] {
+    FPUSupportNone             = 3'b000,
+    FPUSupportHalf             = 3'b001,
+    FPUSupportSingle           = 3'b010,
+    FPUSupportHalfSingle       = 3'b011,
+    FPUSupportDouble           = 3'b100,
+    FPUSupportSingleDouble     = 3'b110,
+    FPUSupportHalfSingleDouble = 3'b111
   } fpu_support_e;
-  fpu_support_e FPUSupport = fpu_support_e'({RVVH, RVVF, RVVD});
+
+  function automatic logic RVVD(fpu_support_e e);
+    return e[2];
+  endfunction: RVVD
+
+  function automatic logic RVVF(fpu_support_e e);
+    return e[1];
+  endfunction: RVVF
+
+  function automatic logic RVVH(fpu_support_e e);
+    return e[0];
+  endfunction: RVVH
 
   // Multiplier latencies.
   localparam int unsigned LatMultiplierEW64 = 1;
@@ -536,7 +544,7 @@ package ara_pkg;
     logic swap_vs2_vd_op; // If asserted: vs2 is kept in MulFPU opqueue C, and vd_op in MulFPU A
 
     fpnew_pkg::roundmode_e fp_rm; // Rounding-Mode for FP operations
-    logic wide_fp_imm; // Widen FP immediate (re-encoding)
+    logic wide_fp_imm;            // Widen FP immediate (re-encoding)
 
     // Vector machine metadata
     vlen_t vl;

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -36,6 +36,16 @@ package ara_pkg;
   localparam bit RVVH = 1'b1 & ariane_pkg::XF16; // Is H extension enabled for vectors?
   localparam bit RVVF = 1'b1; // Is F extension enabled for vectors?
   localparam bit RVVD = 1'b1; // Is D extension enabled for vectors?
+  // FPU support enum type
+  typedef enum bit [2:0] {
+    FPU_16       = 3'b100,
+    FPU_16_32    = 3'b110,
+    FPU_32       = 3'b010,
+    FPU_32_64    = 3'b011,
+    FPU_64       = 3'b001,
+    FPU_16_32_64 = 3'b111
+  } fpu_support_e;
+  fpu_support_e FPUSupport = fpu_support_e'({RVVH, RVVF, RVVD});
 
   // Multiplier latencies.
   localparam int unsigned LatMultiplierEW64 = 1;

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -34,8 +34,8 @@ package ara_pkg;
   localparam bit RVV_FP = 1'b1; // Support for floating-point vector instructions
   // Ara cannot support 16-bit float if the scalar core (CVA6) does not support them
   localparam bit RVVH = 1'b1 & ariane_pkg::XF16; // Is H extension enabled for vectors?
-  localparam bit RVVF = 1'b1; // Is F extension enabled for vectors?
-  localparam bit RVVD = 1'b1; // Is D extension enabled for vectors?
+  localparam bit RVVF = 1'b1 & ariane_pkg::RVF;  // Is F extension enabled for vectors?
+  localparam bit RVVD = 1'b1 & ariane_pkg::RVD;  // Is D extension enabled for vectors?
   // FPU support enum type
   typedef enum bit [2:0] {
     FPU_16       = 3'b100,

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -8,20 +8,21 @@
 
 module ara import ara_pkg::*; #(
     // RVV Parameters
-    parameter int  unsigned NrLanes      = 0,          // Number of parallel vector lanes.
+    parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
+    parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble, // Support for floating-point data types
     // AXI Interface
-    parameter int  unsigned AxiDataWidth = 0,
-    parameter int  unsigned AxiAddrWidth = 0,
-    parameter type          axi_ar_t     = logic,
-    parameter type          axi_r_t      = logic,
-    parameter type          axi_aw_t     = logic,
-    parameter type          axi_w_t      = logic,
-    parameter type          axi_b_t      = logic,
-    parameter type          axi_req_t    = logic,
-    parameter type          axi_resp_t   = logic,
+    parameter  int           unsigned AxiDataWidth = 0,
+    parameter  int           unsigned AxiAddrWidth = 0,
+    parameter  type                   axi_ar_t     = logic,
+    parameter  type                   axi_r_t      = logic,
+    parameter  type                   axi_aw_t     = logic,
+    parameter  type                   axi_w_t      = logic,
+    parameter  type                   axi_b_t      = logic,
+    parameter  type                   axi_req_t    = logic,
+    parameter  type                   axi_resp_t   = logic,
     // Dependant parameters. DO NOT CHANGE!
     // Ara has NrLanes + 3 processing elements: each one of the lanes, the vector load unit, the vector store unit, the slide unit, and the mask unit.
-    localparam int  unsigned NrPEs       = NrLanes + 4
+    localparam int           unsigned NrPEs        = NrLanes + 4
   ) (
     // Clock and Reset
     input  logic              clk_i,
@@ -184,7 +185,8 @@ module ara import ara_pkg::*; #(
 
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
-      .NrLanes(NrLanes)
+      .NrLanes   (NrLanes   ),
+      .FPUSupport(FPUSupport)
     ) i_lane (
       .clk_i                  (clk_i                       ),
       .rst_ni                 (rst_ni                      ),
@@ -361,5 +363,14 @@ module ara import ara_pkg::*; #(
 
   if (ara_pkg::VLEN != 2**$clog2(ara_pkg::VLEN))
     $error("[ara] The vector length must be a power of two.");
+
+  if (RVVD(FPUSupport) && !ariane_pkg::RVD)
+    $error("[ara] Cannot support double-precision floating-point on Ara if Ariane does not support it.");
+
+  if (RVVF(FPUSupport) && !ariane_pkg::RVF)
+    $error("[ara] Cannot support single-precision floating-point on Ara if Ariane does not support it.");
+
+  if (RVVH(FPUSupport) && !ariane_pkg::XF16)
+    $error("[ara] Cannot support half-precision floating-point on Ara if Ariane does not support it.");
 
 endmodule : ara

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1781,38 +1781,38 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Ara can support 16-bit float, 32-bit float, 64-bit float.
                 // Ara cannot support instructions who operates on more than 64 bits.
-                unique case ({RVVH, RVVF, RVVD})
-                  3'b111: begin
+                unique case (FPUSupport)
+                  FPU_16_32_64: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b110: begin
+                  FPU_16_32: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b011: begin
+                  FPU_32_64: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b100: begin
+                  FPU_16: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b010: begin
+                  FPU_32: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b001: begin
+                  FPU_64: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
@@ -2052,38 +2052,38 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Ara can support 16-bit float, 32-bit float, 64-bit float.
                 // Ara cannot support instructions who operates on more than 64 bits.
-                unique case ({RVVH, RVVF, RVVD})
-                  3'b111: begin
+                unique case (FPUSupport)
+                  FPU_16_32_64: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b110: begin
+                  FPU_16_32: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b011: begin
+                  FPU_32_64: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b100: begin
+                  FPU_16: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b010: begin
+                  FPU_32: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  3'b001: begin
+                  FPU_64: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -9,7 +9,8 @@
 // response or an error message.
 
 module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int unsigned NrLanes = 0
+    parameter int unsigned NrLanes     = 0,
+    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble // Support for floating-point data types
   ) (
     // Clock and reset
     input  logic                                 clk_i,
@@ -1555,7 +1556,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             end
 
             OPFVV: begin: opfvv
-              if (RVV_FP) begin
+              if (FPUSupport != FPUSupportNone) begin
                 // These generate a request to Ara's backend
                 ara_req_d.vs1     = insn.varith_type.rs1;
                 ara_req_d.use_vs1 = 1'b1;
@@ -1782,37 +1783,37 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 // Ara can support 16-bit float, 32-bit float, 64-bit float.
                 // Ara cannot support instructions who operates on more than 64 bits.
                 unique case (FPUSupport)
-                  FPU_16_32_64: begin
+                  FPUSupportHalfSingleDouble: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_16_32: begin
+                  FPUSupportHalfSingle: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_32_64: begin
+                  FPUSupportSingleDouble: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_16: begin
+                  FPUSupportHalf: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_32: begin
+                  FPUSupportSingle: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_64: begin
+                  FPUSupportDouble: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
@@ -1837,7 +1838,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             end
 
             OPFVF: begin: opfvf
-              if (RVV_FP) begin
+              if (FPUSupport != FPUSupportNone) begin
                 // These generate a request to Ara's backend
                 ara_req_d.scalar_op     = acc_req_i.rs1;
                 ara_req_d.use_scalar_op = 1'b1;
@@ -2053,37 +2054,37 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 // Ara can support 16-bit float, 32-bit float, 64-bit float.
                 // Ara cannot support instructions who operates on more than 64 bits.
                 unique case (FPUSupport)
-                  FPU_16_32_64: begin
+                  FPUSupportHalfSingleDouble: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_16_32: begin
+                  FPUSupportHalfSingle: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_32_64: begin
+                  FPUSupportSingleDouble: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_16: begin
+                  FPUSupportHalf: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_32: begin
+                  FPUSupportSingle: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_64: begin
+                  FPUSupportDouble: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1555,6 +1555,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             end
 
             OPFVV: begin: opfvv
+            if (RVV_FP) begin
               // These generate a request to Ara's backend
               ara_req_d.vs1     = insn.varith_type.rs1;
               ara_req_d.use_vs1 = 1'b1;
@@ -1778,29 +1779,65 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 default:;
               endcase
 
-              // Ara supports 16-bit float, 32-bit float, 64-bit float.
+              // Ara can support 16-bit float, 32-bit float, 64-bit float.
               // Ara cannot support instructions who operates on more than 64 bits.
-              // Ara cannot support 16-bit float if the scalar core (CVA6) does not support them
-              if (ariane_pkg::XF16) begin
-                if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+              unique case ({RVVH, RVVF, RVVD})
+                3'b111: begin
+                  if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b110: begin
+                  if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b011: begin
+                  if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b100: begin
+                  if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b010: begin
+                  if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b001: begin
+                  if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                default: begin
+                  // Unsupported configuration
                   acc_resp_o.error = 1'b1;
                   ara_req_valid_d  = 1'b0;
                 end
-              end else begin
-                if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-              end
+              endcase
 
               // Instruction is invalid if the vtype is invalid
               if (vtype_q.vill) begin
                 acc_resp_o.error = 1'b1;
                 ara_req_valid_d  = 1'b0;
               end
+            end else begin // Vector FP instructions are disabled
+              acc_resp_o.error = 1'b1;
+              ara_req_valid_d  = 1'b0;
+            end
             end
 
             OPFVF: begin: opfvf
+            if (RVV_FP) begin
               // These generate a request to Ara's backend
               ara_req_d.scalar_op     = acc_req_i.rs1;
               ara_req_d.use_scalar_op = 1'b1;
@@ -2013,26 +2050,61 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 default:;
               endcase
 
-              // Ara supports 16-bit float, 32-bit float, 64-bit float.
+              // Ara can support 16-bit float, 32-bit float, 64-bit float.
               // Ara cannot support instructions who operates on more than 64 bits.
-              // Ara cannot support 16-bit float if the scalar core (CVA6) does not support them
-              if (ariane_pkg::XF16) begin
-                if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+              unique case ({RVVH, RVVF, RVVD})
+                3'b111: begin
+                  if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b110: begin
+                  if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b011: begin
+                  if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b100: begin
+                  if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b010: begin
+                  if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                3'b001: begin
+                  if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                end
+                default: begin
+                  // Unsupported configuration
                   acc_resp_o.error = 1'b1;
                   ara_req_valid_d  = 1'b0;
                 end
-              end else begin
-                if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-              end
+              endcase
 
               // Instruction is invalid if the vtype is invalid
               if (vtype_q.vill) begin
                 acc_resp_o.error = 1'b1;
                 ara_req_valid_d  = 1'b0;
               end
+            end else begin // Vector FP instructions are disabled
+              acc_resp_o.error = 1'b1;
+              ara_req_valid_d  = 1'b0;
+            end
             end
           endcase
         end

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1555,556 +1555,556 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             end
 
             OPFVV: begin: opfvv
-            if (RVV_FP) begin
-              // These generate a request to Ara's backend
-              ara_req_d.vs1     = insn.varith_type.rs1;
-              ara_req_d.use_vs1 = 1'b1;
-              ara_req_d.vs2     = insn.varith_type.rs2;
-              ara_req_d.use_vs2 = 1'b1;
-              ara_req_d.vd      = insn.varith_type.rd;
-              ara_req_d.use_vd  = 1'b1;
-              ara_req_d.vm      = insn.varith_type.vm;
-              ara_req_d.fp_rm   = acc_req_i.frm;
-              ara_req_valid_d   = 1'b1;
+              if (RVV_FP) begin
+                // These generate a request to Ara's backend
+                ara_req_d.vs1     = insn.varith_type.rs1;
+                ara_req_d.use_vs1 = 1'b1;
+                ara_req_d.vs2     = insn.varith_type.rs2;
+                ara_req_d.use_vs2 = 1'b1;
+                ara_req_d.vd      = insn.varith_type.rd;
+                ara_req_d.use_vd  = 1'b1;
+                ara_req_d.vm      = insn.varith_type.vm;
+                ara_req_d.fp_rm   = acc_req_i.frm;
+                ara_req_valid_d   = 1'b1;
 
-              // Decode based on the func6 field
-              unique case (insn.varith_type.func6)
-                // VFP Addition
-                6'b000000: begin
-                  ara_req_d.op             = ara_pkg::VFADD;
-                  // When performing a floating-point add/sub, fpnew adds the second and the third operand
-                  // So, send the first operand (vs2) to the third result queue
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b000010: begin
-                  ara_req_d.op             = ara_pkg::VFSUB;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b000100: ara_req_d.op = ara_pkg::VFMIN;
-                6'b000110: ara_req_d.op = ara_pkg::VFMAX;
-                6'b001000: ara_req_d.op = ara_pkg::VFSGNJ;
-                6'b001001: ara_req_d.op = ara_pkg::VFSGNJN;
-                6'b001010: ara_req_d.op = ara_pkg::VFSGNJX;
-                6'b100100: ara_req_d.op = ara_pkg::VFMUL;
-                6'b101000: begin
-                  ara_req_d.op             = ara_pkg::VFMADD;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101001: begin
-                  ara_req_d.op             = ara_pkg::VFNMADD;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101010: begin
-                  ara_req_d.op             = ara_pkg::VFMSUB;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101011: begin
-                  ara_req_d.op             = ara_pkg::VFNMSUB;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101100: begin
-                  ara_req_d.op        = ara_pkg::VFMACC;
-                  ara_req_d.use_vd_op = 1'b1;
-                end
-                6'b101101: begin
-                  ara_req_d.op        = ara_pkg::VFNMACC;
-                  ara_req_d.use_vd_op = 1'b1;
-                end
-                6'b101110: begin
-                  ara_req_d.op        = ara_pkg::VFMSAC;
-                  ara_req_d.use_vd_op = 1'b1;
-                end
-                6'b101111: begin
-                  ara_req_d.op        = ara_pkg::VFNMSAC;
-                  ara_req_d.use_vd_op = 1'b1;
-                end
-                6'b110000: begin // VFWADD
-                  ara_req_d.op             = ara_pkg::VFADD;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                end
-                6'b110010: begin // VFWSUB
-                  ara_req_d.op             = ara_pkg::VFSUB;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                end
-                6'b110100: begin // VFWADD.W
-                  ara_req_d.op             = ara_pkg::VFADD;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  lmul_vs2                 = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.eew_vs2        = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                end
-                6'b110110: begin // VFWSUB.W
-                  ara_req_d.op             = ara_pkg::VFSUB;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  lmul_vs2                 = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.eew_vs2        = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                end
-                6'b111000: begin // VFWMUL
-                  ara_req_d.op             = ara_pkg::VFMUL;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                end
-                6'b111100: begin // VFWMACC
-                  ara_req_d.op             = ara_pkg::VFMACC;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.eew_vd_op      = vtype_q.vsew.next();
-                end
-                6'b111101: begin // VFWNMACC
-                  ara_req_d.op             = ara_pkg::VFNMACC;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.eew_vd_op      = vtype_q.vsew.next();
-                end
-                6'b111110: begin // VFWMSAC
-                  ara_req_d.op             = ara_pkg::VFMSAC;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.eew_vd_op      = vtype_q.vsew.next();
-                end
-                6'b111111: begin // VFWNMSAC
-                  ara_req_d.op             = ara_pkg::VFNMSAC;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.eew_vd_op      = vtype_q.vsew.next();
-                end
-                default: begin
-                  // Trigger an error
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-              endcase
+                // Decode based on the func6 field
+                unique case (insn.varith_type.func6)
+                  // VFP Addition
+                  6'b000000: begin
+                    ara_req_d.op             = ara_pkg::VFADD;
+                    // When performing a floating-point add/sub, fpnew adds the second and the third operand
+                    // So, send the first operand (vs2) to the third result queue
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b000010: begin
+                    ara_req_d.op             = ara_pkg::VFSUB;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b000100: ara_req_d.op = ara_pkg::VFMIN;
+                  6'b000110: ara_req_d.op = ara_pkg::VFMAX;
+                  6'b001000: ara_req_d.op = ara_pkg::VFSGNJ;
+                  6'b001001: ara_req_d.op = ara_pkg::VFSGNJN;
+                  6'b001010: ara_req_d.op = ara_pkg::VFSGNJX;
+                  6'b100100: ara_req_d.op = ara_pkg::VFMUL;
+                  6'b101000: begin
+                    ara_req_d.op             = ara_pkg::VFMADD;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101001: begin
+                    ara_req_d.op             = ara_pkg::VFNMADD;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101010: begin
+                    ara_req_d.op             = ara_pkg::VFMSUB;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101011: begin
+                    ara_req_d.op             = ara_pkg::VFNMSUB;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101100: begin
+                    ara_req_d.op        = ara_pkg::VFMACC;
+                    ara_req_d.use_vd_op = 1'b1;
+                  end
+                  6'b101101: begin
+                    ara_req_d.op        = ara_pkg::VFNMACC;
+                    ara_req_d.use_vd_op = 1'b1;
+                  end
+                  6'b101110: begin
+                    ara_req_d.op        = ara_pkg::VFMSAC;
+                    ara_req_d.use_vd_op = 1'b1;
+                  end
+                  6'b101111: begin
+                    ara_req_d.op        = ara_pkg::VFNMSAC;
+                    ara_req_d.use_vd_op = 1'b1;
+                  end
+                  6'b110000: begin // VFWADD
+                    ara_req_d.op             = ara_pkg::VFADD;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                  end
+                  6'b110010: begin // VFWSUB
+                    ara_req_d.op             = ara_pkg::VFSUB;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                  end
+                  6'b110100: begin // VFWADD.W
+                    ara_req_d.op             = ara_pkg::VFADD;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    lmul_vs2                 = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.eew_vs2        = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                  end
+                  6'b110110: begin // VFWSUB.W
+                    ara_req_d.op             = ara_pkg::VFSUB;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    lmul_vs2                 = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.eew_vs2        = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                  end
+                  6'b111000: begin // VFWMUL
+                    ara_req_d.op             = ara_pkg::VFMUL;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                  end
+                  6'b111100: begin // VFWMACC
+                    ara_req_d.op             = ara_pkg::VFMACC;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.eew_vd_op      = vtype_q.vsew.next();
+                  end
+                  6'b111101: begin // VFWNMACC
+                    ara_req_d.op             = ara_pkg::VFNMACC;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.eew_vd_op      = vtype_q.vsew.next();
+                  end
+                  6'b111110: begin // VFWMSAC
+                    ara_req_d.op             = ara_pkg::VFMSAC;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.eew_vd_op      = vtype_q.vsew.next();
+                  end
+                  6'b111111: begin // VFWNMSAC
+                    ara_req_d.op             = ara_pkg::VFNMSAC;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueConversionWideFP2;
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.eew_vd_op      = vtype_q.vsew.next();
+                  end
+                  default: begin
+                    // Trigger an error
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                endcase
 
-              // Instructions with an integer LMUL have extra constraints on the registers they can access.
-              // The constraints can be different for the two source operands and the destination register.
-              unique case (ara_req_d.emul)
-                LMUL_2:
-                  if ((insn.varith_type.rd & 5'b00001) != 5'b00000) begin
+                // Instructions with an integer LMUL have extra constraints on the registers they can access.
+                // The constraints can be different for the two source operands and the destination register.
+                unique case (ara_req_d.emul)
+                  LMUL_2:
+                    if ((insn.varith_type.rd & 5'b00001) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_4:
+                    if ((insn.varith_type.rd & 5'b00011) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_8:
+                    if ((insn.varith_type.rd & 5'b00111) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_RSVD: begin
                     acc_resp_o.error = 1'b1;
                     ara_req_valid_d  = 1'b0;
                   end
-                LMUL_4:
-                  if ((insn.varith_type.rd & 5'b00011) != 5'b00000) begin
+                  default:;
+                endcase
+                unique case (lmul_vs2)
+                  LMUL_2:
+                    if ((insn.varith_type.rs2 & 5'b00001) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_4:
+                    if ((insn.varith_type.rs2 & 5'b00011) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_8:
+                    if ((insn.varith_type.rs2 & 5'b00111) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_RSVD: begin
                     acc_resp_o.error = 1'b1;
                     ara_req_valid_d  = 1'b0;
                   end
-                LMUL_8:
-                  if ((insn.varith_type.rd & 5'b00111) != 5'b00000) begin
+                  default:;
+                endcase
+                unique case (lmul_vs1)
+                  LMUL_2:
+                    if ((insn.varith_type.rs1 & 5'b00001) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_4:
+                    if ((insn.varith_type.rs1 & 5'b00011) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_8:
+                    if ((insn.varith_type.rs1 & 5'b00111) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_RSVD: begin
                     acc_resp_o.error = 1'b1;
                     ara_req_valid_d  = 1'b0;
                   end
-                LMUL_RSVD: begin
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-                default:;
-              endcase
-              unique case (lmul_vs2)
-                LMUL_2:
-                  if ((insn.varith_type.rs2 & 5'b00001) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_4:
-                  if ((insn.varith_type.rs2 & 5'b00011) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_8:
-                  if ((insn.varith_type.rs2 & 5'b00111) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_RSVD: begin
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-                default:;
-              endcase
-              unique case (lmul_vs1)
-                LMUL_2:
-                  if ((insn.varith_type.rs1 & 5'b00001) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_4:
-                  if ((insn.varith_type.rs1 & 5'b00011) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_8:
-                  if ((insn.varith_type.rs1 & 5'b00111) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_RSVD: begin
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-                default:;
-              endcase
+                  default:;
+                endcase
 
-              // Ara can support 16-bit float, 32-bit float, 64-bit float.
-              // Ara cannot support instructions who operates on more than 64 bits.
-              unique case ({RVVH, RVVF, RVVD})
-                3'b111: begin
-                  if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                // Ara can support 16-bit float, 32-bit float, 64-bit float.
+                // Ara cannot support instructions who operates on more than 64 bits.
+                unique case ({RVVH, RVVF, RVVD})
+                  3'b111: begin
+                    if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b110: begin
+                    if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b011: begin
+                    if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b100: begin
+                    if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b010: begin
+                    if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b001: begin
+                    if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  default: begin
+                    // Unsupported configuration
                     acc_resp_o.error = 1'b1;
                     ara_req_valid_d  = 1'b0;
                   end
-                end
-                3'b110: begin
-                  if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b011: begin
-                  if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b100: begin
-                  if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b010: begin
-                  if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b001: begin
-                  if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                default: begin
-                  // Unsupported configuration
+                endcase
+
+                // Instruction is invalid if the vtype is invalid
+                if (vtype_q.vill) begin
                   acc_resp_o.error = 1'b1;
                   ara_req_valid_d  = 1'b0;
                 end
-              endcase
-
-              // Instruction is invalid if the vtype is invalid
-              if (vtype_q.vill) begin
+              end else begin // Vector FP instructions are disabled
                 acc_resp_o.error = 1'b1;
                 ara_req_valid_d  = 1'b0;
               end
-            end else begin // Vector FP instructions are disabled
-              acc_resp_o.error = 1'b1;
-              ara_req_valid_d  = 1'b0;
-            end
             end
 
             OPFVF: begin: opfvf
-            if (RVV_FP) begin
-              // These generate a request to Ara's backend
-              ara_req_d.scalar_op     = acc_req_i.rs1;
-              ara_req_d.use_scalar_op = 1'b1;
-              ara_req_d.vs2           = insn.varith_type.rs2;
-              ara_req_d.use_vs2       = 1'b1;
-              ara_req_d.vd            = insn.varith_type.rd;
-              ara_req_d.use_vd        = 1'b1;
-              ara_req_d.vm            = insn.varith_type.vm;
-              ara_req_d.fp_rm         = acc_req_i.frm;
-              ara_req_valid_d         = 1'b1;
+              if (RVV_FP) begin
+                // These generate a request to Ara's backend
+                ara_req_d.scalar_op     = acc_req_i.rs1;
+                ara_req_d.use_scalar_op = 1'b1;
+                ara_req_d.vs2           = insn.varith_type.rs2;
+                ara_req_d.use_vs2       = 1'b1;
+                ara_req_d.vd            = insn.varith_type.rd;
+                ara_req_d.use_vd        = 1'b1;
+                ara_req_d.vm            = insn.varith_type.vm;
+                ara_req_d.fp_rm         = acc_req_i.frm;
+                ara_req_valid_d         = 1'b1;
 
-              // Decode based on the func6 field
-              unique case (insn.varith_type.func6)
-                // VFP Addition
-                6'b000000: begin
-                  ara_req_d.op             = ara_pkg::VFADD;
-                  // When performing a floating-point add/sub, fpnew adds the second and the third operand
-                  // So, send the first operand (vs2) to the third result queue
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b000010: begin
-                  ara_req_d.op             = ara_pkg::VFSUB;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b000100: ara_req_d.op = ara_pkg::VFMIN;
-                6'b000110: ara_req_d.op = ara_pkg::VFMAX;
-                6'b001000: ara_req_d.op = ara_pkg::VFSGNJ;
-                6'b001001: ara_req_d.op = ara_pkg::VFSGNJN;
-                6'b001010: ara_req_d.op = ara_pkg::VFSGNJX;
-                6'b010111: ara_req_d.op = ara_pkg::VMERGE;
-                6'b100100: ara_req_d.op = ara_pkg::VFMUL;
-                6'b100111: begin
-                  ara_req_d.op             = ara_pkg::VFRSUB;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101000: begin
-                  ara_req_d.op             = ara_pkg::VFMADD;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101001: begin
-                  ara_req_d.op             = ara_pkg::VFNMADD;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101010: begin
-                  ara_req_d.op             = ara_pkg::VFMSUB;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101011: begin
-                  ara_req_d.op             = ara_pkg::VFNMSUB;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                end
-                6'b101100: begin
-                  ara_req_d.op        = ara_pkg::VFMACC;
-                  ara_req_d.use_vd_op = 1'b1;
-                end
-                6'b101101: begin
-                  ara_req_d.op        = ara_pkg::VFNMACC;
-                  ara_req_d.use_vd_op = 1'b1;
-                end
-                6'b101110: begin
-                  ara_req_d.op        = ara_pkg::VFMSAC;
-                  ara_req_d.use_vd_op = 1'b1;
-                end
-                6'b101111: begin
-                  ara_req_d.op        = ara_pkg::VFNMSAC;
-                  ara_req_d.use_vd_op = 1'b1;
-                end
-                6'b110000: begin // VFWADD
-                  ara_req_d.op             = ara_pkg::VFADD;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                end
-                6'b110010: begin // VFWSUB
-                  ara_req_d.op             = ara_pkg::VFSUB;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                end
-                6'b110100: begin // VFWADD.W
-                  ara_req_d.op             = ara_pkg::VFADD;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  lmul_vs2                 = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.eew_vs2        = vtype_q.vsew.next();
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                end
-                6'b110110: begin // VFWSUB.W
-                  ara_req_d.op             = ara_pkg::VFSUB;
-                  ara_req_d.swap_vs2_vd_op = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  lmul_vs2                 = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.eew_vs2        = vtype_q.vsew.next();
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                end
-                6'b111000: begin // VFWMUL
-                  ara_req_d.op             = ara_pkg::VFMUL;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                end
-                6'b111100: begin // VFWMACC
-                  ara_req_d.op             = ara_pkg::VFMACC;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                  ara_req_d.eew_vd_op      = vtype_q.vsew.next();
-                end
-                6'b111101: begin // VFWNMACC
-                  ara_req_d.op             = ara_pkg::VFNMACC;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                  ara_req_d.eew_vd_op      = vtype_q.vsew.next();
-                end
-                6'b111110: begin // VFWMSAC
-                  ara_req_d.op             = ara_pkg::VFMSAC;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                  ara_req_d.eew_vd_op      = vtype_q.vsew.next();
-                end
-                6'b111111: begin // VFWNMSAC
-                  ara_req_d.op             = ara_pkg::VFNMSAC;
-                  ara_req_d.use_vd_op      = 1'b1;
-                  ara_req_d.emul           = next_lmul(vtype_q.vlmul);
-                  ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                  ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
-                  ara_req_d.wide_fp_imm    = 1'b1;
-                  ara_req_d.eew_vd_op      = vtype_q.vsew.next();
-                end
-                default: begin
-                  // Trigger an error
+                // Decode based on the func6 field
+                unique case (insn.varith_type.func6)
+                  // VFP Addition
+                  6'b000000: begin
+                    ara_req_d.op             = ara_pkg::VFADD;
+                    // When performing a floating-point add/sub, fpnew adds the second and the third operand
+                    // So, send the first operand (vs2) to the third result queue
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b000010: begin
+                    ara_req_d.op             = ara_pkg::VFSUB;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b000100: ara_req_d.op = ara_pkg::VFMIN;
+                  6'b000110: ara_req_d.op = ara_pkg::VFMAX;
+                  6'b001000: ara_req_d.op = ara_pkg::VFSGNJ;
+                  6'b001001: ara_req_d.op = ara_pkg::VFSGNJN;
+                  6'b001010: ara_req_d.op = ara_pkg::VFSGNJX;
+                  6'b010111: ara_req_d.op = ara_pkg::VMERGE;
+                  6'b100100: ara_req_d.op = ara_pkg::VFMUL;
+                  6'b100111: begin
+                    ara_req_d.op             = ara_pkg::VFRSUB;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101000: begin
+                    ara_req_d.op             = ara_pkg::VFMADD;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101001: begin
+                    ara_req_d.op             = ara_pkg::VFNMADD;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101010: begin
+                    ara_req_d.op             = ara_pkg::VFMSUB;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101011: begin
+                    ara_req_d.op             = ara_pkg::VFNMSUB;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    // Swap "vs2" and "vd" since "vs2" is the addend and "vd" is the multiplicand
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                  end
+                  6'b101100: begin
+                    ara_req_d.op        = ara_pkg::VFMACC;
+                    ara_req_d.use_vd_op = 1'b1;
+                  end
+                  6'b101101: begin
+                    ara_req_d.op        = ara_pkg::VFNMACC;
+                    ara_req_d.use_vd_op = 1'b1;
+                  end
+                  6'b101110: begin
+                    ara_req_d.op        = ara_pkg::VFMSAC;
+                    ara_req_d.use_vd_op = 1'b1;
+                  end
+                  6'b101111: begin
+                    ara_req_d.op        = ara_pkg::VFNMSAC;
+                    ara_req_d.use_vd_op = 1'b1;
+                  end
+                  6'b110000: begin // VFWADD
+                    ara_req_d.op             = ara_pkg::VFADD;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                  end
+                  6'b110010: begin // VFWSUB
+                    ara_req_d.op             = ara_pkg::VFSUB;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                  end
+                  6'b110100: begin // VFWADD.W
+                    ara_req_d.op             = ara_pkg::VFADD;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    lmul_vs2                 = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.eew_vs2        = vtype_q.vsew.next();
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                  end
+                  6'b110110: begin // VFWSUB.W
+                    ara_req_d.op             = ara_pkg::VFSUB;
+                    ara_req_d.swap_vs2_vd_op = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    lmul_vs2                 = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.eew_vs2        = vtype_q.vsew.next();
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                  end
+                  6'b111000: begin // VFWMUL
+                    ara_req_d.op             = ara_pkg::VFMUL;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                  end
+                  6'b111100: begin // VFWMACC
+                    ara_req_d.op             = ara_pkg::VFMACC;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                    ara_req_d.eew_vd_op      = vtype_q.vsew.next();
+                  end
+                  6'b111101: begin // VFWNMACC
+                    ara_req_d.op             = ara_pkg::VFNMACC;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                    ara_req_d.eew_vd_op      = vtype_q.vsew.next();
+                  end
+                  6'b111110: begin // VFWMSAC
+                    ara_req_d.op             = ara_pkg::VFMSAC;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                    ara_req_d.eew_vd_op      = vtype_q.vsew.next();
+                  end
+                  6'b111111: begin // VFWNMSAC
+                    ara_req_d.op             = ara_pkg::VFNMSAC;
+                    ara_req_d.use_vd_op      = 1'b1;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
+                    ara_req_d.wide_fp_imm    = 1'b1;
+                    ara_req_d.eew_vd_op      = vtype_q.vsew.next();
+                  end
+                  default: begin
+                    // Trigger an error
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                endcase
+
+                // Check if the FP scalar operand is NaN-boxed. If not, replace it with a NaN.
+                case (vtype_q.vsew)
+                  EW16: if (~(&acc_req_i.rs1[63:16])) ara_req_d.scalar_op = 64'h0000000000007e00;
+                  EW32: if (~(&acc_req_i.rs1[63:32])) ara_req_d.scalar_op = 64'h000000007fc00000;
+                endcase
+
+                // Instructions with an integer LMUL have extra constraints on the registers they can access.
+                // The constraints can be different for the two source operands and the destination register.
+                unique case (ara_req_d.emul)
+                  LMUL_2:
+                    if ((insn.varith_type.rd & 5'b00001) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_4:
+                    if ((insn.varith_type.rd & 5'b00011) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_8:
+                    if ((insn.varith_type.rd & 5'b00111) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_RSVD: begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                  default:;
+                endcase
+                unique case (lmul_vs2)
+                  LMUL_2:
+                    if ((insn.varith_type.rs2 & 5'b00001) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_4:
+                    if ((insn.varith_type.rs2 & 5'b00011) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_8:
+                    if ((insn.varith_type.rs2 & 5'b00111) != 5'b00000) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  LMUL_RSVD: begin
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                  default:;
+                endcase
+
+                // Ara can support 16-bit float, 32-bit float, 64-bit float.
+                // Ara cannot support instructions who operates on more than 64 bits.
+                unique case ({RVVH, RVVF, RVVD})
+                  3'b111: begin
+                    if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b110: begin
+                    if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b011: begin
+                    if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b100: begin
+                    if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b010: begin
+                    if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  3'b001: begin
+                    if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
+                      acc_resp_o.error = 1'b1;
+                      ara_req_valid_d  = 1'b0;
+                    end
+                  end
+                  default: begin
+                    // Unsupported configuration
+                    acc_resp_o.error = 1'b1;
+                    ara_req_valid_d  = 1'b0;
+                  end
+                endcase
+
+                // Instruction is invalid if the vtype is invalid
+                if (vtype_q.vill) begin
                   acc_resp_o.error = 1'b1;
                   ara_req_valid_d  = 1'b0;
                 end
-              endcase
-
-              // Check if the FP scalar operand is NaN-boxed. If not, replace it with a NaN.
-              case (vtype_q.vsew)
-                EW16: if (~(&acc_req_i.rs1[63:16])) ara_req_d.scalar_op = 64'h0000000000007e00;
-                EW32: if (~(&acc_req_i.rs1[63:32])) ara_req_d.scalar_op = 64'h000000007fc00000;
-              endcase
-
-              // Instructions with an integer LMUL have extra constraints on the registers they can access.
-              // The constraints can be different for the two source operands and the destination register.
-              unique case (ara_req_d.emul)
-                LMUL_2:
-                  if ((insn.varith_type.rd & 5'b00001) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_4:
-                  if ((insn.varith_type.rd & 5'b00011) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_8:
-                  if ((insn.varith_type.rd & 5'b00111) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_RSVD: begin
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-                default:;
-              endcase
-              unique case (lmul_vs2)
-                LMUL_2:
-                  if ((insn.varith_type.rs2 & 5'b00001) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_4:
-                  if ((insn.varith_type.rs2 & 5'b00011) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_8:
-                  if ((insn.varith_type.rs2 & 5'b00111) != 5'b00000) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                LMUL_RSVD: begin
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-                default:;
-              endcase
-
-              // Ara can support 16-bit float, 32-bit float, 64-bit float.
-              // Ara cannot support instructions who operates on more than 64 bits.
-              unique case ({RVVH, RVVF, RVVD})
-                3'b111: begin
-                  if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b110: begin
-                  if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b011: begin
-                  if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b100: begin
-                  if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b010: begin
-                  if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                3'b001: begin
-                  if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
-                    acc_resp_o.error = 1'b1;
-                    ara_req_valid_d  = 1'b0;
-                  end
-                end
-                default: begin
-                  // Unsupported configuration
-                  acc_resp_o.error = 1'b1;
-                  ara_req_valid_d  = 1'b0;
-                end
-              endcase
-
-              // Instruction is invalid if the vtype is invalid
-              if (vtype_q.vill) begin
+              end else begin // Vector FP instructions are disabled
                 acc_resp_o.error = 1'b1;
                 ara_req_valid_d  = 1'b0;
               end
-            end else begin // Vector FP instructions are disabled
-              acc_resp_o.error = 1'b1;
-              ara_req_valid_d  = 1'b0;
-            end
             end
           endcase
         end

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -6,20 +6,21 @@
 // Description:
 // Ara's SoC, containing Ariane, Ara, and a L2 cache.
 
-module ara_soc import axi_pkg::*; #(
+module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     // RVV Parameters
-    parameter int  unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
+    parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
+    parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble, // Support for floating-point data types
     // AXI Interface
-    parameter int  unsigned AxiDataWidth = 32*NrLanes,
-    parameter int  unsigned AxiAddrWidth = 64,
-    parameter int  unsigned AxiUserWidth = 1,
-    parameter int  unsigned AxiIdWidth   = 6,
+    parameter  int           unsigned AxiDataWidth = 32*NrLanes,
+    parameter  int           unsigned AxiAddrWidth = 64,
+    parameter  int           unsigned AxiUserWidth = 1,
+    parameter  int           unsigned AxiIdWidth   = 6,
     // Dependant parameters. DO NOT CHANGE!
-    localparam type          axi_data_t   = logic [AxiDataWidth-1:0],
-    localparam type          axi_strb_t   = logic [AxiDataWidth/8-1:0],
-    localparam type          axi_addr_t   = logic [AxiAddrWidth-1:0],
-    localparam type          axi_user_t   = logic [AxiUserWidth-1:0],
-    localparam type          axi_id_t     = logic [AxiIdWidth-1:0]
+    localparam type                   axi_data_t   = logic [AxiDataWidth-1:0],
+    localparam type                   axi_strb_t   = logic [AxiDataWidth/8-1:0],
+    localparam type                   axi_addr_t   = logic [AxiAddrWidth-1:0],
+    localparam type                   axi_user_t   = logic [AxiUserWidth-1:0],
+    localparam type                   axi_id_t     = logic [AxiIdWidth-1:0]
   ) (
     input  logic             clk_i,
     input  logic             rst_ni,
@@ -654,6 +655,7 @@ module ara_soc import axi_pkg::*; #(
 
   ara #(
     .NrLanes     (NrLanes               ),
+    .FPUSupport  (FPUSupport            ),
     .AxiDataWidth(AxiWideDataWidth      ),
     .AxiAddrWidth(AxiAddrWidth          ),
     .axi_ar_t    (axi_core_ar_chan_t    ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -8,16 +8,17 @@
 // together with the execution units.
 
 module lane import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int  unsigned NrLanes          = 1,                                   // Number of lanes
+    parameter  int           unsigned NrLanes         = 1,                                   // Number of lanes
+    parameter  fpu_support_e          FPUSupport      = FPUSupportHalfSingleDouble,          // Support for floating-point data types
     // Dependant parameters. DO NOT CHANGE!
     // VRF Parameters
-    localparam int  unsigned MaxVLenPerLane  = VLEN / NrLanes,                      // In bits
-    localparam int  unsigned MaxVLenBPerLane = VLENB / NrLanes,                     // In bytes
-    localparam int  unsigned VRFSizePerLane  = MaxVLenPerLane * 32,                 // In bits
-    localparam int  unsigned VRFBSizePerLane = MaxVLenBPerLane * 32,                // In bytes
-    localparam type          vaddr_t         = logic [$clog2(VRFBSizePerLane)-1:0], // Address of an element in the lane's VRF
-    localparam int  unsigned DataWidth       = $bits(elen_t),                       // Width of the lane datapath
-    localparam type          strb_t          = logic [DataWidth/8-1:0]              // Byte-strobe type
+    localparam int           unsigned MaxVLenPerLane  = VLEN / NrLanes,                      // In bits
+    localparam int           unsigned MaxVLenBPerLane = VLENB / NrLanes,                     // In bytes
+    localparam int           unsigned VRFSizePerLane  = MaxVLenPerLane * 32,                 // In bits
+    localparam int           unsigned VRFBSizePerLane = MaxVLenBPerLane * 32,                // In bytes
+    localparam type                   vaddr_t         = logic [$clog2(VRFBSizePerLane)-1:0], // Address of an element in the lane's VRF
+    localparam int           unsigned DataWidth       = $bits(elen_t),                       // Width of the lane datapath
+    localparam type                   strb_t          = logic [DataWidth/8-1:0]              // Byte-strobe type
   ) (
     input  logic                                           clk_i,
     input  logic                                           rst_ni,
@@ -250,7 +251,9 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic  [2:0] mfpu_operand_valid;
   logic  [2:0] mfpu_operand_ready;
 
-  operand_queues_stage i_operand_queues (
+  operand_queues_stage #(
+    .FPUSupport(FPUSupport)
+  ) i_operand_queues (
     .clk_i                    (clk_i                                             ),
     .rst_ni                   (rst_ni                                            ),
     // Interface with the Vector Register File
@@ -289,8 +292,9 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
    *****************************/
 
   vector_fus_stage #(
-    .NrLanes(NrLanes),
-    .vaddr_t(vaddr_t)
+    .NrLanes   (NrLanes   ),
+    .FPUSupport(FPUSupport),
+    .vaddr_t   (vaddr_t   )
   ) i_vfus (
     .clk_i                (clk_i                  ),
     .rst_ni               (rst_ni                 ),

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -9,15 +9,16 @@
 // need it.
 
 module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int   unsigned BufferDepth    = 2,
-    parameter int   unsigned NrSlaves       = 1,
+    parameter  int           unsigned BufferDepth    = 2,
+    parameter  int           unsigned NrSlaves       = 1,
+    parameter  fpu_support_e          FPUSupport     = FPUSupportHalfSingleDouble, // Support for floating-point data types
     // Supported conversions
-    parameter logic          SupportIntExt2 = 1'b0,
-    parameter logic          SupportIntExt4 = 1'b0,
-    parameter logic          SupportIntExt8 = 1'b0,
+    parameter  logic                  SupportIntExt2 = 1'b0,
+    parameter  logic                  SupportIntExt4 = 1'b0,
+    parameter  logic                  SupportIntExt8 = 1'b0,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int   unsigned DataWidth     = $bits(elen_t),
-    localparam int   unsigned StrbWidth     = DataWidth/8
+    localparam int           unsigned DataWidth      = $bits(elen_t),
+    localparam int           unsigned StrbWidth      = DataWidth/8
   ) (
     input  logic                              clk_i,
     input  logic                              rst_ni,
@@ -184,8 +185,8 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
 
       // Floating-Point re-encoding
       OpQueueConversionWideFP2: begin
-        if (RVV_FP) begin
-          unique casez ({cmd.eew, RVVH, RVVF, RVVD})
+        if (FPUSupport != FPUSupportNone) begin
+          unique casez ({cmd.eew, RVVH(FPUSupport), RVVF(FPUSupport), RVVD(FPUSupport)})
             {EW16, 1'b1, 1'b1, 1'b?}: begin
               for (int e = 0; e < 2; e++) begin
                automatic fp16_t fp16 = ibuf_operand[8*select + 32*e +: 16];

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -185,31 +185,31 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
       // Floating-Point re-encoding
       OpQueueConversionWideFP2: begin
         if (RVV_FP) begin
-        unique casez ({cmd.eew, RVVH, RVVF, RVVD})
-          {EW16, 1'b1, 1'b1, 1'b?}: begin
-            for (int e = 0; e < 2; e++) begin
-             automatic fp16_t fp16 = ibuf_operand[8*select + 32*e +: 16];
-             automatic fp32_t fp32;
+          unique casez ({cmd.eew, RVVH, RVVF, RVVD})
+            {EW16, 1'b1, 1'b1, 1'b?}: begin
+              for (int e = 0; e < 2; e++) begin
+               automatic fp16_t fp16 = ibuf_operand[8*select + 32*e +: 16];
+               automatic fp32_t fp32;
 
-              fp32.s = fp16.s;
-              fp32.e = (fp16.e - 15) + 127;
-              fp32.m = {fp16.m, 13'b0};
+                fp32.s = fp16.s;
+                fp32.e = (fp16.e - 15) + 127;
+                fp32.m = {fp16.m, 13'b0};
 
-              conv_operand[32*e +: 32] = fp32;
+                conv_operand[32*e +: 32] = fp32;
+              end
             end
-          end
-          {EW32, 1'b?, 1'b1, 1'b1}: begin
-            automatic fp32_t fp32 = ibuf_operand[8*select +: 32];
-            automatic fp64_t fp64;
+            {EW32, 1'b?, 1'b1, 1'b1}: begin
+              automatic fp32_t fp32 = ibuf_operand[8*select +: 32];
+              automatic fp64_t fp64;
 
-            fp64.s = fp32.s;
-            fp64.e = (fp32.e - 127) + 1023;
-            fp64.m = {fp32.m, 29'b0};
+              fp64.s = fp32.s;
+              fp64.e = (fp32.e - 127) + 1023;
+              fp64.m = {fp32.m, 29'b0};
 
-            conv_operand = fp64;
-          end
-          default:;
-        endcase
+              conv_operand = fp64;
+            end
+            default:;
+          endcase
         end
       end
 

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -184,8 +184,9 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
 
       // Floating-Point re-encoding
       OpQueueConversionWideFP2: begin
-        unique case (cmd.eew)
-          EW16: begin
+        if (RVV_FP) begin
+        unique casez ({cmd.eew, RVVH, RVVF, RVVD})
+          {EW16, 1'b1, 1'b1, 1'b?}: begin
             for (int e = 0; e < 2; e++) begin
              automatic fp16_t fp16 = ibuf_operand[8*select + 32*e +: 16];
              automatic fp32_t fp32;
@@ -197,7 +198,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
               conv_operand[32*e +: 32] = fp32;
             end
           end
-          EW32: begin
+          {EW32, 1'b?, 1'b1, 1'b1}: begin
             automatic fp32_t fp32 = ibuf_operand[8*select +: 32];
             automatic fp64_t fp64;
 
@@ -209,6 +210,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
           end
           default:;
         endcase
+        end
       end
 
       default:;

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -6,7 +6,9 @@
 // Description:
 // This stage holds the operand queues, holding elements for the VRFs.
 
-module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
+module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
+    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble // Support for floating-point data types
+  ) (
     input  logic                                     clk_i,
     input  logic                                     rst_ni,
     // Interface with the Vector Register File
@@ -45,10 +47,11 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
    *********/
 
   operand_queue #(
-    .BufferDepth   (5   ),
-    .SupportIntExt2(1'b1),
-    .SupportIntExt4(1'b1),
-    .SupportIntExt8(1'b1)
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      ),
+    .SupportIntExt4(1'b1      ),
+    .SupportIntExt8(1'b1      )
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -64,10 +67,11 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
   );
 
   operand_queue #(
-    .BufferDepth   (5   ),
-    .SupportIntExt2(1'b1),
-    .SupportIntExt4(1'b1),
-    .SupportIntExt8(1'b1)
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      ),
+    .SupportIntExt4(1'b1      ),
+    .SupportIntExt8(1'b1      )
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -87,8 +91,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
    ********************/
 
   operand_queue #(
-    .BufferDepth   (5    ),
-    .SupportIntExt2(1'b1 )
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_a (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -104,8 +109,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
   );
 
   operand_queue #(
-    .BufferDepth   (5    ),
-    .SupportIntExt2(1'b1 )
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_b (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -121,8 +127,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
   );
 
   operand_queue #(
-    .BufferDepth   (5    ),
-    .SupportIntExt2(1'b1 )
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_c (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -142,7 +149,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
    *********************/
 
   operand_queue #(
-    .BufferDepth(2)
+    .BufferDepth(2         ),
+    .FPUSupport (FPUSupport)
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
@@ -158,7 +166,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
   );
 
   operand_queue #(
-    .BufferDepth(2)
+    .BufferDepth(2         ),
+    .FPUSupport (FPUSupport)
   ) i_operand_queue_addrgen_a (
     .clk_i                    (clk_i                               ),
     .rst_ni                   (rst_ni                              ),
@@ -178,7 +187,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
    ***************/
 
   operand_queue #(
-    .BufferDepth(1)
+    .BufferDepth(1         ),
+    .FPUSupport (FPUSupport)
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -8,12 +8,13 @@
 // of each lane, namely the ALU and the Multiplier/FPU.
 
 module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int  unsigned NrLanes    = 0,
+    parameter  int           unsigned NrLanes    = 0,
+    parameter  fpu_support_e          FPUSupport = FPUSupportHalfSingleDouble, // Support for floating-point data types
     // Type used to address vector register file elements
-    parameter type          vaddr_t    = logic,
+    parameter  type                   vaddr_t    = logic,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int  unsigned DataWidth = $bits(elen_t),
-    localparam type          strb_t    = logic [DataWidth/8-1:0]
+    localparam int           unsigned DataWidth  = $bits(elen_t),
+    localparam type                   strb_t     = logic [DataWidth/8-1:0]
   ) (
     input  logic                         clk_i,
     input  logic                         rst_ni,
@@ -105,8 +106,9 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
    *****************/
 
   vmfpu #(
-    .NrLanes(NrLanes),
-    .vaddr_t(vaddr_t)
+    .NrLanes   (NrLanes   ),
+    .FPUSupport(FPUSupport),
+    .vaddr_t   (vaddr_t   )
   ) i_vmfpu (
     .clk_i                (clk_i                ),
     .rst_ni               (rst_ni               ),

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -336,12 +336,25 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
    *  FPU  *
    ********/
 
+  // FPU-related signals
+  elen_t      vfpu_result;
+  status_t    vfpu_ex_flag;
+  strb_t      vfpu_mask;
+  logic       vfpu_in_valid;
+  logic       vfpu_out_valid;
+  logic       vfpu_in_ready;
+  logic       vfpu_out_ready;
+  logic       fflags_ex_valid_d, fflags_ex_valid_q;
+  logic [4:0] fflags_ex_d, fflags_ex_q;
+
+  // Is the FPU enabled?
+  if (RVV_FP) begin : fpu_gen
   // Features (enabled formats, vectors etc.)
   localparam fpu_features_t FPUFeatures = '{
     Width        : 64,
     EnableVectors: 1'b1,
     EnableNanBox : 1'b1,
-    FpFmtMask    : {1'b1, 1'b1, 1'b1, 1'b0, 1'b0},
+    FpFmtMask    : {RVVF, RVVD, RVVH, 1'b0, 1'b0},
     IntFmtMask   : {1'b0, 1'b0, 1'b0, 1'b0}
   };
 
@@ -465,10 +478,6 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
   assign vfpu_operands[1] = operand_b;
   assign vfpu_operands[2] = operand_c;
 
-  elen_t   vfpu_result;
-  status_t vfpu_ex_flag;
-  strb_t   vfpu_mask;
-
   // Do not raise exceptions on inactive elements
   localparam FPULanes = max_num_lanes(FPUFeatures.Width, FPUFeatures.FpFmtMask, FPUFeatures.EnableVectors);
   typedef logic [FPULanes-1:0] fpu_mask_t;
@@ -477,11 +486,6 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
   for (genvar b = 0; b < FPULanes; b++) begin: gen_vfpu_simd_mask
     assign vfpu_simd_mask[b] = issue_be[2*b];
   end: gen_vfpu_simd_mask
-
-  logic vfpu_in_valid;
-  logic vfpu_out_valid;
-  logic vfpu_in_ready;
-  logic vfpu_out_ready;
 
   fpnew_top #(
     .Features      (FPUFeatures      ),
@@ -514,11 +518,18 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
   );
 
   // Stabilize signals regardless of FPU latency (signals to CVA6)
-  logic       fflags_ex_valid_d, fflags_ex_valid_q;
-  logic [4:0] fflags_ex_d, fflags_ex_q;
-
   assign fflags_ex_d       = vfpu_ex_flag;
   assign fflags_ex_valid_d = vfpu_out_valid & vfpu_out_ready;
+
+  end else begin : no_fpu_gen // The FPU is disabled
+    assign vfpu_in_ready     = 1'b0;
+    assign vfpu_result       = '0;
+    assign vfpu_ex_flag      = '0;
+    assign vfpu_mask         = '0;
+    assign vfpu_out_valid    = 1'b0;
+    assign fflags_ex_d       = '0;
+    assign fflags_ex_valid_d = 1'b0;
+  end
 
   assign fflags_ex_o       = fflags_ex_q;
   assign fflags_ex_valid_o = fflags_ex_valid_q;
@@ -771,9 +782,11 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
         commit_cnt_d = vfu_operation_i.vl;
 
       // Floating-Point re-encoding for widening operations
+      // Enabled only for the supported formats
+      if (RVV_FP) begin
       if (vfu_operation_i.wide_fp_imm) begin
-        unique case (vfu_operation_i.vtype.vsew)
-          EW32: begin
+        unique casez ({vfu_operation_i.vtype.vsew, RVVH, RVVF, RVVD})
+          {EW32, 1'b1, 1'b1, 1'b?}: begin
             for (int e = 0; e < 2; e++) begin
               automatic fp16_t fp16 = vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[15:0];
               automatic fp32_t fp32;
@@ -783,7 +796,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
               vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[32*e +: 32] = fp32;
             end
           end
-          EW64: begin
+          {EW64, 1'b?, 1'b1, 1'b1}: begin
             automatic fp32_t fp32 = vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[31:0];
             automatic fp64_t fp64;
             fp64.s = fp32.s;
@@ -793,6 +806,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
           end
           default:;
         endcase
+      end
       end
 
       // Bump pointers and counters of the vector instruction queue


### PR DESCRIPTION
Add four new parameters to tune the support for floating-point operations in general, or just for specific formats. 

* `RVV_FP`: enables/disables the decoding of `OPFVV` and `OPFVF` instructions, the FPU, the FP re-encodings in `vmfpu` and `operand_queue`.
* `RVVH`: enable/disable support for 16b floating-point operations. This can be enabled only if CVA6 supports these operations as well (`ariane_pkg::XF16` == `1'b1`).
* `RVVF`: enable/disable support for 32b floating-point operations.
* `RVVD`: enable/disable support for 64b floating-point operations.

## Changelog

### Added

- Parametrization for FPU and FPU-specific formats support

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed
