### PR TITLE
[README] Fix for typos in build instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Fix typo on the build instructions of the README
 
 ## 2.1.0 - 2021-07-16
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To build this toolchain, run the following command in the project's root directo
 
 ```bash
 # Build the LLVM toolchain
-make toolchain
+make toolchain-llvm
 ```
 
 Ara also requires an updated Spike ISA simulator, with support for the vector extension.
@@ -95,7 +95,7 @@ cd hardware
 # Apply the patches (only need to run this once)
 make apply-patches
 # Only compile the hardware without running the simulation.
-make build
+make compile
 # Run the simulation with the *hello_world* binary loaded
 app=hello_world make sim
 # Run the simulation with the *some_binary* binary. This allows specifying the full path to the binary


### PR DESCRIPTION
Description of PR that completes issue here...

## Changelog

### Fixed

- The README instruction to build llvm toolchain will result in error. I fixed the README to use the correct target in the Makefile.
- The README instruction to compile hardware will result in error. The correct target to call is to use `make compile` and not `make build`


## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed


