### PR TITLE
Dump waveforms with Verilator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Vector whole-register load/store `vl1r`, `vs1r`
 - Vector load/store mask `vle1`, `vse1`
 - Whole-register instructions are executed also if `vtype.vl == 0`
+- Makefile option (`trace=1`) to generate waveform traces when running simulations with Verilator
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ preload=/some_path/some_binary make sim
 app=hello_world make simc
 ```
 
+We also provide the `simv` makefile target to run simulations with the Verilator model.
+
+```bash
+# Go to the hardware folder
+cd hardware
+# Apply the patches (only need to run this once)
+make apply-patches
+# Only compile the hardware without running the simulation.
+make verilate
+# Run the simulation with the *hello_world* binary loaded
+app=hello_world make simv
+```
+
 It is also possible to simulate the unit tests compiled in the `apps` folder. Given the number of unit tests, we use Verilator. Use the following command to install Verilator, verilate the design, and run the simulation:
 
 ```bash
@@ -118,6 +131,11 @@ make riscv_tests_simv
 ```
 
 Alternatively, you can also use the `riscv_tests` target at Ara's top-level Makefile to both compile the RISC-V tests and run their simulation.
+
+### Traces
+
+Add `trace=1` to the `verilate`, `simv`, and `riscv_tests_simv` commands to generate waveform traces in the `fst` format.
+You can use `gtkwave` to open such waveforms.
 
 ## Publication
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -176,19 +176,20 @@ $(veril_library)/V$(veril_top): $(config_file) Makefile ../Bender.yml $(shell fi
   $(ROOT_DIR)/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/*.cc      \
   $(ROOT_DIR)/tb/verilator/ara_tb.cpp                                           \
   --cc                                                                          \
+  $(if $(trace),--trace-fst -Wno-INSECURE,)                                     \
   --top-module $(veril_top) &&                                                  \
 	cd $(veril_library) && OBJCACHE='' make -j4 -f V$(veril_top).mk
 
 # Simulation
 .PHONY: simv
 simv:
-	$(veril_library)/V$(veril_top) -l ram,$(app_path)/$(app),elf
+	$(veril_library)/V$(veril_top) $(if $(trace),-t,) -l ram,$(app_path)/$(app),elf
 
 .PHONY: riscv_tests_simv
 riscv_tests_simv: $(tests)
 
 $(tests): rv%: $(app_path)/rv%
-	$(veril_library)/V$(veril_top) -l ram,$<,elf &> $(buildpath)/$@.trace
+	$(veril_library)/V$(veril_top) $(if $(trace),-t,) -l ram,$<,elf &> $(buildpath)/$@.trace
 
 # DPIs
 .PHONY: dpi

--- a/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilated_toplevel.h
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilated_toplevel.h
@@ -31,10 +31,10 @@
 #define VM_TRACE 0
 #endif
 
-// VM_TRACE_FMT_FST must be set by the user when calling Verilator with
+// VM_TRACE_FST must be set by the user when calling Verilator with
 // --trace-fst. VM_TRACE is set by Verilator itself.
 #if VM_TRACE == 1
-#ifdef VM_TRACE_FMT_FST
+#ifdef VM_TRACE_FST
 #include "verilated_fst_c.h"
 #define VM_TRACE_CLASS_NAME VerilatedFstC
 #else

--- a/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hardware/tb/verilator/lowrisc_dv_verilator_simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -264,7 +264,7 @@ void VerilatorSimCtrl::PrintStatistics() const {
 }
 
 const char *VerilatorSimCtrl::GetTraceFileName() const {
-#ifdef VM_TRACE_FMT_FST
+#ifdef VM_TRACE_FST
   return "sim.fst";
 #else
   return "sim.vcd";
@@ -280,6 +280,8 @@ void VerilatorSimCtrl::Run() {
     top_->trace(tracer_, 99, 0);
   }
 
+  Trace();
+
   // Evaluate all initial blocks, including the DPI setup routines
   top_->eval();
 
@@ -288,7 +290,6 @@ void VerilatorSimCtrl::Run() {
 
   time_begin_ = std::chrono::steady_clock::now();
   UnsetReset();
-  Trace();
 
   unsigned long start_reset_cycle_ = initial_reset_delay_cycles_;
   unsigned long end_reset_cycle_ = start_reset_cycle_ + reset_duration_cycles_;


### PR DESCRIPTION
This PR adds waveform dumping capabilities to the Verilator model, through the usage of the `trace=1` option. This is based on @kuopinghsu's commit and work on the PR #62, which I changed to align it with our code style. 

Closes #60.
Closes #62.

## Changelog

### Added

- Makefile option (`trace=1`) to generate waveform traces when running simulations with Verilator

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
