### PR TITLE
Fix Gnuplot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,9 @@ jobs:
         tar xvf benchmarks-8_lanes.tar
         tar xvf benchmarks-16_lanes.tar
     - name: Install gnuplot
-      run: sudo apt-get install gnuplot
+      run: |
+        sudo apt-get update
+        sudo apt-get install gnuplot
     - name: Plot the rooflines
       run: gnuplot -c scripts/benchmark.gnuplot
     - name: Upload the imatmul roofline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix typo on the build instructions of the README
+- Fix Gnuplot installation on GitHub's CI
 
 ### Added
 
@@ -23,9 +24,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add spill register at the lane edge, to cut the timing-critical interface between the Mask unit and the VFUs
 - Increase latency of the 16-bit multiplier from 0 to 1 to cut an in-lane timing-critical path
-
-### Changed
-
 - Widen CVA6's cache lines
 - Implement back-to-back accelerator instruction issue mechanism on CVA6
 


### PR DESCRIPTION
This PR fixes the installation of `gnuplot` on GitHub's CI by running `apt-get update` before installing the package.

## Changelog

### Fixed

- Fix Gnuplot installation on GitHub's CI

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
