### PR TITLE
Verilation with LLVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,13 +138,18 @@ jobs:
         cache-name: cache-verilator
       with:
         path: install/verilator
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.tc-verilator-hash }}
+        key: ${{ runner.os }}-build-llvm10-${{ env.cache-name }}-${{ env.tc-verilator-hash }}
         restore-keys:
-          ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.tc-verilator-hash }}
+          ${{ runner.os }}-build-llvm10-${{ env.cache-name }}-${{ env.tc-verilator-hash }}
     - name: Download Verilator
       if: steps.tc-verilator-cache.outputs.cache-hit != 'true'
       run: |
         git submodule update --init --recursive -- toolchain/verilator
+    - name: Install LLVM and Clang
+      if: steps.tc-verilator-cache.outputs.cache-hit != 'true'
+      uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "10.0"
     - name: Compile Verilator
       if: steps.tc-verilator-cache.outputs.cache-hit != 'true'
       run: |
@@ -249,6 +254,10 @@ jobs:
         ln -s $VERILATOR_ROOT/share/verilator/bin/verilator_includer $VERILATOR_ROOT/bin/verilator_includer
     - name: Download RTL submodules
       run: git submodule update --init --recursive hardware
+    - name: Install LLVM and Clang
+      uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "10.0"
     - name: Compile Verilated model of Ara
       run: |
         sudo apt-get install libelf-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Format source files in the `apps` folder with clang-format by running `make format`
 
+### Changed
+
+- Compile Verilator and Ara's verilated model with LLVM, for a faster compile time.
+
 ## 2.0.0 - 2021-06-24
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ ${VERIL_INSTALL_DIR}: Makefile
 	cd $(CURDIR)/toolchain/verilator && git reset --hard && git fetch && git checkout ${VERIL_VERSION}
 	# Compile verilator
 	cd $(CURDIR)/toolchain/verilator && git clean -xfdf && autoconf && \
-	./configure --prefix=$(VERIL_INSTALL_DIR) && make -j4 && make install
+	CC=clang CXX=clang++ ./configure --prefix=$(VERIL_INSTALL_DIR) && make -j4 && make install
 
 # RISC-V Tests
 riscv_tests:

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -142,6 +142,7 @@ $(veril_library)/V$(veril_top): Makefile ../Bender.yml $(shell find src -type f)
   -Wno-WIDTHCONCAT                                                              \
   --Mdir $(veril_library) --trace                                               \
   -Itb/dpi                                                                      \
+  --compiler clang                                                              \
   -CFLAGS "-std=c++11 -Wall -DTOPLEVEL_NAME=$(veril_top)"                       \
   -CFLAGS "-DNR_LANES=$(nr_lanes)"                                              \
   -CFLAGS -I$(ROOT_DIR)/tb/verilator/lowrisc_dv_verilator_memutil_dpi/cpp       \


### PR DESCRIPTION
I found out that it is much faster to compile the Verilated model of Ara with `clang` than with `gcc`. The runtime of the latest CI run brought the compilation time from 1h40min to about 10min, a fraction of the time. 

This PR compiles Verilator with `clang`, so that it uses LLVM when compiling the model. It also updates the CI to install LLVM before running the compilation.

## Changelog

### Changed

- Compile Verilator and Ara's verilated model with LLVM, for a faster compile time.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
