### PR TITLE
Hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix `vrf_seq_byte` definition in the Load Unit
+- Fix check to discriminate a valid byte in the VRF word, in the Load Unit
+- Fix `axi_addrgen_d.len` calculation in the Address Generation Unit
+- Correctly check whether the generated address corresponds to the vector load or the store unit
+
 ## 1.2.0 - 2020-04-12
 
 ### Added

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -2564,6 +2564,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
     // Any valid non-config instruction is a NOP if vl == 0
     if (acc_req_valid_i && vl_q == '0 && !is_config && !acc_resp_o.error) begin
+      acc_req_ready_o  = 1'b1;
       acc_resp_valid_o = 1'b1;
       ara_req_valid_d  = 1'b0;
     end

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -302,8 +302,8 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
             axi_addrgen_queue_push = 1'b1;
 
             // Account for the requested operands
-            axi_addrgen_d.len = axi_addrgen_q.len - ((aligned_end_addr_q[11:0] - axi_addrgen_q.addr[11:0] + ((1 << int'(axi_addrgen_q.vew)) - 1)) >> int'(axi_addrgen_q.vew)) - 1;
-            if (axi_addrgen_q.len < ((aligned_end_addr_q[11:0] - axi_addrgen_q.addr[11:0] + ((1 << int'(axi_addrgen_q.vew)) - 1)) >> int'(axi_addrgen_q.vew)) + 1)
+            axi_addrgen_d.len = axi_addrgen_q.len - ((aligned_end_addr_q[11:0] - axi_addrgen_q.addr[11:0] + 1) >> int'(axi_addrgen_q.vew));
+            if (axi_addrgen_q.len < ((aligned_end_addr_q[11:0] - axi_addrgen_q.addr[11:0] + 1) >> int'(axi_addrgen_q.vew)))
               axi_addrgen_d.len = 0;
             axi_addrgen_d.addr = aligned_end_addr_q + 1;
 

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -223,7 +223,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     // - There is an R beat available.
     // - The Address Generator sent us the data about the corresponding AR beat
     // - There is place in the result queue to write the data read from the R channel
-    if (axi_r_valid_i && axi_addrgen_req_valid_i && !result_queue_full) begin
+    if (axi_r_valid_i && axi_addrgen_req_valid_i && axi_addrgen_req_i.is_load && !result_queue_full) begin
       // Bytes valid in the current R beat
       automatic shortint unsigned lower_byte = beat_lower_byte(axi_addrgen_req_i.addr, axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, len_q);
       automatic shortint unsigned upper_byte = beat_upper_byte(axi_addrgen_req_i.addr, axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, len_q);

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -241,7 +241,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
             automatic int vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew);
 
             // Is this byte a valid byte in the VRF word?
-            if (vrf_seq_byte < issue_cnt_q) begin
+            if (vrf_seq_byte < issue_cnt_q && vrf_seq_byte < NrLanes * 8) begin
               // At which lane, and what is the byte offset in that lane, of the byte vrf_byte?
               automatic int vrf_lane   = vrf_byte >> 3;
               automatic int vrf_offset = vrf_byte[2:0];

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -236,7 +236,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
           // Is this byte a valid byte in the R beat?
           if (axi_byte >= lower_byte + r_pnt_q && axi_byte <= upper_byte) begin
             // Map axy_byte to the corresponding byte in the VRF word (sequential)
-            automatic int vrf_seq_byte = axi_byte - lower_byte + r_pnt_q + vrf_pnt_q;
+            automatic int vrf_seq_byte = axi_byte - lower_byte - r_pnt_q + vrf_pnt_q;
             // And then shuffle it
             automatic int vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew);
 

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -178,7 +178,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
     // - We received all the operands from the lanes
     // - The address generator generated an AXI AW request for this write beat
     // - The AXI subsystem is ready to accept this W beat
-    if (vinsn_issue_valid && &stu_operand_valid_i && (vinsn_issue_q.vm || (|mask_valid_i)) && axi_addrgen_req_valid_i && axi_w_ready_i) begin
+    if (vinsn_issue_valid && &stu_operand_valid_i && (vinsn_issue_q.vm || (|mask_valid_i)) && axi_addrgen_req_valid_i && !axi_addrgen_req_i.is_load && axi_w_ready_i) begin
       // Bytes valid in the current W beat
       automatic shortint unsigned lower_byte = beat_lower_byte(axi_addrgen_req_i.addr, axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, len_q);
       automatic shortint unsigned upper_byte = beat_upper_byte(axi_addrgen_req_i.addr, axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, len_q);


### PR DESCRIPTION
## Changelog

### Fixed

- Fix `vrf_seq_byte` definition in the Load Unit
- Fix check to discriminate a valid byte in the VRF word, in the Load Unit
- Fix `axi_addrgen_d.len` calculation in the Address Generation Unit

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
