### PR TITLE
fix core dump issue when using Verilator to dump waveform

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -176,19 +176,20 @@ $(veril_library)/V$(veril_top): $(config_file) Makefile ../Bender.yml $(shell fi
   $(ROOT_DIR)/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/*.cc      \
   $(ROOT_DIR)/tb/verilator/ara_tb.cpp                                           \
   --cc                                                                          \
+  $(if $(DEBUG),--trace-fst -Wno-INSECURE,)                                     \
   --top-module $(veril_top) &&                                                  \
 	cd $(veril_library) && OBJCACHE='' make -j4 -f V$(veril_top).mk
 
 # Simulation
 .PHONY: simv
 simv:
-	$(veril_library)/V$(veril_top) -l ram,$(app_path)/$(app),elf
+	$(veril_library)/V$(veril_top) $(if $(DEBUG),-t,) -l ram,$(app_path)/$(app),elf
 
 .PHONY: riscv_tests_simv
 riscv_tests_simv: $(tests)
 
 $(tests): rv%: $(app_path)/rv%
-	$(veril_library)/V$(veril_top) -l ram,$<,elf &> $(buildpath)/$@.trace
+	$(veril_library)/V$(veril_top) $(if $(DEBUG),-t,) -l ram,$<,elf &> $(buildpath)/$@.trace
 
 # DPIs
 .PHONY: dpi

--- a/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilated_toplevel.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilated_toplevel.h
@@ -31,10 +31,10 @@
 #define VM_TRACE 0
 #endif
 
-// VM_TRACE_FMT_FST must be set by the user when calling Verilator with
+// VM_TRACE_FST must be set by the user when calling Verilator with
 // --trace-fst. VM_TRACE is set by Verilator itself.
 #if VM_TRACE == 1
-#ifdef VM_TRACE_FMT_FST
+#ifdef VM_TRACE_FST
 #include "verilated_fst_c.h"
 #define VM_TRACE_CLASS_NAME VerilatedFstC
 #else

--- a/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -264,7 +264,7 @@ void VerilatorSimCtrl::PrintStatistics() const {
 }
 
 const char *VerilatorSimCtrl::GetTraceFileName() const {
-#ifdef VM_TRACE_FMT_FST
+#ifdef VM_TRACE_FST
   return "sim.fst";
 #else
   return "sim.vcd";
@@ -280,6 +280,8 @@ void VerilatorSimCtrl::Run() {
     top_->trace(tracer_, 99, 0);
   }
 
+  Trace();
+
   // Evaluate all initial blocks, including the DPI setup routines
   top_->eval();
 
@@ -288,7 +290,6 @@ void VerilatorSimCtrl::Run() {
 
   time_begin_ = std::chrono::steady_clock::now();
   UnsetReset();
-  Trace();
 
   unsigned long start_reset_cycle_ = initial_reset_delay_cycles_;
   unsigned long end_reset_cycle_ = start_reset_cycle_ + reset_duration_cycles_;


### PR DESCRIPTION
Description of PR that completes issue here...

## Changelog

1. Solve the core dump issue
2. Change macro VM_TRACE_FMT_FST to VM_TRACE_FST to support fst waveform dump.
3. Add DEBUG in Makefile to generate the waveform (default fst format)

### Fixed

Fix core dump when using Verilator to dump waveform.

### Added

Add DEBUG in Makefile to generate the waveform (default fst format)

Users can use the following command to generate trace for Verilator

```
$ make verilate DEBUG=1
```

Using following command to run the diag

```
$ make simv app=benchmarks DEBUG=1
```

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

