### PR TITLE
Performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add spill register at the lane edge, to cut the timing-critical interface between the Mask unit and the VFUs
 - Increase latency of the 16-bit multiplier from 0 to 1 to cut an in-lane timing-critical path
 
+### Changed
+
+- Widen CVA6's cache lines
+- Implement back-to-back accelerator instruction issue mechanism on CVA6
+
 ## 2.1.0 - 2021-07-16
 
 ### Fixed

--- a/apps/fmatmul/kernel/fmatmul.c
+++ b/apps/fmatmul/kernel/fmatmul.c
@@ -21,8 +21,9 @@
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-void fmatmul(double *c, const double *a, const double *b, int64_t M, int64_t N,
-             int64_t P) {
+void fmatmul(double *c, const double *a, const double *b,
+             const unsigned long int M, const unsigned long int N,
+             const unsigned long int P) {
   if (M <= 4) {
     fmatmul_4x4(c, a, b, M, N, P);
   } else if (M <= 8) {
@@ -36,19 +37,20 @@ void fmatmul(double *c, const double *a, const double *b, int64_t M, int64_t N,
 // 4x4
 // ---------------
 
-void fmatmul_4x4(double *c, const double *a, const double *b, int64_t M,
-                 int64_t N, int64_t P) {
+void fmatmul_4x4(double *c, const double *a, const double *b,
+                 const unsigned long int M, const unsigned long int N,
+                 const unsigned long int P) {
   // We work on 4 rows of the matrix at once
-  int64_t block_size = 4;
-  int64_t block_size_p;
+  const unsigned long int block_size = 4;
+  unsigned long int block_size_p;
 
   // Set the vector configuration
   asm volatile("vsetvli %0, %1, e64, m4, ta, ma" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
-  for (int64_t p = 0; p < P; p += block_size_p) {
+  for (unsigned long int p = 0; p < P; p += block_size_p) {
     // Set the vector length
-    int64_t p_ = MIN(P - p, block_size_p);
+    const unsigned long int p_ = MIN(P - p, block_size_p);
 
     // Find pointers to the submatrices
     const double *b_ = b + p;
@@ -57,7 +59,7 @@ void fmatmul_4x4(double *c, const double *a, const double *b, int64_t M,
     asm volatile("vsetvli zero, %0, e64, m4, ta, ma" ::"r"(p_));
 
     // Iterate over the rows
-    for (int64_t m = 0; m < M; m += block_size) {
+    for (unsigned long int m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
       const double *a_ = a + m * N;
       double *c__ = c_ + m * P;
@@ -75,8 +77,8 @@ void fmatmul_vec_4x4_slice_init() {
   asm volatile("vmv.v.i v12, 0");
 }
 
-void fmatmul_vec_4x4(double *c, const double *a, const double *b, int64_t N,
-                     int64_t P) {
+void fmatmul_vec_4x4(double *c, const double *a, const double *b,
+                     const unsigned long int N, const unsigned long int P) {
   // Temporary variables
   double t0, t1, t2, t3;
 
@@ -88,59 +90,50 @@ void fmatmul_vec_4x4(double *c, const double *a, const double *b, int64_t N,
   b += P;
 
   // Prefetch one row of scalar values
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
+  t0 = *a, a += N;
+  t1 = *a, a += N;
+  t2 = *a, a += N;
+  t3 = *a;
 
   // Compute the multiplication
-  int64_t n = 0;
+  unsigned long int n = 0;
 
-  while (n < N) {
+  while (n != N) {
     // Calculate pointer to the matrix A
-    a = (const double *)a_ + ++n;
+    a = a_ + ++n;
 
     asm volatile("vfmacc.vf v0, %0, v16" ::"f"(t0));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v20, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vfmacc.vf v4, %0, v16" ::"f"(t1));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vfmacc.vf v8, %0, v16" ::"f"(t2));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vfmacc.vf v12, %0, v16" ::"f"(t3));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
+    t3 = *a;
 
-    if (n == N - 1)
+    a = a_ + ++n;
+
+    if (n == N)
       break;
 
-    a = (const double *)a_ + ++n;
-
     asm volatile("vfmacc.vf v0, %0, v20" ::"f"(t0));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v16, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vfmacc.vf v4, %0, v20" ::"f"(t1));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vfmacc.vf v8, %0, v20" ::"f"(t2));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vfmacc.vf v12, %0, v20" ::"f"(t3));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
+    t3 = *a;
   }
 
   // Last iteration: store results
@@ -161,19 +154,20 @@ void fmatmul_vec_4x4(double *c, const double *a, const double *b, int64_t N,
 // 8x8
 // ---------------
 
-void fmatmul_8x8(double *c, const double *a, const double *b, int64_t M,
-                 int64_t N, int64_t P) {
+void fmatmul_8x8(double *c, const double *a, const double *b,
+                 const unsigned long int M, const unsigned long int N,
+                 const unsigned long int P) {
   // We work on 4 rows of the matrix at once
-  int64_t block_size = 8;
-  int64_t block_size_p;
+  const unsigned long int block_size = 8;
+  unsigned long int block_size_p;
 
   // Set the vector configuration
   asm volatile("vsetvli %0, %1, e64, m2, ta, ma" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
-  for (int64_t p = 0; p < P; p += block_size_p) {
+  for (unsigned long int p = 0; p < P; p += block_size_p) {
     // Set the vector length
-    int64_t p_ = MIN(P - p, block_size_p);
+    const unsigned long int p_ = MIN(P - p, block_size_p);
 
     // Find pointers to the submatrices
     const double *b_ = b + p;
@@ -182,7 +176,7 @@ void fmatmul_8x8(double *c, const double *a, const double *b, int64_t M,
     asm volatile("vsetvli zero, %0, e64, m2, ta, ma" ::"r"(p_));
 
     // Iterate over the rows
-    for (int64_t m = 0; m < M; m += block_size) {
+    for (unsigned long int m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
       const double *a_ = a + m * N;
       double *c__ = c_ + m * P;
@@ -204,8 +198,8 @@ void fmatmul_vec_8x8_slice_init() {
   asm volatile("vmv.v.i v14, 0");
 }
 
-void fmatmul_vec_8x8(double *c, const double *a, const double *b, int64_t N,
-                     int64_t P) {
+void fmatmul_vec_8x8(double *c, const double *a, const double *b,
+                     const unsigned long int N, const unsigned long int P) {
   // Temporary variables
   double t0, t1, t2, t3, t4, t5, t6, t7;
 
@@ -217,91 +211,70 @@ void fmatmul_vec_8x8(double *c, const double *a, const double *b, int64_t N,
   b += P;
 
   // Prefetch one row of scalar values
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t4) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t5) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t6) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t7) : [a] "r"(a));
+  t0 = *a, a += N;
+  t1 = *a, a += N;
+  t2 = *a, a += N;
+  t3 = *a, a += N;
+  t4 = *a, a += N;
+  t5 = *a, a += N;
+  t6 = *a, a += N;
+  t7 = *a;
 
   // Compute the multiplication
-  int64_t n = 0;
+  unsigned long int n = 0;
 
-  while (n < N) {
+  while (n != N) {
     // Calculate pointer to the matrix A
-    a = (const double *)a_ + ++n;
+    a = a_ + ++n;
 
     asm volatile("vfmacc.vf v0, %0, v18" ::"f"(t0));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v20, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vfmacc.vf v2, %0, v18" ::"f"(t1));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vfmacc.vf v4, %0, v18" ::"f"(t2));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vfmacc.vf v6, %0, v18" ::"f"(t3));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
-    a += N;
+    t3 = *a, a += N;
     asm volatile("vfmacc.vf v8, %0, v18" ::"f"(t4));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t4) : [a] "r"(a));
-    a += N;
+    t4 = *a, a += N;
     asm volatile("vfmacc.vf v10, %0, v18" ::"f"(t5));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t5) : [a] "r"(a));
-    a += N;
+    t5 = *a, a += N;
     asm volatile("vfmacc.vf v12, %0, v18" ::"f"(t6));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t6) : [a] "r"(a));
-    a += N;
+    t6 = *a, a += N;
     asm volatile("vfmacc.vf v14, %0, v18" ::"f"(t7));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t7) : [a] "r"(a));
+    t7 = *a;
 
-    if (n == N - 1)
+    a = a_ + ++n;
+
+    if (n == N)
       break;
 
-    a = (const double *)a_ + ++n;
-
     asm volatile("vfmacc.vf v0, %0, v20" ::"f"(t0));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v18, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vfmacc.vf v2, %0, v20" ::"f"(t1));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vfmacc.vf v4, %0, v20" ::"f"(t2));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vfmacc.vf v6, %0, v20" ::"f"(t3));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
-    a += N;
+    t3 = *a, a += N;
     asm volatile("vfmacc.vf v8, %0, v20" ::"f"(t4));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t4) : [a] "r"(a));
-    a += N;
+    t4 = *a, a += N;
     asm volatile("vfmacc.vf v10, %0, v20" ::"f"(t5));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t5) : [a] "r"(a));
-    a += N;
+    t5 = *a, a += N;
     asm volatile("vfmacc.vf v12, %0, v20" ::"f"(t6));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t6) : [a] "r"(a));
-    a += N;
+    t6 = *a, a += N;
     asm volatile("vfmacc.vf v14, %0, v20" ::"f"(t7));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t7) : [a] "r"(a));
+    t7 = *a;
   }
 
   // Last iteration: store results
@@ -334,19 +307,20 @@ void fmatmul_vec_8x8(double *c, const double *a, const double *b, int64_t N,
 // 16x16
 // ---------------
 
-void fmatmul_16x16(double *c, const double *a, const double *b, int64_t M,
-                   int64_t N, int64_t P) {
+void fmatmul_16x16(double *c, const double *a, const double *b,
+                   unsigned long int M, unsigned long int N,
+                   unsigned long int P) {
   // We work on 4 rows of the matrix at once
-  int64_t block_size = 16;
-  int64_t block_size_p;
+  const unsigned long int block_size = 16;
+  unsigned long int block_size_p;
 
   // Set the vector configuration
   asm volatile("vsetvli %0, %1, e64, m1, ta, ma" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
-  for (int64_t p = 0; p < P; p += block_size_p) {
+  for (unsigned long int p = 0; p < P; p += block_size_p) {
     // Set the vector length
-    int64_t p_ = MIN(P - p, block_size_p);
+    const unsigned long int p_ = MIN(P - p, block_size_p);
 
     // Find pointers to the submatrices
     const double *b_ = b + p;
@@ -355,7 +329,7 @@ void fmatmul_16x16(double *c, const double *a, const double *b, int64_t M,
     asm volatile("vsetvli zero, %0, e64, m1, ta, ma" ::"r"(p_));
 
     // Iterate over the rows
-    for (int64_t m = 0; m < M; m += block_size) {
+    for (unsigned long int m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
       const double *a_ = a + m * N;
       double *c__ = c_ + m * P;
@@ -385,168 +359,123 @@ void fmatmul_vec_16x16_slice_init() {
   asm volatile("vmv.v.i v15, 0");
 }
 
-void fmatmul_vec_16x16(double *c, const double *a, const double *b, int64_t N,
-                       int64_t P) {
+void fmatmul_vec_16x16(double *c, const double *a, const double *b,
+                       const unsigned long int N, const unsigned long int P) {
   // Temporary variables
   double t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15;
 
   // Original pointer
   const double *a_ = a;
 
+  // Prefetch one row of scalar values
+  t0 = *a, a += N;
+  t1 = *a, a += N;
+  t2 = *a, a += N;
+  t3 = *a, a += N;
+  t4 = *a, a += N;
+  t5 = *a, a += N;
+  t6 = *a, a += N;
+  t7 = *a, a += N;
+  t8 = *a, a += N;
+  t9 = *a, a += N;
+  t10 = *a, a += N;
+  t11 = *a, a += N;
+  t12 = *a, a += N;
+  t13 = *a, a += N;
+  t14 = *a, a += N;
+  t15 = *a;
+
   // Prefetch one row of matrix B
   asm volatile("vle64.v v16, (%0);" ::"r"(b));
   b += P;
 
-  // Prefetch one row of scalar values
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t4) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t5) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t6) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t7) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t8) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t9) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t10) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t11) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t12) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t13) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t14) : [a] "r"(a));
-  a += N;
-  asm volatile("fld %[t], (%[a])" : [t] "=f"(t15) : [a] "r"(a));
-
   // Compute the multiplication
-  int64_t n = 0;
+  unsigned long int n = 0;
 
-  while (n < N) {
+  while (n != N) {
     // Calculate pointer to the matrix A
-    a = (const double *)a_ + ++n;
+    a = a_ + ++n;
 
     asm volatile("vfmacc.vf v0, %0, v16" ::"f"(t0));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v17, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vfmacc.vf v1, %0, v16" ::"f"(t1));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vfmacc.vf v2, %0, v16" ::"f"(t2));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vfmacc.vf v3, %0, v16" ::"f"(t3));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
-    a += N;
+    t3 = *a, a += N;
     asm volatile("vfmacc.vf v4, %0, v16" ::"f"(t4));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t4) : [a] "r"(a));
-    a += N;
+    t4 = *a, a += N;
     asm volatile("vfmacc.vf v5, %0, v16" ::"f"(t5));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t5) : [a] "r"(a));
-    a += N;
+    t5 = *a, a += N;
     asm volatile("vfmacc.vf v6, %0, v16" ::"f"(t6));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t6) : [a] "r"(a));
-    a += N;
+    t6 = *a, a += N;
     asm volatile("vfmacc.vf v7, %0, v16" ::"f"(t7));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t7) : [a] "r"(a));
-    a += N;
+    t7 = *a, a += N;
     asm volatile("vfmacc.vf v8, %0, v16" ::"f"(t8));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t8) : [a] "r"(a));
-    a += N;
+    t8 = *a, a += N;
     asm volatile("vfmacc.vf v9, %0, v16" ::"f"(t9));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t9) : [a] "r"(a));
-    a += N;
+    t9 = *a, a += N;
     asm volatile("vfmacc.vf v10, %0, v16" ::"f"(t10));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t10) : [a] "r"(a));
-    a += N;
+    t10 = *a, a += N;
     asm volatile("vfmacc.vf v11, %0, v16" ::"f"(t11));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t11) : [a] "r"(a));
-    a += N;
+    t11 = *a, a += N;
     asm volatile("vfmacc.vf v12, %0, v16" ::"f"(t12));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t12) : [a] "r"(a));
-    a += N;
+    t12 = *a, a += N;
     asm volatile("vfmacc.vf v13, %0, v16" ::"f"(t13));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t13) : [a] "r"(a));
-    a += N;
+    t13 = *a, a += N;
     asm volatile("vfmacc.vf v14, %0, v16" ::"f"(t14));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t14) : [a] "r"(a));
-    a += N;
+    t14 = *a, a += N;
     asm volatile("vfmacc.vf v15, %0, v16" ::"f"(t15));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t15) : [a] "r"(a));
+    t15 = *a;
 
-    if (n == N - 1)
+    a = a_ + ++n;
+
+    if (n == N)
       break;
 
-    a = (const double *)a_ + ++n;
-
     asm volatile("vfmacc.vf v0, %0, v17" ::"f"(t0));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v16, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vfmacc.vf v1, %0, v17" ::"f"(t1));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vfmacc.vf v2, %0, v17" ::"f"(t2));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vfmacc.vf v3, %0, v17" ::"f"(t3));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t3) : [a] "r"(a));
-    a += N;
+    t3 = *a, a += N;
     asm volatile("vfmacc.vf v4, %0, v17" ::"f"(t4));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t4) : [a] "r"(a));
-    a += N;
+    t4 = *a, a += N;
     asm volatile("vfmacc.vf v5, %0, v17" ::"f"(t5));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t5) : [a] "r"(a));
-    a += N;
+    t5 = *a, a += N;
     asm volatile("vfmacc.vf v6, %0, v17" ::"f"(t6));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t6) : [a] "r"(a));
-    a += N;
+    t6 = *a, a += N;
     asm volatile("vfmacc.vf v7, %0, v17" ::"f"(t7));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t7) : [a] "r"(a));
-    a += N;
+    t7 = *a, a += N;
     asm volatile("vfmacc.vf v8, %0, v17" ::"f"(t8));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t8) : [a] "r"(a));
-    a += N;
+    t8 = *a, a += N;
     asm volatile("vfmacc.vf v9, %0, v17" ::"f"(t9));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t9) : [a] "r"(a));
-    a += N;
+    t9 = *a, a += N;
     asm volatile("vfmacc.vf v10, %0, v17" ::"f"(t10));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t10) : [a] "r"(a));
-    a += N;
+    t10 = *a, a += N;
     asm volatile("vfmacc.vf v11, %0, v17" ::"f"(t11));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t11) : [a] "r"(a));
-    a += N;
+    t11 = *a, a += N;
     asm volatile("vfmacc.vf v12, %0, v17" ::"f"(t12));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t12) : [a] "r"(a));
-    a += N;
+    t12 = *a, a += N;
     asm volatile("vfmacc.vf v13, %0, v17" ::"f"(t13));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t13) : [a] "r"(a));
-    a += N;
+    t13 = *a, a += N;
     asm volatile("vfmacc.vf v14, %0, v17" ::"f"(t14));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t14) : [a] "r"(a));
-    a += N;
+    t14 = *a, a += N;
     asm volatile("vfmacc.vf v15, %0, v17" ::"f"(t15));
-    asm volatile("fld %[t], (%[a])" : [t] "=f"(t15) : [a] "r"(a));
+    t15 = *a;
   }
 
   // Last iteration: store results

--- a/apps/fmatmul/kernel/fmatmul.c
+++ b/apps/fmatmul/kernel/fmatmul.c
@@ -28,8 +28,16 @@ void fmatmul(double *c, const double *a, const double *b,
     fmatmul_4x4(c, a, b, M, N, P);
   } else if (M <= 8) {
     fmatmul_8x8(c, a, b, M, N, P);
-  } else {
+  } else if (M <= 64) {
     fmatmul_16x16(c, a, b, M, N, P);
+  } else if (M <= 128) {
+    // Vector length is 64 elements. With an 8x8 matmul,
+    // we can use LMUL=2, having a vl of 128.
+    fmatmul_8x8(c, a, b, M, N, P);
+  } else {
+    // Vector length is 64 elements. With an 4x4 matmul,
+    // we can use LMUL=4, having a vl of 256.
+    fmatmul_4x4(c, a, b, M, N, P);
   }
 }
 

--- a/apps/fmatmul/kernel/fmatmul.h
+++ b/apps/fmatmul/kernel/fmatmul.h
@@ -22,25 +22,26 @@
 
 #include <stdint.h>
 
-void fmatmul(double *c, const double *a, const double *b, int64_t m, int64_t n,
-             int64_t p);
+void fmatmul(double *c, const double *a, const double *b, unsigned long int m,
+             unsigned long int n, unsigned long int p);
 
-void fmatmul_4x4(double *c, const double *a, const double *b, int64_t m,
-                 int64_t n, int64_t p);
+void fmatmul_4x4(double *c, const double *a, const double *b,
+                 unsigned long int m, unsigned long int n, unsigned long int p);
 void fmatmul_vec_4x4_slice_init();
-void fmatmul_vec_4x4(double *c, const double *a, const double *b, int64_t n,
-                     int64_t p);
+void fmatmul_vec_4x4(double *c, const double *a, const double *b,
+                     unsigned long int n, unsigned long int p);
 
-void fmatmul_8x8(double *c, const double *a, const double *b, int64_t m,
-                 int64_t n, int64_t p);
+void fmatmul_8x8(double *c, const double *a, const double *b,
+                 unsigned long int m, unsigned long int n, unsigned long int p);
 void fmatmul_vec_8x8_slice_init();
-void fmatmul_vec_8x8(double *c, const double *a, const double *b, int64_t n,
-                     int64_t p);
+void fmatmul_vec_8x8(double *c, const double *a, const double *b,
+                     unsigned long int n, unsigned long int p);
 
-void fmatmul_16x16(double *c, const double *a, const double *b, int64_t m,
-                   int64_t n, int64_t p);
+void fmatmul_16x16(double *c, const double *a, const double *b,
+                   unsigned long int m, unsigned long int n,
+                   unsigned long int p);
 void fmatmul_vec_16x16_slice_init();
-void fmatmul_vec_16x16(double *c, const double *a, const double *b, int64_t n,
-                       int64_t p);
+void fmatmul_vec_16x16(double *c, const double *a, const double *b,
+                       unsigned long int n, unsigned long int p);
 
 #endif

--- a/apps/imatmul/kernel/imatmul.c
+++ b/apps/imatmul/kernel/imatmul.c
@@ -26,8 +26,12 @@ void imatmul(int64_t *c, const int64_t *a, const int64_t *b,
              const unsigned long int P) {
   if (M <= 4) {
     imatmul_4x4(c, a, b, M, N, P);
-  } else {
+  } else if (M <= 128) {
     imatmul_8x8(c, a, b, M, N, P);
+  } else {
+    // Vector length is 64 elements. With an 4x4 matmul,
+    // we can use LMUL=4, having a vl of 256.
+    imatmul_4x4(c, a, b, M, N, P);
   }
 }
 

--- a/apps/imatmul/kernel/imatmul.c
+++ b/apps/imatmul/kernel/imatmul.c
@@ -21,8 +21,9 @@
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-void imatmul(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
-             int64_t N, int64_t P) {
+void imatmul(int64_t *c, const int64_t *a, const int64_t *b,
+             const unsigned long int M, const unsigned long int N,
+             const unsigned long int P) {
   if (M <= 4) {
     imatmul_4x4(c, a, b, M, N, P);
   } else {
@@ -34,19 +35,20 @@ void imatmul(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
 // 4x4
 // ---------------
 
-void imatmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
-                 int64_t N, int64_t P) {
+void imatmul_4x4(int64_t *c, const int64_t *a, const int64_t *b,
+                 const unsigned long int M, const unsigned long int N,
+                 const unsigned long int P) {
   // We work on 4 rows of the matrix at once
-  int64_t block_size = 4;
-  int64_t block_size_p;
+  const unsigned long int block_size = 4;
+  unsigned long int block_size_p;
 
   // Set the vector configuration
   asm volatile("vsetvli %0, %1, e64, m4, ta, ma" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
-  for (int64_t p = 0; p < P; p += block_size_p) {
+  for (unsigned long int p = 0; p < P; p += block_size_p) {
     // Set the vector length
-    int64_t p_ = MIN(P - p, block_size_p);
+    const unsigned long int p_ = MIN(P - p, block_size_p);
 
     // Find pointers to the submatrices
     const int64_t *b_ = b + p;
@@ -55,7 +57,7 @@ void imatmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
     asm volatile("vsetvli zero, %0, e64, m4, ta, ma" ::"r"(p_));
 
     // Iterate over the rows
-    for (int64_t m = 0; m < M; m += block_size) {
+    for (unsigned long int m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
       const int64_t *a_ = a + m * N;
       int64_t *c__ = c_ + m * P;
@@ -73,8 +75,8 @@ void imatmul_vec_4x4_slice_init() {
   asm volatile("vmv.v.i v12, 0");
 }
 
-void imatmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t N,
-                     int64_t P) {
+void imatmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b,
+                     const unsigned long int N, const unsigned long int P) {
   // Temporary variables
   int64_t t0, t1, t2, t3;
 
@@ -86,59 +88,50 @@ void imatmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t N,
   b += P;
 
   // Prefetch one row of scalar values
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t0) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t1) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t2) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t3) : [a] "r"(a));
+  t0 = *a, a += N;
+  t1 = *a, a += N;
+  t2 = *a, a += N;
+  t3 = *a;
 
   // Compute the multiplication
-  int64_t n = 0;
+  unsigned long int n = 0;
 
   while (n < N) {
     // Calculate pointer to the matrix A
-    a = (const int64_t *)a_ + ++n;
+    a = a_ + ++n;
 
     asm volatile("vmacc.vx v0, %0, v16" ::"r"(t0));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v20, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vmacc.vx v4, %0, v16" ::"r"(t1));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vmacc.vx v8, %0, v16" ::"r"(t2));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vmacc.vx v12, %0, v16" ::"r"(t3));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t3) : [a] "r"(a));
+    t3 = *a;
 
-    if (n == N - 1)
+    a = a_ + ++n;
+
+    if (n == N)
       break;
 
-    a = (const int64_t *)a_ + ++n;
-
     asm volatile("vmacc.vx v0, %0, v20" ::"r"(t0));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v16, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vmacc.vx v4, %0, v20" ::"r"(t1));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vmacc.vx v8, %0, v20" ::"r"(t2));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vmacc.vx v12, %0, v20" ::"r"(t3));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t3) : [a] "r"(a));
+    t3 = *a;
   }
 
   // Last iteration: store results
@@ -159,19 +152,20 @@ void imatmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t N,
 // 8x8
 // ---------------
 
-void imatmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
-                 int64_t N, int64_t P) {
+void imatmul_8x8(int64_t *c, const int64_t *a, const int64_t *b,
+                 const unsigned long int M, const unsigned long int N,
+                 const unsigned long int P) {
   // We work on 4 rows of the matrix at once
-  int64_t block_size = 8;
-  int64_t block_size_p;
+  const unsigned long int block_size = 8;
+  unsigned long int block_size_p;
 
   // Set the vector configuration
   asm volatile("vsetvli %0, %1, e64, m2, ta, ma" : "=r"(block_size_p) : "r"(P));
 
   // Slice the matrix into a manageable number of columns p_
-  for (int64_t p = 0; p < P; p += block_size_p) {
+  for (unsigned long int p = 0; p < P; p += block_size_p) {
     // Set the vector length
-    int64_t p_ = MIN(P - p, block_size_p);
+    const unsigned long int p_ = MIN(P - p, block_size_p);
 
     // Find pointers to the submatrices
     const int64_t *b_ = b + p;
@@ -180,7 +174,7 @@ void imatmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t M,
     asm volatile("vsetvli zero, %0, e64, m2, ta, ma" ::"r"(p_));
 
     // Iterate over the rows
-    for (int64_t m = 0; m < M; m += block_size) {
+    for (unsigned long int m = 0; m < M; m += block_size) {
       // Find pointer to the submatrices
       const int64_t *a_ = a + m * N;
       int64_t *c__ = c_ + m * P;
@@ -202,8 +196,8 @@ void imatmul_vec_8x8_slice_init() {
   asm volatile("vmv.v.i v14, 0");
 }
 
-void imatmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t N,
-                     int64_t P) {
+void imatmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b,
+                     const unsigned long int N, const unsigned long int P) {
   // Temporary variables
   int64_t t0, t1, t2, t3, t4, t5, t6, t7;
 
@@ -215,91 +209,70 @@ void imatmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t N,
   b += P;
 
   // Prefetch one row of scalar values
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t0) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t1) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t2) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t3) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t4) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t5) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t6) : [a] "r"(a));
-  a += N;
-  asm volatile("ld %[t], (%[a])" : [t] "=r"(t7) : [a] "r"(a));
+  t0 = *a, a += N;
+  t1 = *a, a += N;
+  t2 = *a, a += N;
+  t3 = *a, a += N;
+  t4 = *a, a += N;
+  t5 = *a, a += N;
+  t6 = *a, a += N;
+  t7 = *a;
 
   // Compute the multiplication
-  int64_t n = 0;
+  unsigned long int n = 0;
 
   while (n < N) {
     // Calculate pointer to the matrix A
-    a = (const int64_t *)a_ + ++n;
+    a = a_ + ++n;
 
     asm volatile("vmacc.vx v0, %0, v18" ::"r"(t0));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v20, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vmacc.vx v2, %0, v18" ::"r"(t1));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vmacc.vx v4, %0, v18" ::"r"(t2));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vmacc.vx v6, %0, v18" ::"r"(t3));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t3) : [a] "r"(a));
-    a += N;
+    t3 = *a, a += N;
     asm volatile("vmacc.vx v8, %0, v18" ::"r"(t4));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t4) : [a] "r"(a));
-    a += N;
+    t4 = *a, a += N;
     asm volatile("vmacc.vx v10, %0, v18" ::"r"(t5));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t5) : [a] "r"(a));
-    a += N;
+    t5 = *a, a += N;
     asm volatile("vmacc.vx v12, %0, v18" ::"r"(t6));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t6) : [a] "r"(a));
-    a += N;
+    t6 = *a, a += N;
     asm volatile("vmacc.vx v14, %0, v18" ::"r"(t7));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t7) : [a] "r"(a));
+    t7 = *a;
 
-    if (n == N - 1)
+    a = a_ + ++n;
+
+    if (n == N)
       break;
 
-    a = (const int64_t *)a_ + ++n;
-
     asm volatile("vmacc.vx v0, %0, v20" ::"r"(t0));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t0) : [a] "r"(a));
-    a += N;
+    t0 = *a, a += N;
 
     // Load one row of B
     asm volatile("vle64.v v18, (%0);" ::"r"(b));
     b += P;
 
     asm volatile("vmacc.vx v2, %0, v20" ::"r"(t1));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t1) : [a] "r"(a));
-    a += N;
+    t1 = *a, a += N;
     asm volatile("vmacc.vx v4, %0, v20" ::"r"(t2));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t2) : [a] "r"(a));
-    a += N;
+    t2 = *a, a += N;
     asm volatile("vmacc.vx v6, %0, v20" ::"r"(t3));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t3) : [a] "r"(a));
-    a += N;
+    t3 = *a, a += N;
     asm volatile("vmacc.vx v8, %0, v20" ::"r"(t4));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t4) : [a] "r"(a));
-    a += N;
+    t4 = *a, a += N;
     asm volatile("vmacc.vx v10, %0, v20" ::"r"(t5));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t5) : [a] "r"(a));
-    a += N;
+    t5 = *a, a += N;
     asm volatile("vmacc.vx v12, %0, v20" ::"r"(t6));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t6) : [a] "r"(a));
-    a += N;
+    t6 = *a, a += N;
     asm volatile("vmacc.vx v14, %0, v20" ::"r"(t7));
-    asm volatile("ld %[t], (%[a])" : [t] "=r"(t7) : [a] "r"(a));
+    t7 = *a;
   }
 
   // Last iteration: store results

--- a/apps/imatmul/kernel/imatmul.h
+++ b/apps/imatmul/kernel/imatmul.h
@@ -22,19 +22,22 @@
 
 #include <stdint.h>
 
-void imatmul(int64_t *c, const int64_t *a, const int64_t *b, int64_t m,
-             int64_t n, int64_t p);
+void imatmul(int64_t *c, const int64_t *a, const int64_t *b,
+             const unsigned long int m, const unsigned long int n,
+             const unsigned long int p);
 
-void imatmul_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t m,
-                 int64_t n, int64_t p);
+void imatmul_4x4(int64_t *c, const int64_t *a, const int64_t *b,
+                 const unsigned long int m, const unsigned long int n,
+                 const unsigned long int p);
 void imatmul_vec_4x4_slice_init();
-void imatmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b, int64_t n,
-                     int64_t p);
+void imatmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b,
+                     const unsigned long int n, const unsigned long int p);
 
-void imatmul_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t m,
-                 int64_t n, int64_t p);
+void imatmul_8x8(int64_t *c, const int64_t *a, const int64_t *b,
+                 const unsigned long int m, const unsigned long int n,
+                 const unsigned long int p);
 void imatmul_vec_8x8_slice_init();
-void imatmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b, int64_t n,
-                     int64_t p);
+void imatmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b,
+                     const unsigned long int n, const unsigned long int p);
 
 #endif

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -545,12 +545,12 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   );
 
   axi_inval_filter #(
-    .MaxTxns    (4                   ),
-    .AddrWidth  (AxiAddrWidth        ),
-    .L1LineWidth(16                  ),
-    .aw_chan_t  (axi_core_aw_chan_t  ),
-    .req_t      (axi_core_wide_req_t ),
-    .resp_t     (axi_core_wide_resp_t)
+    .MaxTxns    (4                              ),
+    .AddrWidth  (AxiAddrWidth                   ),
+    .L1LineWidth(ariane_pkg::DCACHE_LINE_WIDTH/8),
+    .aw_chan_t  (axi_core_aw_chan_t             ),
+    .req_t      (axi_core_wide_req_t            ),
+    .resp_t     (axi_core_wide_resp_t           )
   ) i_axi_inval_filter (
     .clk_i        (clk_i             ),
     .rst_ni       (rst_ni            ),


### PR DESCRIPTION
This PR improves the performance of Ara on the matrix multiplication kernels. It does so by widening Ariane's cache lines to 256 bits (I$) and 512 bits (D$), and by issuing vector instructions back-to-back. 

Merge this after merging #54.

I still need to check the performance impacts of those changes on the interface between Ara and Ariane. 

## Changelog

### Changed

- Widen CVA6's cache lines
- Implement back-to-back accelerator instruction issue mechanism on CVA6

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
