### PR TITLE
Add FPU Support as an ara_soc parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Parametrization for FPU and FPU-specific formats support
+- Parametrization for FPU and FPU-specific formats support, through the `FPUSupport` ara_soc parameter
 
 ## 1.1.0 - 2020-03-18
 

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -31,21 +31,29 @@ package ara_pkg;
   localparam int unsigned MaxNrLanes = 16;
 
   // Ara Features.
-  localparam bit RVV_FP = 1'b1; // Support for floating-point vector instructions
-  // Ara cannot support 16-bit float if the scalar core (CVA6) does not support them
-  localparam bit RVVH = 1'b1 & ariane_pkg::XF16; // Is H extension enabled for vectors?
-  localparam bit RVVF = 1'b1 & ariane_pkg::RVF;  // Is F extension enabled for vectors?
-  localparam bit RVVD = 1'b1 & ariane_pkg::RVD;  // Is D extension enabled for vectors?
-  // FPU support enum type
-  typedef enum bit [2:0] {
-    FPU_16       = 3'b100,
-    FPU_16_32    = 3'b110,
-    FPU_32       = 3'b010,
-    FPU_32_64    = 3'b011,
-    FPU_64       = 3'b001,
-    FPU_16_32_64 = 3'b111
+
+  // The three bits correspond to {RVVD, RVVF, RVVH}
+  typedef enum logic [2:0] {
+    FPUSupportNone             = 3'b000,
+    FPUSupportHalf             = 3'b001,
+    FPUSupportSingle           = 3'b010,
+    FPUSupportHalfSingle       = 3'b011,
+    FPUSupportDouble           = 3'b100,
+    FPUSupportSingleDouble     = 3'b110,
+    FPUSupportHalfSingleDouble = 3'b111
   } fpu_support_e;
-  fpu_support_e FPUSupport = fpu_support_e'({RVVH, RVVF, RVVD});
+
+  function automatic logic RVVD(fpu_support_e e);
+    return e[2];
+  endfunction: RVVD
+
+  function automatic logic RVVF(fpu_support_e e);
+    return e[1];
+  endfunction: RVVF
+
+  function automatic logic RVVH(fpu_support_e e);
+    return e[0];
+  endfunction: RVVH
 
   // Multiplier latencies.
   localparam int unsigned LatMultiplierEW64 = 1;
@@ -536,7 +544,7 @@ package ara_pkg;
     logic swap_vs2_vd_op; // If asserted: vs2 is kept in MulFPU opqueue C, and vd_op in MulFPU A
 
     fpnew_pkg::roundmode_e fp_rm; // Rounding-Mode for FP operations
-    logic wide_fp_imm; // Widen FP immediate (re-encoding)
+    logic wide_fp_imm;            // Widen FP immediate (re-encoding)
 
     // Vector machine metadata
     vlen_t vl;

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -8,20 +8,21 @@
 
 module ara import ara_pkg::*; #(
     // RVV Parameters
-    parameter int  unsigned NrLanes      = 0,          // Number of parallel vector lanes.
+    parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
+    parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble, // Support for floating-point data types
     // AXI Interface
-    parameter int  unsigned AxiDataWidth = 0,
-    parameter int  unsigned AxiAddrWidth = 0,
-    parameter type          axi_ar_t     = logic,
-    parameter type          axi_r_t      = logic,
-    parameter type          axi_aw_t     = logic,
-    parameter type          axi_w_t      = logic,
-    parameter type          axi_b_t      = logic,
-    parameter type          axi_req_t    = logic,
-    parameter type          axi_resp_t   = logic,
+    parameter  int           unsigned AxiDataWidth = 0,
+    parameter  int           unsigned AxiAddrWidth = 0,
+    parameter  type                   axi_ar_t     = logic,
+    parameter  type                   axi_r_t      = logic,
+    parameter  type                   axi_aw_t     = logic,
+    parameter  type                   axi_w_t      = logic,
+    parameter  type                   axi_b_t      = logic,
+    parameter  type                   axi_req_t    = logic,
+    parameter  type                   axi_resp_t   = logic,
     // Dependant parameters. DO NOT CHANGE!
     // Ara has NrLanes + 3 processing elements: each one of the lanes, the vector load unit, the vector store unit, the slide unit, and the mask unit.
-    localparam int  unsigned NrPEs       = NrLanes + 4
+    localparam int           unsigned NrPEs        = NrLanes + 4
   ) (
     // Clock and Reset
     input  logic              clk_i,
@@ -184,7 +185,8 @@ module ara import ara_pkg::*; #(
 
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
-      .NrLanes(NrLanes)
+      .NrLanes   (NrLanes   ),
+      .FPUSupport(FPUSupport)
     ) i_lane (
       .clk_i                  (clk_i                       ),
       .rst_ni                 (rst_ni                      ),

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -364,4 +364,13 @@ module ara import ara_pkg::*; #(
   if (ara_pkg::VLEN != 2**$clog2(ara_pkg::VLEN))
     $error("[ara] The vector length must be a power of two.");
 
+  if (RVVD(FPUSupport) && !ariane_pkg::RVD)
+    $error("[ara] Cannot support double-precision floating-point on Ara if Ariane does not support it.");
+
+  if (RVVF(FPUSupport) && !ariane_pkg::RVF)
+    $error("[ara] Cannot support single-precision floating-point on Ara if Ariane does not support it.");
+
+  if (RVVH(FPUSupport) && !ariane_pkg::XF16)
+    $error("[ara] Cannot support half-precision floating-point on Ara if Ariane does not support it.");
+
 endmodule : ara

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -9,7 +9,8 @@
 // response or an error message.
 
 module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int unsigned NrLanes = 0
+    parameter int unsigned NrLanes     = 0,
+    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble // Support for floating-point data types
   ) (
     // Clock and reset
     input  logic                                 clk_i,
@@ -1555,7 +1556,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             end
 
             OPFVV: begin: opfvv
-              if (RVV_FP) begin
+              if (FPUSupport != FPUSupportNone) begin
                 // These generate a request to Ara's backend
                 ara_req_d.vs1     = insn.varith_type.rs1;
                 ara_req_d.use_vs1 = 1'b1;
@@ -1782,37 +1783,37 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 // Ara can support 16-bit float, 32-bit float, 64-bit float.
                 // Ara cannot support instructions who operates on more than 64 bits.
                 unique case (FPUSupport)
-                  FPU_16_32_64: begin
+                  FPUSupportHalfSingleDouble: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_16_32: begin
+                  FPUSupportHalfSingle: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_32_64: begin
+                  FPUSupportSingleDouble: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_16: begin
+                  FPUSupportHalf: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_32: begin
+                  FPUSupportSingle: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_64: begin
+                  FPUSupportDouble: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
@@ -1837,7 +1838,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             end
 
             OPFVF: begin: opfvf
-              if (RVV_FP) begin
+              if (FPUSupport != FPUSupportNone) begin
                 // These generate a request to Ara's backend
                 ara_req_d.scalar_op     = acc_req_i.rs1;
                 ara_req_d.use_scalar_op = 1'b1;
@@ -2053,37 +2054,37 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 // Ara can support 16-bit float, 32-bit float, 64-bit float.
                 // Ara cannot support instructions who operates on more than 64 bits.
                 unique case (FPUSupport)
-                  FPU_16_32_64: begin
+                  FPUSupportHalfSingleDouble: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_16_32: begin
+                  FPUSupportHalfSingle: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW16) || int'(ara_req_d.vtype.vsew) > int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_32_64: begin
+                  FPUSupportSingleDouble: begin
                     if (int'(ara_req_d.vtype.vsew) < int'(EW32) || int'(ara_req_d.vtype.vsew) > int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_16: begin
+                  FPUSupportHalf: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW16)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_32: begin
+                  FPUSupportSingle: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW32)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;
                     end
                   end
-                  FPU_64: begin
+                  FPUSupportDouble: begin
                     if (int'(ara_req_d.vtype.vsew) != int'(EW64)) begin
                       acc_resp_o.error = 1'b1;
                       ara_req_valid_d  = 1'b0;

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -6,20 +6,21 @@
 // Description:
 // Ara's SoC, containing Ariane, Ara, and a L2 cache.
 
-module ara_soc import axi_pkg::*; #(
+module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     // RVV Parameters
-    parameter int  unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
+    parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
+    parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble, // Support for floating-point data types
     // AXI Interface
-    parameter int  unsigned AxiDataWidth = 32*NrLanes,
-    parameter int  unsigned AxiAddrWidth = 64,
-    parameter int  unsigned AxiUserWidth = 1,
-    parameter int  unsigned AxiIdWidth   = 6,
+    parameter  int           unsigned AxiDataWidth = 32*NrLanes,
+    parameter  int           unsigned AxiAddrWidth = 64,
+    parameter  int           unsigned AxiUserWidth = 1,
+    parameter  int           unsigned AxiIdWidth   = 6,
     // Dependant parameters. DO NOT CHANGE!
-    localparam type          axi_data_t   = logic [AxiDataWidth-1:0],
-    localparam type          axi_strb_t   = logic [AxiDataWidth/8-1:0],
-    localparam type          axi_addr_t   = logic [AxiAddrWidth-1:0],
-    localparam type          axi_user_t   = logic [AxiUserWidth-1:0],
-    localparam type          axi_id_t     = logic [AxiIdWidth-1:0]
+    localparam type                   axi_data_t   = logic [AxiDataWidth-1:0],
+    localparam type                   axi_strb_t   = logic [AxiDataWidth/8-1:0],
+    localparam type                   axi_addr_t   = logic [AxiAddrWidth-1:0],
+    localparam type                   axi_user_t   = logic [AxiUserWidth-1:0],
+    localparam type                   axi_id_t     = logic [AxiIdWidth-1:0]
   ) (
     input  logic             clk_i,
     input  logic             rst_ni,
@@ -654,6 +655,7 @@ module ara_soc import axi_pkg::*; #(
 
   ara #(
     .NrLanes     (NrLanes               ),
+    .FPUSupport  (FPUSupport            ),
     .AxiDataWidth(AxiWideDataWidth      ),
     .AxiAddrWidth(AxiAddrWidth          ),
     .axi_ar_t    (axi_core_ar_chan_t    ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -8,16 +8,17 @@
 // together with the execution units.
 
 module lane import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int  unsigned NrLanes          = 1,                                   // Number of lanes
+    parameter  int           unsigned NrLanes         = 1,                                   // Number of lanes
+    parameter  fpu_support_e          FPUSupport      = FPUSupportHalfSingleDouble,          // Support for floating-point data types
     // Dependant parameters. DO NOT CHANGE!
     // VRF Parameters
-    localparam int  unsigned MaxVLenPerLane  = VLEN / NrLanes,                      // In bits
-    localparam int  unsigned MaxVLenBPerLane = VLENB / NrLanes,                     // In bytes
-    localparam int  unsigned VRFSizePerLane  = MaxVLenPerLane * 32,                 // In bits
-    localparam int  unsigned VRFBSizePerLane = MaxVLenBPerLane * 32,                // In bytes
-    localparam type          vaddr_t         = logic [$clog2(VRFBSizePerLane)-1:0], // Address of an element in the lane's VRF
-    localparam int  unsigned DataWidth       = $bits(elen_t),                       // Width of the lane datapath
-    localparam type          strb_t          = logic [DataWidth/8-1:0]              // Byte-strobe type
+    localparam int           unsigned MaxVLenPerLane  = VLEN / NrLanes,                      // In bits
+    localparam int           unsigned MaxVLenBPerLane = VLENB / NrLanes,                     // In bytes
+    localparam int           unsigned VRFSizePerLane  = MaxVLenPerLane * 32,                 // In bits
+    localparam int           unsigned VRFBSizePerLane = MaxVLenBPerLane * 32,                // In bytes
+    localparam type                   vaddr_t         = logic [$clog2(VRFBSizePerLane)-1:0], // Address of an element in the lane's VRF
+    localparam int           unsigned DataWidth       = $bits(elen_t),                       // Width of the lane datapath
+    localparam type                   strb_t          = logic [DataWidth/8-1:0]              // Byte-strobe type
   ) (
     input  logic                                           clk_i,
     input  logic                                           rst_ni,
@@ -250,7 +251,9 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic  [2:0] mfpu_operand_valid;
   logic  [2:0] mfpu_operand_ready;
 
-  operand_queues_stage i_operand_queues (
+  operand_queues_stage #(
+    .FPUSupport(FPUSupport)
+  ) i_operand_queues (
     .clk_i                    (clk_i                                             ),
     .rst_ni                   (rst_ni                                            ),
     // Interface with the Vector Register File
@@ -289,8 +292,9 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
    *****************************/
 
   vector_fus_stage #(
-    .NrLanes(NrLanes),
-    .vaddr_t(vaddr_t)
+    .NrLanes   (NrLanes   ),
+    .FPUSupport(FPUSupport),
+    .vaddr_t   (vaddr_t   )
   ) i_vfus (
     .clk_i                (clk_i                  ),
     .rst_ni               (rst_ni                 ),

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -9,15 +9,16 @@
 // need it.
 
 module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int   unsigned BufferDepth    = 2,
-    parameter int   unsigned NrSlaves       = 1,
+    parameter  int           unsigned BufferDepth    = 2,
+    parameter  int           unsigned NrSlaves       = 1,
+    parameter  fpu_support_e          FPUSupport     = FPUSupportHalfSingleDouble, // Support for floating-point data types
     // Supported conversions
-    parameter logic          SupportIntExt2 = 1'b0,
-    parameter logic          SupportIntExt4 = 1'b0,
-    parameter logic          SupportIntExt8 = 1'b0,
+    parameter  logic                  SupportIntExt2 = 1'b0,
+    parameter  logic                  SupportIntExt4 = 1'b0,
+    parameter  logic                  SupportIntExt8 = 1'b0,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int   unsigned DataWidth     = $bits(elen_t),
-    localparam int   unsigned StrbWidth     = DataWidth/8
+    localparam int           unsigned DataWidth      = $bits(elen_t),
+    localparam int           unsigned StrbWidth      = DataWidth/8
   ) (
     input  logic                              clk_i,
     input  logic                              rst_ni,
@@ -184,8 +185,8 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; #(
 
       // Floating-Point re-encoding
       OpQueueConversionWideFP2: begin
-        if (RVV_FP) begin
-          unique casez ({cmd.eew, RVVH, RVVF, RVVD})
+        if (FPUSupport != FPUSupportNone) begin
+          unique casez ({cmd.eew, RVVH(FPUSupport), RVVF(FPUSupport), RVVD(FPUSupport)})
             {EW16, 1'b1, 1'b1, 1'b?}: begin
               for (int e = 0; e < 2; e++) begin
                automatic fp16_t fp16 = ibuf_operand[8*select + 32*e +: 16];

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -6,7 +6,9 @@
 // Description:
 // This stage holds the operand queues, holding elements for the VRFs.
 
-module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
+module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
+    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble // Support for floating-point data types
+  ) (
     input  logic                                     clk_i,
     input  logic                                     rst_ni,
     // Interface with the Vector Register File
@@ -45,10 +47,11 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
    *********/
 
   operand_queue #(
-    .BufferDepth   (5   ),
-    .SupportIntExt2(1'b1),
-    .SupportIntExt4(1'b1),
-    .SupportIntExt8(1'b1)
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      ),
+    .SupportIntExt4(1'b1      ),
+    .SupportIntExt8(1'b1      )
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -64,10 +67,11 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
   );
 
   operand_queue #(
-    .BufferDepth   (5   ),
-    .SupportIntExt2(1'b1),
-    .SupportIntExt4(1'b1),
-    .SupportIntExt8(1'b1)
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      ),
+    .SupportIntExt4(1'b1      ),
+    .SupportIntExt8(1'b1      )
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -87,8 +91,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
    ********************/
 
   operand_queue #(
-    .BufferDepth   (5    ),
-    .SupportIntExt2(1'b1 )
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_a (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -104,8 +109,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
   );
 
   operand_queue #(
-    .BufferDepth   (5    ),
-    .SupportIntExt2(1'b1 )
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_b (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -121,8 +127,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
   );
 
   operand_queue #(
-    .BufferDepth   (5    ),
-    .SupportIntExt2(1'b1 )
+    .BufferDepth   (5         ),
+    .FPUSupport    (FPUSupport),
+    .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_c (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -142,7 +149,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
    *********************/
 
   operand_queue #(
-    .BufferDepth(2)
+    .BufferDepth(2         ),
+    .FPUSupport (FPUSupport)
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
@@ -158,7 +166,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
   );
 
   operand_queue #(
-    .BufferDepth(2)
+    .BufferDepth(2         ),
+    .FPUSupport (FPUSupport)
   ) i_operand_queue_addrgen_a (
     .clk_i                    (clk_i                               ),
     .rst_ni                   (rst_ni                              ),
@@ -178,7 +187,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; (
    ***************/
 
   operand_queue #(
-    .BufferDepth(1)
+    .BufferDepth(1         ),
+    .FPUSupport (FPUSupport)
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -8,12 +8,13 @@
 // of each lane, namely the ALU and the Multiplier/FPU.
 
 module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int  unsigned NrLanes    = 0,
+    parameter  int           unsigned NrLanes    = 0,
+    parameter  fpu_support_e          FPUSupport = FPUSupportHalfSingleDouble, // Support for floating-point data types
     // Type used to address vector register file elements
-    parameter type          vaddr_t    = logic,
+    parameter  type                   vaddr_t    = logic,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int  unsigned DataWidth = $bits(elen_t),
-    localparam type          strb_t    = logic [DataWidth/8-1:0]
+    localparam int           unsigned DataWidth  = $bits(elen_t),
+    localparam type                   strb_t     = logic [DataWidth/8-1:0]
   ) (
     input  logic                         clk_i,
     input  logic                         rst_ni,
@@ -105,8 +106,9 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
    *****************/
 
   vmfpu #(
-    .NrLanes(NrLanes),
-    .vaddr_t(vaddr_t)
+    .NrLanes   (NrLanes   ),
+    .FPUSupport(FPUSupport),
+    .vaddr_t   (vaddr_t   )
   ) i_vmfpu (
     .clk_i                (clk_i                ),
     .rst_ni               (rst_ni               ),


### PR DESCRIPTION
With this PR, I move the RVVD, RVVF, and RVVH parameters from `ara_pkg` to a parameter of `ara_soc`, which is propagated all the way down to the FPU.

## Changelog

### Added

- FPUSupport parameter to ara_soc, determining which floating-point representations are supported by Ara.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
