### PR TITLE
Hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Arithmetic and memory vector instructions with `vl == 0` are considered as a `NOP`
+- Increment bit width of the vector length type (`vlen_t`), accounting for vectors whose length is `VLMAX`
+- Fix vector length calculation for the `MaskB` operand, which depends on `vsew`
+- Fix typo on the `vrf_pnt` updating logic at the Mask Unit
+
 ## 1.1.1 - 2020-03-25
 
 ### Added

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -75,7 +75,7 @@ package ara_pkg;
    *  Definitions  *
    *****************/
 
-  typedef logic [$clog2(MAXVL)-1:0] vlen_t;
+  typedef logic [$clog2(MAXVL+1)-1:0] vlen_t;
   typedef logic [$clog2(NrVInsn)-1:0] vid_t;
 
   typedef logic [ELEN-1:0] elen_t;

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -395,12 +395,12 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
               vtype  : pe_req_i.vtype,
               // Since this request goes outside of the lane, we might need to request an
               // extra operand regardless of whether it is valid in this lane or not.
-              vl     : (pe_req_i.vl / NrLanes / ELEN),
+              vl     : (pe_req_i.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req_i.vtype.vsew)),
               vstart : vfu_operation_d.vstart,
               hazard : pe_req_i.hazard_vd,
               default: '0
             };
-            if ((operand_request_i[MaskB].vl * NrLanes * ELEN) != pe_req_i.vl)
+            if ((pe_req_i.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req_i.vtype.vsew)) != pe_req_i.vl)
               operand_request_i[MaskB].vl += 1;
             operand_request_push[MaskB] = pe_req_i.use_vd_op;
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -497,7 +497,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
           // Increment the VRF pointer
           if (vinsn_issue.op inside {VMSEQ, VMSNE, VMSLT, VMSLTU, VMSLE, VMSLEU, VMSGT, VMSGTU, VMADC, VMSBC}) begin
-            vrf_pnt_d = vrf_pnt_q + NrLanes << (int'(EW64) - vinsn_issue.vtype.vsew);
+            vrf_pnt_d = vrf_pnt_q + (NrLanes << (int'(EW64) - vinsn_issue.vtype.vsew));
 
             // Filled-up a word, or finished execution
             if (vrf_pnt_d == DataWidth*NrLanes || vrf_pnt_d >= issue_cnt_q) begin

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -490,7 +490,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             result_queue_d[result_queue_write_pnt_q][lane] = '{
               wdata: result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result[lane],
               be   : be(element_cnt, vinsn_issue.vtype.vsew),
-              addr : vaddr(vinsn_issue.vd, NrLanes) + (((vinsn_issue.vl - issue_cnt_q) / NrLanes / 8) >> (int'(EW64) - int'(vinsn_issue.vtype.vsew))),
+              addr : vaddr(vinsn_issue.vd, NrLanes) + (((vinsn_issue.vl - issue_cnt_q) / NrLanes / DataWidth)),
               id   : vinsn_issue.id
             };
           end


### PR DESCRIPTION
Four hotfixes for bugs triggered by the dropout benchmark.

## Changelog

### Fixed

- `vlen_t` type bit width should allow for counting up to `MAXVL`. So we need one bit more when `MAXVL` is a power of 2.
- `MaskB queue` gives elements to the mask unit from the destination register, and it needs to take into account the `vsew` of the current operation.
- `vrf_pnt` update in the mask unit was wrong.
- Fix addressing bug in the Mask Unit, as the addressing does not depend on `vsew`.
- When `vl == 0`, valid vector instructions that do not imply CSR operations are considered as NOP.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
