### PR TITLE
Removing dependency for a specific gcc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-
+- Removed dependency to a specific gcc g++ version in Makefile
 - Arithmetic and memory vector instructions with `vl == 0` are considered as a `NOP`
 - Increment bit width of the vector length type (`vlen_t`), accounting for vectors whose length is `VLMAX`
 - Fix vector length calculation for the `MaskB` operand, which depends on `vsew`

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ VERIL_VERSION       ?= v4.106
 # CC and CXX are Makefile default variables that are always defined in a Makefile. Hence, overwrite
 # the variable if it is only defined by the Makefile (its origin in the Makefile's default).
 ifeq ($(origin CC),default)
-CC     = gcc-7.2.0
+CC     = gcc
 endif
 ifeq ($(origin CXX),default)
-CXX    = g++-7.2.0
+CXX    = g++
 endif
 
 # Default target


### PR DESCRIPTION
Description of PR that completes issue here...

## Changelog

### Fixed

- Removed dependency in Makefile to use a specific gcc version

### Added

- Used only `gcc` and `g++` commands so that the correct version is picked up by the build system

### Changed

- Used only `gcc` and `g++` commands so that the correct version is picked up by the build system

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
