### PR TITLE
Move to HTTPS protocol for git repos (DTC and NEWLIB)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,7 +26,7 @@
 	url = https://github.com/pulp-platform/cva6.git
 [submodule "toolchain/newlib"]
 	path = toolchain/newlib
-	url = git://sourceware.org/git/newlib-cygwin.git
+	url = https://sourceware.org/git/newlib-cygwin.git
 	ignore = dirty
 [submodule "toolchain/riscv-llvm"]
 	path = toolchain/riscv-llvm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Widen CVA6's cache lines
 - Implement back-to-back accelerator instruction issue mechanism on CVA6
 - Use https protocol when cloning DTC from main Makefile
+- Use https protocol for newlib-cygwin in .gitmodules
 
 ## 2.1.0 - 2021-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Increase latency of the 16-bit multiplier from 0 to 1 to cut an in-lane timing-critical path
 - Widen CVA6's cache lines
 - Implement back-to-back accelerator instruction issue mechanism on CVA6
+- Use https protocol when cloning DTC from main Makefile
 
 ## 2.1.0 - 2021-07-16
 

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ ${ISA_SIM_INSTALL_DIR}: Makefile
 	# There are linking issues with the standard libraries when using newer CC/CXX versions to compile Spike.
 	# Therefore, here we resort to older versions of the compilers.
 	cd toolchain/riscv-isa-sim && mkdir -p build && cd build; \
-	[ -d dtc ] || git clone git://git.kernel.org/pub/scm/utils/dtc/dtc.git && cd dtc; \
+	[ -d dtc ] || git clone https://git.kernel.org/pub/scm/utils/dtc/dtc.git && cd dtc; \
 	make install SETUP_PREFIX=$(ISA_SIM_INSTALL_DIR) PREFIX=$(ISA_SIM_INSTALL_DIR) && \
 	PATH=$(ISA_SIM_INSTALL_DIR)/bin:$$PATH; cd ..; \
 	../configure --prefix=$(ISA_SIM_INSTALL_DIR) && make -j4 && make install


### PR DESCRIPTION
Addressing issues https://github.com/pulp-platform/ara/issues/64 and https://github.com/pulp-platform/ara/issues/67

## Changelog

### Changed

- When cloning DTC from main makefile, use HTTPS, the official git protocol
- Use HTTPS for newlib-cygwin in .gitmodules

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed