### PR TITLE
[HW] Add support for the single-laned configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
+        ara_config: [1_lane, 2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: tc-llvm
     steps:
     - uses: actions/checkout@v2
@@ -193,7 +193,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
+        ara_config: [1_lane, 2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["tc-llvm", "tc-gcc", "tc-isa-sim"]
     steps:
     - uses: actions/checkout@v2
@@ -231,7 +231,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
+        ara_config: [1_lane, 2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["tc-verilator", "tc-isa-sim"]
     steps:
     - uses: actions/checkout@v2
@@ -281,7 +281,7 @@ jobs:
     strategy:
       matrix:
         app:        [hello_world, imatmul, fmatmul, conv2d]
-        ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
+        ara_config: [1_lane, 2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["compile-ara", "compile-apps"]
     steps:
     - uses: actions/checkout@v2
@@ -313,7 +313,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
+        ara_config: [1_lane, 2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["compile-ara", "compile-riscv-tests"]
     steps:
     - uses: actions/checkout@v2
@@ -441,7 +441,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
+        ara_config: [1_lane, 2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["compile-ara", "compile-apps"]
     steps:
     - uses: actions/checkout@v2
@@ -479,6 +479,10 @@ jobs:
     needs: benchmark
     steps:
     - uses: actions/checkout@v2
+    - name: Get benchmark results (1 lane)
+      uses: actions/download-artifact@v2
+      with:
+        name: benchmark-1_lane
     - name: Get benchmark results (2 lanes)
       uses: actions/download-artifact@v2
       with:
@@ -497,6 +501,7 @@ jobs:
         name: benchmark-16_lanes
     - name: Untar the results
       run: |
+        tar xvf benchmarks-1_lane.tar
         tar xvf benchmarks-2_lanes.tar
         tar xvf benchmarks-4_lanes.tar
         tar xvf benchmarks-8_lanes.tar

--- a/config/16_lanes.mk
+++ b/config/16_lanes.mk
@@ -21,5 +21,5 @@
 nr_lanes ?= 16
 
 # Length of each vector register (in bits)
-# Constraints: VLEN > 128
-vlen ?= 4096
+# Constraints: VLEN >= 8192
+vlen ?= 8192

--- a/config/1_lane.mk
+++ b/config/1_lane.mk
@@ -18,8 +18,8 @@
 #         Matheus Cavalcante, ETH Zurich
 
 # Number of vector lanes
-nr_lanes ?= 2
+nr_lanes ?= 1
 
 # Length of each vector register (in bits)
-# Constraints: VLEN >= 1024
+# Constraints: VLEN >= 512
 vlen ?= 4096

--- a/config/4_lanes.mk
+++ b/config/4_lanes.mk
@@ -21,5 +21,5 @@
 nr_lanes ?= 4
 
 # Length of each vector register (in bits)
-# Constraints: VLEN > 128
+# Constraints: VLEN >= 2048
 vlen ?= 4096

--- a/config/8_lanes.mk
+++ b/config/8_lanes.mk
@@ -21,5 +21,5 @@
 nr_lanes ?= 8
 
 # Length of each vector register (in bits)
-# Constraints: VLEN > 128
+# Constraints: VLEN >= 4096
 vlen ?= 4096

--- a/config/README.md
+++ b/config/README.md
@@ -6,6 +6,7 @@ parameters such as the number of lanes in the design. This will automatically
 generate the correct software runtime and the correct hardware.
 
 Ara currently has four configurations, which differ on the amount of lanes:
+- `1_lane.mk`
 - `2_lanes.mk`
 - `4_lanes.mk`
 - `8_lanes.mk`

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -413,14 +413,17 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
                 // we must request it as well from the VRF
 
                 // Find the number of extra elements to ask, related to the stride
-                unique case (pe_req_i.eew_vs2)
-                  EW8:  extra_stride =        pe_req_i.stride[$clog2(8*NrLanes)-1:0];
-                  EW16: extra_stride = {1'b0, pe_req_i.stride[$clog2(4*NrLanes)-1:0]};
-                  EW32: extra_stride = {2'b0, pe_req_i.stride[$clog2(2*NrLanes)-1:0]};
-                  EW64: extra_stride = {3'b0, pe_req_i.stride[$clog2(1*NrLanes)-1:0]};
-                  default:
-                    extra_stride = {3'b0, pe_req_i.stride[$clog2(1*NrLanes)-1:0]};
-                endcase
+                if (NrLanes != 1)
+                  unique case (pe_req_i.eew_vs2)
+                    EW8:  extra_stride =        pe_req_i.stride[idx_width(8*NrLanes)-1:0];
+                    EW16: extra_stride = {1'b0, pe_req_i.stride[idx_width(4*NrLanes)-1:0]};
+                    EW32: extra_stride = {2'b0, pe_req_i.stride[idx_width(2*NrLanes)-1:0]};
+                    EW64: extra_stride = {3'b0, pe_req_i.stride[idx_width(1*NrLanes)-1:0]};
+                    default:
+                      extra_stride = {3'b0, pe_req_i.stride[idx_width(1*NrLanes)-1:0]};
+                  endcase
+                else
+                  extra_stride = '0;
 
                 // Find the total number of elements to be asked
                 vl_tot = pe_req_i.vl;

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -264,9 +264,9 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
             // Is this a valid byte?
             if (b < issue_cnt_q && in_seq_byte < NrLanes * 8 && out_seq_byte < NrLanes * 8) begin
               // At which lane, and what is the offset in that lane, are the input and output bytes?
-              automatic int src_lane        = in_byte[3 +: $clog2(NrLanes)];
+              automatic int src_lane = NrLanes == 1 ? 0 : in_byte[3 +: idx_width(NrLanes)];
               automatic int src_lane_offset = in_byte[2:0];
-              automatic int tgt_lane        = out_byte[3 +: $clog2(NrLanes)];
+              automatic int tgt_lane = NrLanes == 1 ? 0 : out_byte[3 +: idx_width(NrLanes)];
               automatic int tgt_lane_offset = out_byte[2:0];
 
               result_queue_d[result_queue_write_pnt_q][tgt_lane].wdata[8*tgt_lane_offset +: 8] =
@@ -358,7 +358,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
               // Copy the scalar operand to the last word
               automatic int out_seq_byte = issue_cnt_q;
               automatic int out_byte = shuffle_index(out_seq_byte, NrLanes, vinsn_issue.vtype.vsew);
-              automatic int tgt_lane = out_byte[3 +: $clog2(NrLanes)];
+              automatic int tgt_lane = NrLanes == 1 ? 0 : out_byte[3 +: idx_width(NrLanes)];
               automatic int tgt_lane_offset = out_byte[2:0];
 
               unique case (vinsn_issue.vtype.vsew)

--- a/scripts/benchmark.gnuplot
+++ b/scripts/benchmark.gnuplot
@@ -14,7 +14,7 @@ set grid x y
 
 # Set the range
 set xrange [1:256]
-set yrange [0.5:35]
+set yrange [0.25:35]
 
 # Set axis labels
 set xlabel 'Matrix size (#elements)'
@@ -31,7 +31,9 @@ set term png
 set out "imatmul.png"
 
 # Plot the rooflines
-plot roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
+plot roof_mem(x, 0.5,2) w l lw 2 lc 5 notitle, roof_cpu(x, 0.5,2) w l lw 2 lc 5 t  '1 Lane',  \
+     'imatmul_1.benchmark' w p lw 2 lc 5 pt 2 notitle,                                        \
+     roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
      'imatmul_2.benchmark' w p lw 2 lc 1 pt 2 notitle,                                        \
      roof_mem(x, 2,  8) w l lw 2 lc 2 notitle, roof_cpu(x, 2,  8) w l lw 2 lc 2 t  '4 Lanes', \
      'imatmul_4.benchmark' w p lw 2 lc 2 pt 2 notitle,                                        \
@@ -53,7 +55,9 @@ set term png
 set out "fmatmul.png"
 
 # Plot the rooflines
-plot roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
+plot roof_mem(x, 0.5,2) w l lw 2 lc 5 notitle, roof_cpu(x, 0.5,2) w l lw 2 lc 5 t  '1 Lane',  \
+     'fmatmul_1.benchmark' w p lw 2 lc 5 pt 2 notitle,                                        \
+     roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
      'fmatmul_2.benchmark' w p lw 2 lc 1 pt 2 notitle,                                        \
      roof_mem(x, 2,  8) w l lw 2 lc 2 notitle, roof_cpu(x, 2,  8) w l lw 2 lc 2 t  '4 Lanes', \
      'fmatmul_4.benchmark' w p lw 2 lc 2 pt 2 notitle,                                        \


### PR DESCRIPTION
This PR adds support for a single-laned configuration. It also updated the constraints on the `VLEN` for all configuration, which now are lower-bounded by `8 * 64 * NrLanes`. 

Closes #63.

## Changelog

### Fixed

- Description of changes

### Added

- Description of changes

### Changed

- Description of changes

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
