### PR TITLE
Create the `ara_system` wrapper

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -57,6 +57,8 @@ sources:
     # Level 5
     - hardware/src/ara.sv
     # Level 6
+    - hardware/src/ara_system.sv
+    # Level 7
     - hardware/src/ara_soc.sv
 
     - target: ara_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use https protocol for newlib-cygwin in .gitmodules
 - Cut a timing-critical path from Addrgen to Sequencer (1 cycle more to start an AXI transaction)
 - Cut a timing-critical path in the `VSTU`, relative to the calculation of the pointer to the `VRF` word received from the lanes
+- Create `ara_system` wrapper containing Ara, Ariane, and an AXI mux, instantiated from within Ara's SoC
 
 ## 2.1.0 - 2021-07-16
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -48,7 +48,7 @@ veril_top      ?= ara_tb_verilator
 # Top level module to compile
 top_level      ?= ara_tb
 # QuestaSim Version
-questa_version ?= 2020.1
+questa_version ?= 2021.2
 # QuestaSim command
 questa_cmd     ?= questa-$(questa_version)
 # QuestaSim arguments

--- a/hardware/scripts/wave_ara.tcl
+++ b/hardware/scripts/wave_ara.tcl
@@ -4,21 +4,21 @@
 #
 # Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
-add wave -noupdate -group Ara -group core /ara_tb/dut/i_ara_soc/i_ara/*
+add wave -noupdate -group Ara -group core /ara_tb/dut/i_ara_soc/i_system/i_ara/*
 
-add wave -noupdate -group Ara -group dispatcher /ara_tb/dut/i_ara_soc/i_ara/i_dispatcher/*
-add wave -noupdate -group Ara -group sequencer /ara_tb/dut/i_ara_soc/i_ara/i_sequencer/*
+add wave -noupdate -group Ara -group dispatcher /ara_tb/dut/i_ara_soc/i_system/i_ara/i_dispatcher/*
+add wave -noupdate -group Ara -group sequencer /ara_tb/dut/i_ara_soc/i_system/i_ara/i_sequencer/*
 
 # Add waves from all the lanes
 for {set lane 0}  {$lane < [examine -radix dec ara_tb.NrLanes]} {incr lane} {
     do ../scripts/wave_lane.tcl $lane
 }
 
-add wave -noupdate -group Ara -group masku /ara_tb/dut/i_ara_soc/i_ara/i_masku/*
+add wave -noupdate -group Ara -group masku /ara_tb/dut/i_ara_soc/i_system/i_ara/i_masku/*
 
-add wave -noupdate -group Ara -group sldu /ara_tb/dut/i_ara_soc/i_ara/i_sldu/*
+add wave -noupdate -group Ara -group sldu /ara_tb/dut/i_ara_soc/i_system/i_ara/i_sldu/*
 
-add wave -noupdate -group Ara -group vlsu -group addrgen /ara_tb/dut/i_ara_soc/i_ara/i_vlsu/i_addrgen/*
-add wave -noupdate -group Ara -group vlsu -group vldu /ara_tb/dut/i_ara_soc/i_ara/i_vlsu/i_vldu/*
-add wave -noupdate -group Ara -group vlsu -group vstu /ara_tb/dut/i_ara_soc/i_ara/i_vlsu/i_vstu/*
-add wave -noupdate -group Ara -group vlsu /ara_tb/dut/i_ara_soc/i_ara/i_vlsu/*
+add wave -noupdate -group Ara -group vlsu -group addrgen /ara_tb/dut/i_ara_soc/i_system/i_ara/i_vlsu/i_addrgen/*
+add wave -noupdate -group Ara -group vlsu -group vldu /ara_tb/dut/i_ara_soc/i_system/i_ara/i_vlsu/i_vldu/*
+add wave -noupdate -group Ara -group vlsu -group vstu /ara_tb/dut/i_ara_soc/i_system/i_ara/i_vlsu/i_vstu/*
+add wave -noupdate -group Ara -group vlsu /ara_tb/dut/i_ara_soc/i_system/i_ara/i_vlsu/*

--- a/hardware/scripts/wave_core.tcl
+++ b/hardware/scripts/wave_core.tcl
@@ -4,61 +4,61 @@
 #
 # Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
-add wave -noupdate -group CVA6 -group core /ara_tb/dut/i_ara_soc/i_ariane/*
+add wave -noupdate -group CVA6 -group core /ara_tb/dut/i_ara_soc/i_system/i_ariane/*
 
-add wave -noupdate -group CVA6 -group frontend /ara_tb/dut/i_ara_soc/i_ariane/i_frontend/*
-add wave -noupdate -group CVA6 -group frontend -group icache /ara_tb/dut/i_ara_soc/i_ariane/i_cache_subsystem/i_cva6_icache/*
-add wave -noupdate -group CVA6 -group frontend -group ras /ara_tb/dut/i_ara_soc/i_ariane/i_frontend/i_ras/*
-add wave -noupdate -group CVA6 -group frontend -group btb /ara_tb/dut/i_ara_soc/i_ariane/i_frontend/i_btb/*
-add wave -noupdate -group CVA6 -group frontend -group bht /ara_tb/dut/i_ara_soc/i_ariane/i_frontend/i_bht/*
-# add wave -noupdate -group CVA6 -group frontend -group instr_scan /ara_tb/dut/i_ara_soc/i_ariane/i_frontend/*/i_instr_scan/*
-# add wave -noupdate -group CVA6 -group frontend -group fetch_fifo /ara_tb/dut/i_ara_soc/i_ariane/i_frontend/i_fetch_fifo/*
+add wave -noupdate -group CVA6 -group frontend /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_frontend/*
+add wave -noupdate -group CVA6 -group frontend -group icache /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_cache_subsystem/i_cva6_icache/*
+add wave -noupdate -group CVA6 -group frontend -group ras /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_frontend/i_ras/*
+add wave -noupdate -group CVA6 -group frontend -group btb /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_frontend/i_btb/*
+add wave -noupdate -group CVA6 -group frontend -group bht /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_frontend/i_bht/*
+# add wave -noupdate -group CVA6 -group frontend -group instr_scan /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_frontend/*/i_instr_scan/*
+# add wave -noupdate -group CVA6 -group frontend -group fetch_fifo /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_frontend/i_fetch_fifo/*
 
-add wave -noupdate -group CVA6 -group id_stage -group decoder /ara_tb/dut/i_ara_soc/i_ariane/id_stage_i/decoder_i/*
-add wave -noupdate -group CVA6 -group id_stage -group compressed_decoder /ara_tb/dut/i_ara_soc/i_ariane/id_stage_i/compressed_decoder_i/*
-add wave -noupdate -group CVA6 -group id_stage /ara_tb/dut/i_ara_soc/i_ariane/id_stage_i/*
+add wave -noupdate -group CVA6 -group id_stage -group decoder /ara_tb/dut/i_ara_soc/i_system/i_ariane/id_stage_i/decoder_i/*
+add wave -noupdate -group CVA6 -group id_stage -group compressed_decoder /ara_tb/dut/i_ara_soc/i_system/i_ariane/id_stage_i/compressed_decoder_i/*
+add wave -noupdate -group CVA6 -group id_stage /ara_tb/dut/i_ara_soc/i_system/i_ariane/id_stage_i/*
 
-add wave -noupdate -group CVA6 -group issue_stage -group scoreboard /ara_tb/dut/i_ara_soc/i_ariane/issue_stage_i/i_scoreboard/*
-add wave -noupdate -group CVA6 -group issue_stage -group issue_read_operands /ara_tb/dut/i_ara_soc/i_ariane/issue_stage_i/i_issue_read_operands/*
-add wave -noupdate -group CVA6 -group issue_stage -group rename /ara_tb/dut/i_ara_soc/i_ariane/issue_stage_i/i_re_name/*
-add wave -noupdate -group CVA6 -group issue_stage /ara_tb/dut/i_ara_soc/i_ariane/issue_stage_i/*
+add wave -noupdate -group CVA6 -group issue_stage -group scoreboard /ara_tb/dut/i_ara_soc/i_system/i_ariane/issue_stage_i/i_scoreboard/*
+add wave -noupdate -group CVA6 -group issue_stage -group issue_read_operands /ara_tb/dut/i_ara_soc/i_system/i_ariane/issue_stage_i/i_issue_read_operands/*
+add wave -noupdate -group CVA6 -group issue_stage -group rename /ara_tb/dut/i_ara_soc/i_system/i_ariane/issue_stage_i/i_re_name/*
+add wave -noupdate -group CVA6 -group issue_stage /ara_tb/dut/i_ara_soc/i_system/i_ariane/issue_stage_i/*
 
-add wave -noupdate -group CVA6 -group ex_stage -group alu /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/alu_i/*
-add wave -noupdate -group CVA6 -group ex_stage -group mult /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/i_mult/*
-add wave -noupdate -group CVA6 -group ex_stage -group mult -group mul /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/i_mult/i_multiplier/*
-add wave -noupdate -group CVA6 -group ex_stage -group mult -group div /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/i_mult/i_div/*
-add wave -noupdate -group CVA6 -group ex_stage -group fpu /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/fpu_gen/fpu_i/*
-add wave -noupdate -group CVA6 -group ex_stage -group fpu -group fpnew /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/fpu_gen/fpu_i/fpu_gen/i_fpnew_bulk/*
+add wave -noupdate -group CVA6 -group ex_stage -group alu /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/alu_i/*
+add wave -noupdate -group CVA6 -group ex_stage -group mult /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/i_mult/*
+add wave -noupdate -group CVA6 -group ex_stage -group mult -group mul /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/i_mult/i_multiplier/*
+add wave -noupdate -group CVA6 -group ex_stage -group mult -group div /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/i_mult/i_div/*
+add wave -noupdate -group CVA6 -group ex_stage -group fpu /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/fpu_gen/fpu_i/*
+add wave -noupdate -group CVA6 -group ex_stage -group fpu -group fpnew /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/fpu_gen/fpu_i/fpu_gen/i_fpnew_bulk/*
 
-add wave -noupdate -group CVA6 -group ex_stage -group lsu /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/*
-add wave -noupdate -group CVA6 -group ex_stage -group lsu  -group lsu_bypass /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/lsu_bypass_i/*
-add wave -noupdate -group CVA6 -group ex_stage -group lsu -group mmu /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/i_mmu/*
-add wave -noupdate -group CVA6 -group ex_stage -group lsu -group mmu -group itlb /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/i_mmu/i_itlb/*
-add wave -noupdate -group CVA6 -group ex_stage -group lsu -group mmu -group dtlb /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/i_mmu/i_dtlb/*
-add wave -noupdate -group CVA6 -group ex_stage -group lsu -group mmu -group ptw /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/i_mmu/i_ptw/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu  -group lsu_bypass /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/lsu_bypass_i/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu -group mmu /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/i_mmu/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu -group mmu -group itlb /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/i_mmu/i_itlb/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu -group mmu -group dtlb /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/i_mmu/i_dtlb/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu -group mmu -group ptw /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/i_mmu/i_ptw/*
 
-add wave -noupdate -group CVA6 -group ex_stage -group lsu -group store_unit /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/i_store_unit/*
-add wave -noupdate -group CVA6 -group ex_stage -group lsu -group store_unit -group store_buffer /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/i_store_unit/store_buffer_i/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu -group store_unit /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/i_store_unit/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu -group store_unit -group store_buffer /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/i_store_unit/store_buffer_i/*
 
-add wave -noupdate -group CVA6 -group ex_stage -group lsu -group load_unit /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/lsu_i/i_load_unit/*
+add wave -noupdate -group CVA6 -group ex_stage -group lsu -group load_unit /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/lsu_i/i_load_unit/*
 
-add wave -noupdate -group CVA6 -group ex_stage -group branch_unit /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/branch_unit_i/*
+add wave -noupdate -group CVA6 -group ex_stage -group branch_unit /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/branch_unit_i/*
 
-add wave -noupdate -group CVA6 -group ex_stage -group csr_buffer /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/csr_buffer_i/*
+add wave -noupdate -group CVA6 -group ex_stage -group csr_buffer /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/csr_buffer_i/*
 
-add wave -noupdate -group CVA6 -group ex_stage -group dispatcher /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/gen_accelerator/i_acc_dispatcher/*
-add wave -noupdate -group CVA6 -group ex_stage /ara_tb/dut/i_ara_soc/i_ariane/ex_stage_i/*
+add wave -noupdate -group CVA6 -group ex_stage -group dispatcher /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/gen_accelerator/i_acc_dispatcher/*
+add wave -noupdate -group CVA6 -group ex_stage /ara_tb/dut/i_ara_soc/i_system/i_ariane/ex_stage_i/*
 
-add wave -noupdate -group CVA6 -group commit_stage /ara_tb/dut/i_ara_soc/i_ariane/commit_stage_i/*
+add wave -noupdate -group CVA6 -group commit_stage /ara_tb/dut/i_ara_soc/i_system/i_ariane/commit_stage_i/*
 
-add wave -noupdate -group CVA6 -group csr_file /ara_tb/dut/i_ara_soc/i_ariane/csr_regfile_i/*
+add wave -noupdate -group CVA6 -group csr_file /ara_tb/dut/i_ara_soc/i_system/i_ariane/csr_regfile_i/*
 
-add wave -noupdate -group CVA6 -group controller /ara_tb/dut/i_ara_soc/i_ariane/controller_i/*
+add wave -noupdate -group CVA6 -group controller /ara_tb/dut/i_ara_soc/i_system/i_ariane/controller_i/*
 
-add wave -noupdate -group CVA6 -group wt_dcache /ara_tb/dut/i_ara_soc/i_ariane/i_cache_subsystem/i_wt_dcache/*
-add wave -noupdate -group CVA6 -group wt_dcache -group miss_handler /ara_tb/dut/i_ara_soc/i_ariane/i_cache_subsystem/i_wt_dcache/i_wt_dcache_missunit/*
+add wave -noupdate -group CVA6 -group wt_dcache /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_cache_subsystem/i_wt_dcache/*
+add wave -noupdate -group CVA6 -group wt_dcache -group miss_handler /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_cache_subsystem/i_wt_dcache/i_wt_dcache_missunit/*
 
-add wave -noupdate -group CVA6 -group wt_dcache -group load {/ara_tb/dut/i_ara_soc/i_ariane/i_cache_subsystem/i_wt_dcache/gen_rd_ports[0]/i_wt_dcache_ctrl/*}
-add wave -noupdate -group CVA6 -group wt_dcache -group ptw {/ara_tb/dut/i_ara_soc/i_ariane/i_cache_subsystem/i_wt_dcache/gen_rd_ports[1]/i_wt_dcache_ctrl/*}
+add wave -noupdate -group CVA6 -group wt_dcache -group load {/ara_tb/dut/i_ara_soc/i_system/i_ariane/i_cache_subsystem/i_wt_dcache/gen_rd_ports[0]/i_wt_dcache_ctrl/*}
+add wave -noupdate -group CVA6 -group wt_dcache -group ptw {/ara_tb/dut/i_ara_soc/i_system/i_ariane/i_cache_subsystem/i_wt_dcache/gen_rd_ports[1]/i_wt_dcache_ctrl/*}
 
-add wave -noupdate -group CVA6 -group perf_counters /ara_tb/dut/i_ara_soc/i_ariane/i_perf_counters/*
+add wave -noupdate -group CVA6 -group perf_counters /ara_tb/dut/i_ara_soc/i_system/i_ariane/i_perf_counters/*

--- a/hardware/scripts/wave_lane.tcl
+++ b/hardware/scripts/wave_lane.tcl
@@ -4,37 +4,37 @@
 #
 # Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
-add wave -noupdate -group Ara -group Lane[$1] -group sequencer /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_lane_sequencer/*
+add wave -noupdate -group Ara -group Lane[$1] -group sequencer /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_lane_sequencer/*
 
-add wave -noupdate -group Ara -group Lane[$1] -group operand_requester /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_requester/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_requester /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_requester/*
 for {set requester 0}  {$requester < [examine -radix dec ara_pkg::NrOperandQueues]} {incr requester} {
-    add wave -noupdate -group Ara -group Lane[$1] -group operand_requester -group requester[$requester] /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_requester/gen_operand_requester[$requester]/*
+    add wave -noupdate -group Ara -group Lane[$1] -group operand_requester -group requester[$requester] /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_requester/gen_operand_requester[$requester]/*
 }
 
-add wave -noupdate -group Ara -group Lane[$1] -group vector_regfile /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vrf/*
+add wave -noupdate -group Ara -group Lane[$1] -group vector_regfile /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vrf/*
 
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group alu_a /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_alu_a/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group alu_b /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_alu_b/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_a /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_a/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_b /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_b/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_c /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_c/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_c /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_c/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group st_mask_a /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_st_mask_a/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group slide_addrgen_a /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_slide_addrgen_a/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mask_b /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mask_b/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mask_m /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mask_m/*
-add wave -noupdate -group Ara -group Lane[$1] -group operand_queues /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group alu_a /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_alu_a/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group alu_b /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_alu_b/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_a /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_a/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_b /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_b/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_c /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_c/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_c /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_c/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group st_mask_a /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_st_mask_a/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group slide_addrgen_a /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_slide_addrgen_a/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mask_b /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mask_b/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mask_m /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mask_m/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/*
 
-add wave -noupdate -group Ara -group Lane[$1] -group valu -group simd_alu /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_valu/i_simd_alu/*
-add wave -noupdate -group Ara -group Lane[$1] -group valu /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_valu/*
+add wave -noupdate -group Ara -group Lane[$1] -group valu -group simd_alu /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_valu/i_simd_alu/*
+add wave -noupdate -group Ara -group Lane[$1] -group valu /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_valu/*
 
-add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew64 /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew64/*
-add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew32 /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew32/*
-add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew16 /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew16/*
-add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew8 /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew8/*
-add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vdiv /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_div/*
-add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vdiv -group serdiv /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_div/i_serdiv/*
-add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group fpnew /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/fpu_gen/i_fpnew_bulk/*
-add wave -noupdate -group Ara -group Lane[$1] -group vmfpu /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew64 /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew64/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew32 /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew32/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew16 /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew16/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew8 /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew8/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vdiv /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_div/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vdiv -group serdiv /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_div/i_serdiv/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group fpnew /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/fpu_gen/i_fpnew_bulk/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/*
 
-add wave -noupdate -group Ara -group Lane[$1] /ara_tb/dut/i_ara_soc/i_ara/gen_lanes[$1]/i_lane/*
+add wave -noupdate -group Ara -group Lane[$1] /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/*

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -8,14 +8,14 @@
 
 module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     // RVV Parameters
-    parameter  int           unsigned NrLanes      = 0, // Number of parallel vector lanes.
+    parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
     // AXI Interface
     parameter  int           unsigned AxiDataWidth = 32*NrLanes,
     parameter  int           unsigned AxiAddrWidth = 64,
     parameter  int           unsigned AxiUserWidth = 1,
-    parameter  int           unsigned AxiIdWidth   = 6,
+    parameter  int           unsigned AxiIdWidth   = 5,
     // Main memory
     parameter  int           unsigned L2NumWords   = 2**19,
     // Dependant parameters. DO NOT CHANGE!
@@ -43,11 +43,15 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     input  logic        uart_pslverr_i
   );
 
+  `include "axi/assign.svh"
+  `include "axi/typedef.svh"
+  `include "common_cells/registers.svh"
+
   //////////////////////
   //  Memory Regions  //
   //////////////////////
 
-  localparam NrAXIMasters = 2; // Actually masters, but slaves on the crossbar
+  localparam NrAXIMasters = 1; // Actually masters, but slaves on the crossbar
 
   typedef enum int unsigned {
     L2MEM = 0,
@@ -72,9 +76,6 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   //  AXI  //
   ///////////
 
-  `include "axi/assign.svh"
-  `include "axi/typedef.svh"
-
   // Ariane's AXI port data width
   localparam AxiNarrowDataWidth = 64;
   localparam AxiNarrowStrbWidth = AxiNarrowDataWidth / 8;
@@ -85,72 +86,30 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   localparam AxiSocIdWidth  = AxiIdWidth - $clog2(NrAXIMasters);
   localparam AxiCoreIdWidth = AxiSocIdWidth - 1;
 
-  // AXI Typedefs
-
-  // These are used for ara_soc's AXI interface
-  `AXI_TYPEDEF_AR_CHAN_T(ar_chan_t, axi_addr_t, axi_id_t, axi_user_t)
-  `AXI_TYPEDEF_R_CHAN_T(r_chan_t, axi_data_t, axi_id_t, axi_user_t)
-  `AXI_TYPEDEF_AW_CHAN_T(aw_chan_t, axi_addr_t, axi_id_t, axi_user_t)
-  `AXI_TYPEDEF_W_CHAN_T(w_chan_t, axi_data_t, axi_strb_t, axi_user_t)
-  `AXI_TYPEDEF_B_CHAN_T(b_chan_t, axi_id_t, axi_user_t)
-  `AXI_TYPEDEF_REQ_T(axi_req_t, aw_chan_t, w_chan_t, ar_chan_t)
-  `AXI_TYPEDEF_RESP_T(axi_resp_t, b_chan_t, r_chan_t)
-
   // Internal types
   typedef logic [AxiNarrowDataWidth-1:0] axi_narrow_data_t;
   typedef logic [AxiNarrowStrbWidth-1:0] axi_narrow_strb_t;
   typedef logic [AxiSocIdWidth-1:0] axi_soc_id_t;
   typedef logic [AxiCoreIdWidth-1:0] axi_core_id_t;
 
-  `AXI_TYPEDEF_W_CHAN_T(axi_wide_w_chan_t, axi_data_t, axi_strb_t, axi_user_t)
-  `AXI_TYPEDEF_W_CHAN_T(axi_narrow_w_chan_t, axi_narrow_data_t, axi_narrow_strb_t, axi_user_t)
-
-  `AXI_TYPEDEF_AR_CHAN_T(axi_soc_ar_chan_t, axi_addr_t, axi_soc_id_t, axi_user_t)
-  `AXI_TYPEDEF_R_CHAN_T(axi_soc_wide_r_chan_t, axi_data_t, axi_soc_id_t, axi_user_t)
-  `AXI_TYPEDEF_R_CHAN_T(axi_soc_narrow_r_chan_t, axi_narrow_data_t, axi_soc_id_t, axi_user_t)
-  `AXI_TYPEDEF_AW_CHAN_T(axi_soc_aw_chan_t, axi_addr_t, axi_soc_id_t, axi_user_t)
-  `AXI_TYPEDEF_B_CHAN_T(axi_soc_b_chan_t, axi_soc_id_t, axi_user_t)
-  `AXI_TYPEDEF_REQ_T(axi_soc_wide_req_t, axi_soc_aw_chan_t, axi_wide_w_chan_t, axi_soc_ar_chan_t)
-  `AXI_TYPEDEF_RESP_T(axi_soc_wide_resp_t, axi_soc_b_chan_t, axi_soc_wide_r_chan_t)
-  `AXI_TYPEDEF_REQ_T(axi_soc_narrow_req_t, axi_soc_aw_chan_t, axi_narrow_w_chan_t,
-    axi_soc_ar_chan_t)
-  `AXI_TYPEDEF_RESP_T(axi_soc_narrow_resp_t, axi_soc_b_chan_t, axi_soc_narrow_r_chan_t)
-
-  `AXI_TYPEDEF_AR_CHAN_T(axi_core_ar_chan_t, axi_addr_t, axi_core_id_t, axi_user_t)
-  `AXI_TYPEDEF_R_CHAN_T(axi_core_wide_r_chan_t, axi_data_t, axi_core_id_t, axi_user_t)
-  `AXI_TYPEDEF_R_CHAN_T(axi_core_narrow_r_chan_t, axi_narrow_data_t, axi_core_id_t, axi_user_t)
-  `AXI_TYPEDEF_AW_CHAN_T(axi_core_aw_chan_t, axi_addr_t, axi_core_id_t, axi_user_t)
-  `AXI_TYPEDEF_B_CHAN_T(axi_core_b_chan_t, axi_core_id_t, axi_user_t)
-  `AXI_TYPEDEF_REQ_T(axi_core_wide_req_t, axi_core_aw_chan_t, axi_wide_w_chan_t, axi_core_ar_chan_t)
-  `AXI_TYPEDEF_RESP_T(axi_core_wide_resp_t, axi_core_b_chan_t, axi_core_wide_r_chan_t)
-  `AXI_TYPEDEF_REQ_T(axi_core_narrow_req_t, axi_core_aw_chan_t, axi_narrow_w_chan_t,
-    axi_core_ar_chan_t)
-  `AXI_TYPEDEF_RESP_T(axi_core_narrow_resp_t, axi_core_b_chan_t, axi_core_narrow_r_chan_t)
-
-  `AXI_LITE_TYPEDEF_AW_CHAN_T(axi_lite_soc_narrow_aw_t, axi_addr_t)
-  `AXI_LITE_TYPEDEF_W_CHAN_T(axi_lite_soc_narrow_w_t, axi_narrow_data_t, axi_narrow_strb_t)
-  `AXI_LITE_TYPEDEF_B_CHAN_T(axi_lite_soc_narrow_b_t)
-  `AXI_LITE_TYPEDEF_AR_CHAN_T(axi_lite_soc_narrow_ar_t, axi_addr_t)
-  `AXI_LITE_TYPEDEF_R_CHAN_T(axi_lite_soc_narrow_r_t, axi_narrow_data_t)
-  `AXI_LITE_TYPEDEF_REQ_T(axi_lite_soc_narrow_req_t, axi_lite_soc_narrow_aw_t,
-    axi_lite_soc_narrow_w_t, axi_lite_soc_narrow_ar_t)
-  `AXI_LITE_TYPEDEF_RESP_T(axi_lite_soc_narrow_resp_t, axi_lite_soc_narrow_b_t,
-    axi_lite_soc_narrow_r_t)
+  // AXI Typedefs
+  `AXI_TYPEDEF_ALL(system, axi_addr_t, axi_id_t, axi_data_t, axi_strb_t, axi_user_t)
+  `AXI_TYPEDEF_ALL(ara_axi, axi_addr_t, axi_core_id_t, axi_data_t, axi_strb_t, axi_user_t)
+  `AXI_TYPEDEF_ALL(ariane_axi, axi_addr_t, axi_core_id_t, axi_narrow_data_t, axi_narrow_strb_t,
+    axi_user_t)
+  `AXI_TYPEDEF_ALL(soc_narrow, axi_addr_t, axi_soc_id_t, axi_narrow_data_t, axi_narrow_strb_t,
+    axi_user_t)
+  `AXI_TYPEDEF_ALL(soc_wide, axi_addr_t, axi_soc_id_t, axi_data_t, axi_strb_t, axi_user_t)
+  `AXI_LITE_TYPEDEF_ALL(soc_narrow_lite, axi_addr_t, axi_narrow_data_t, axi_narrow_strb_t)
 
   // Buses
-  axi_core_narrow_req_t  ariane_narrow_axi_req;
-  axi_core_narrow_resp_t ariane_narrow_axi_resp;
-  axi_core_wide_req_t    ariane_axi_req;
-  axi_core_wide_resp_t   ariane_axi_resp;
-  axi_core_wide_req_t    ara_axi_req;
-  axi_core_wide_resp_t   ara_axi_resp;
-  axi_core_wide_req_t    ara_axi_req_inval;
-  axi_core_wide_resp_t   ara_axi_resp_inval;
+  system_req_t  system_axi_req;
+  system_resp_t system_axi_resp;
 
-  axi_soc_wide_req_t    [NrAXISlaves-1:0] periph_wide_axi_req;
-  axi_soc_wide_resp_t   [NrAXISlaves-1:0] periph_wide_axi_resp;
-  axi_soc_narrow_req_t  [NrAXISlaves-1:0] periph_narrow_axi_req;
-  axi_soc_narrow_resp_t [NrAXISlaves-1:0] periph_narrow_axi_resp;
+  soc_wide_req_t    [NrAXISlaves-1:0] periph_wide_axi_req;
+  soc_wide_resp_t   [NrAXISlaves-1:0] periph_wide_axi_resp;
+  soc_narrow_req_t  [NrAXISlaves-1:0] periph_narrow_axi_req;
+  soc_narrow_resp_t [NrAXISlaves-1:0] periph_narrow_axi_resp;
 
   ////////////////
   //  Crossbar  //
@@ -163,8 +122,8 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     MaxSlvTrans       : 4,
     FallThrough       : 1'b0,
     LatencyMode       : axi_pkg::CUT_MST_PORTS,
-    AxiIdWidthSlvPorts: AxiCoreIdWidth,
-    AxiIdUsedSlvPorts : AxiCoreIdWidth,
+    AxiIdWidthSlvPorts: AxiSocIdWidth,
+    AxiIdUsedSlvPorts : AxiSocIdWidth,
     UniqueIds         : 1'b0,
     AxiAddrWidth      : AxiAddrWidth,
     AxiDataWidth      : AxiWideDataWidth,
@@ -180,48 +139,46 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
 
   axi_xbar #(
     .Cfg          (XBarCfg                ),
-    .slv_aw_chan_t(axi_core_aw_chan_t     ),
-    .mst_aw_chan_t(axi_soc_aw_chan_t      ),
-    .w_chan_t     (axi_wide_w_chan_t      ),
-    .slv_b_chan_t (axi_core_b_chan_t      ),
-    .mst_b_chan_t (axi_soc_b_chan_t       ),
-    .slv_ar_chan_t(axi_core_ar_chan_t     ),
-    .mst_ar_chan_t(axi_soc_ar_chan_t      ),
-    .slv_r_chan_t (axi_core_wide_r_chan_t ),
-    .mst_r_chan_t (axi_soc_wide_r_chan_t  ),
-    .slv_req_t    (axi_core_wide_req_t    ),
-    .slv_resp_t   (axi_core_wide_resp_t   ),
-    .mst_req_t    (axi_soc_wide_req_t     ),
-    .mst_resp_t   (axi_soc_wide_resp_t    ),
+    .slv_aw_chan_t(system_aw_chan_t       ),
+    .mst_aw_chan_t(soc_wide_aw_chan_t     ),
+    .w_chan_t     (system_w_chan_t        ),
+    .slv_b_chan_t (system_b_chan_t        ),
+    .mst_b_chan_t (soc_wide_b_chan_t      ),
+    .slv_ar_chan_t(system_ar_chan_t       ),
+    .mst_ar_chan_t(soc_wide_ar_chan_t     ),
+    .slv_r_chan_t (system_r_chan_t        ),
+    .mst_r_chan_t (soc_wide_r_chan_t      ),
+    .slv_req_t    (system_req_t           ),
+    .slv_resp_t   (system_resp_t          ),
+    .mst_req_t    (soc_wide_req_t         ),
+    .mst_resp_t   (soc_wide_resp_t        ),
     .rule_t       (axi_pkg::xbar_rule_64_t)
   ) i_soc_xbar (
-    .clk_i                (clk_i                                ),
-    .rst_ni               (rst_ni                               ),
-    .test_i               (1'b0                                 ),
-    .slv_ports_req_i      ({ariane_axi_req, ara_axi_req_inval}  ),
-    .slv_ports_resp_o     ({ariane_axi_resp, ara_axi_resp_inval}),
-    .mst_ports_req_o      (periph_wide_axi_req                  ),
-    .mst_ports_resp_i     (periph_wide_axi_resp                 ),
-    .addr_map_i           (routing_rules                        ),
-    .en_default_mst_port_i('0                                   ),
-    .default_mst_port_i   ('0                                   )
+    .clk_i                (clk_i               ),
+    .rst_ni               (rst_ni              ),
+    .test_i               (1'b0                ),
+    .slv_ports_req_i      (system_axi_req      ),
+    .slv_ports_resp_o     (system_axi_resp     ),
+    .mst_ports_req_o      (periph_wide_axi_req ),
+    .mst_ports_resp_i     (periph_wide_axi_resp),
+    .addr_map_i           (routing_rules       ),
+    .en_default_mst_port_i('0                  ),
+    .default_mst_port_i   ('0                  )
   );
 
   //////////
   //  L2  //
   //////////
 
-  `include "common_cells/registers.svh"
-
   // The L2 memory does not support atomics
 
-  axi_soc_wide_req_t  l2mem_wide_axi_req_wo_atomics;
-  axi_soc_wide_resp_t l2mem_wide_axi_resp_wo_atomics;
+  soc_wide_req_t  l2mem_wide_axi_req_wo_atomics;
+  soc_wide_resp_t l2mem_wide_axi_resp_wo_atomics;
   axi_atop_filter #(
-    .AxiIdWidth     (AxiSocIdWidth      ),
-    .AxiMaxWriteTxns(4                  ),
-    .req_t          (axi_soc_wide_req_t ),
-    .resp_t         (axi_soc_wide_resp_t)
+    .AxiIdWidth     (AxiSocIdWidth  ),
+    .AxiMaxWriteTxns(4              ),
+    .req_t          (soc_wide_req_t ),
+    .resp_t         (soc_wide_resp_t)
   ) i_l2mem_atop_filter (
     .clk_i     (clk_i                         ),
     .rst_ni    (rst_ni                        ),
@@ -240,12 +197,12 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   logic                      l2_rvalid;
 
   axi_to_mem #(
-    .AddrWidth (AxiAddrWidth       ),
-    .DataWidth (AxiDataWidth       ),
-    .IdWidth   (AxiSocIdWidth      ),
-    .NumBanks  (1                  ),
-    .axi_req_t (axi_soc_wide_req_t ),
-    .axi_resp_t(axi_soc_wide_resp_t)
+    .AddrWidth (AxiAddrWidth   ),
+    .DataWidth (AxiDataWidth   ),
+    .IdWidth   (AxiSocIdWidth  ),
+    .NumBanks  (1              ),
+    .axi_req_t (soc_wide_req_t ),
+    .axi_resp_t(soc_wide_resp_t)
   ) i_axi_to_mem (
     .clk_i       (clk_i                         ),
     .rst_ni      (rst_ni                        ),
@@ -352,22 +309,22 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   );
 
   axi_dw_converter #(
-    .AxiSlvPortDataWidth(AxiWideDataWidth       ),
-    .AxiMstPortDataWidth(AxiNarrowDataWidth     ),
-    .AxiAddrWidth       (AxiAddrWidth           ),
-    .AxiIdWidth         (AxiSocIdWidth          ),
-    .AxiMaxReads        (2                      ),
-    .ar_chan_t          (axi_soc_ar_chan_t      ),
-    .mst_r_chan_t       (axi_soc_narrow_r_chan_t),
-    .slv_r_chan_t       (axi_soc_wide_r_chan_t  ),
-    .aw_chan_t          (axi_soc_aw_chan_t      ),
-    .b_chan_t           (axi_soc_b_chan_t       ),
-    .mst_w_chan_t       (axi_narrow_w_chan_t    ),
-    .slv_w_chan_t       (axi_wide_w_chan_t      ),
-    .axi_mst_req_t      (axi_soc_narrow_req_t   ),
-    .axi_mst_resp_t     (axi_soc_narrow_resp_t  ),
-    .axi_slv_req_t      (axi_soc_wide_req_t     ),
-    .axi_slv_resp_t     (axi_soc_wide_resp_t    )
+    .AxiSlvPortDataWidth(AxiWideDataWidth     ),
+    .AxiMstPortDataWidth(AxiNarrowDataWidth   ),
+    .AxiAddrWidth       (AxiAddrWidth         ),
+    .AxiIdWidth         (AxiSocIdWidth        ),
+    .AxiMaxReads        (2                    ),
+    .ar_chan_t          (soc_wide_ar_chan_t   ),
+    .mst_r_chan_t       (soc_narrow_r_chan_t  ),
+    .slv_r_chan_t       (soc_wide_r_chan_t    ),
+    .aw_chan_t          (soc_narrow_aw_chan_t ),
+    .b_chan_t           (soc_wide_b_chan_t    ),
+    .mst_w_chan_t       (soc_narrow_w_chan_t  ),
+    .slv_w_chan_t       (soc_wide_w_chan_t    ),
+    .axi_mst_req_t      (soc_narrow_req_t     ),
+    .axi_mst_resp_t     (soc_narrow_resp_t    ),
+    .axi_slv_req_t      (soc_wide_req_t       ),
+    .axi_slv_resp_t     (soc_wide_resp_t      )
   ) i_axi_slave_uart_dwc (
     .clk_i     (clk_i                       ),
     .rst_ni    (rst_ni                      ),
@@ -381,21 +338,21 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   //  Control registers  //
   /////////////////////////
 
-  axi_lite_soc_narrow_req_t  axi_lite_ctrl_registers_req;
-  axi_lite_soc_narrow_resp_t axi_lite_ctrl_registers_resp;
+  soc_narrow_lite_req_t  axi_lite_ctrl_registers_req;
+  soc_narrow_lite_resp_t axi_lite_ctrl_registers_resp;
 
   axi_to_axi_lite #(
-    .AxiAddrWidth   (AxiAddrWidth              ),
-    .AxiDataWidth   (AxiNarrowDataWidth        ),
-    .AxiIdWidth     (AxiSocIdWidth             ),
-    .AxiUserWidth   (AxiUserWidth              ),
-    .AxiMaxReadTxns (1                         ),
-    .AxiMaxWriteTxns(1                         ),
-    .FallThrough    (1'b0                      ),
-    .full_req_t     (axi_soc_narrow_req_t      ),
-    .full_resp_t    (axi_soc_narrow_resp_t     ),
-    .lite_req_t     (axi_lite_soc_narrow_req_t ),
-    .lite_resp_t    (axi_lite_soc_narrow_resp_t)
+    .AxiAddrWidth   (AxiAddrWidth          ),
+    .AxiDataWidth   (AxiNarrowDataWidth    ),
+    .AxiIdWidth     (AxiSocIdWidth         ),
+    .AxiUserWidth   (AxiUserWidth          ),
+    .AxiMaxReadTxns (1                     ),
+    .AxiMaxWriteTxns(1                     ),
+    .FallThrough    (1'b0                  ),
+    .full_req_t     (soc_narrow_req_t      ),
+    .full_resp_t    (soc_narrow_resp_t     ),
+    .lite_req_t     (soc_narrow_lite_req_t ),
+    .lite_resp_t    (soc_narrow_lite_resp_t)
   ) i_axi_to_axi_lite (
     .clk_i     (clk_i                        ),
     .rst_ni    (rst_ni                       ),
@@ -407,12 +364,12 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   );
 
   ctrl_registers #(
-    .DRAMBaseAddr   (DRAMBase                  ),
-    .DRAMLength     (DRAMLength                ),
-    .DataWidth      (AxiNarrowDataWidth        ),
-    .AddrWidth      (AxiAddrWidth              ),
-    .axi_lite_req_t (axi_lite_soc_narrow_req_t ),
-    .axi_lite_resp_t(axi_lite_soc_narrow_resp_t)
+    .DRAMBaseAddr   (DRAMBase              ),
+    .DRAMLength     (DRAMLength            ),
+    .DataWidth      (AxiNarrowDataWidth    ),
+    .AddrWidth      (AxiAddrWidth          ),
+    .axi_lite_req_t (soc_narrow_lite_req_t ),
+    .axi_lite_resp_t(soc_narrow_lite_resp_t)
   ) i_ctrl_registers (
     .clk_i                (clk_i                       ),
     .rst_ni               (rst_ni                      ),
@@ -424,22 +381,22 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   );
 
   axi_dw_converter #(
-    .AxiSlvPortDataWidth(AxiWideDataWidth       ),
-    .AxiMstPortDataWidth(AxiNarrowDataWidth     ),
-    .AxiAddrWidth       (AxiAddrWidth           ),
-    .AxiIdWidth         (AxiSocIdWidth          ),
-    .AxiMaxReads        (2                      ),
-    .ar_chan_t          (axi_soc_ar_chan_t      ),
-    .mst_r_chan_t       (axi_soc_narrow_r_chan_t),
-    .slv_r_chan_t       (axi_soc_wide_r_chan_t  ),
-    .aw_chan_t          (axi_soc_aw_chan_t      ),
-    .b_chan_t           (axi_soc_b_chan_t       ),
-    .mst_w_chan_t       (axi_narrow_w_chan_t    ),
-    .slv_w_chan_t       (axi_wide_w_chan_t      ),
-    .axi_mst_req_t      (axi_soc_narrow_req_t   ),
-    .axi_mst_resp_t     (axi_soc_narrow_resp_t  ),
-    .axi_slv_req_t      (axi_soc_wide_req_t     ),
-    .axi_slv_resp_t     (axi_soc_wide_resp_t    )
+    .AxiSlvPortDataWidth(AxiWideDataWidth    ),
+    .AxiMstPortDataWidth(AxiNarrowDataWidth  ),
+    .AxiAddrWidth       (AxiAddrWidth        ),
+    .AxiIdWidth         (AxiSocIdWidth       ),
+    .AxiMaxReads        (2                   ),
+    .ar_chan_t          (soc_wide_ar_chan_t  ),
+    .mst_r_chan_t       (soc_narrow_r_chan_t ),
+    .slv_r_chan_t       (soc_wide_r_chan_t   ),
+    .aw_chan_t          (soc_narrow_aw_chan_t),
+    .b_chan_t           (soc_narrow_b_chan_t ),
+    .mst_w_chan_t       (soc_narrow_w_chan_t ),
+    .slv_w_chan_t       (soc_wide_w_chan_t   ),
+    .axi_mst_req_t      (soc_narrow_req_t    ),
+    .axi_mst_resp_t     (soc_narrow_resp_t   ),
+    .axi_slv_req_t      (soc_wide_req_t      ),
+    .axi_slv_resp_t     (soc_wide_resp_t     )
   ) i_axi_slave_ctrl_dwc (
     .clk_i     (clk_i                       ),
     .rst_ni    (rst_ni                      ),
@@ -449,12 +406,9 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     .mst_resp_i(periph_narrow_axi_resp[CTRL])
   );
 
-  //////////////////////
-  //  Ara and Ariane  //
-  //////////////////////
-
-  import ariane_pkg::accelerator_req_t;
-  import ariane_pkg::accelerator_resp_t;
+  //////////////
+  //  System  //
+  //////////////
 
   localparam ariane_pkg::ariane_cfg_t ArianeAraConfig = '{
     RASDepth             : 2,
@@ -480,116 +434,44 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     NrPMPEntries         : 0
   };
 
-  // Accelerator ports
-  accelerator_req_t                     acc_req;
-  logic                                 acc_req_valid;
-  logic                                 acc_req_ready;
-  accelerator_resp_t                    acc_resp;
-  logic                                 acc_resp_valid;
-  logic                                 acc_resp_ready;
-  logic                                 acc_cons_en;
-  logic              [AxiAddrWidth-1:0] inval_addr;
-  logic                                 inval_valid;
-  logic                                 inval_ready;
-
-  ariane #(
-    .ArianeCfg(ArianeAraConfig)
-  ) i_ariane (
-    .clk_i            (clk_i                 ),
-    .rst_ni           (rst_ni                ),
-    .boot_addr_i      (DRAMBase              ), // start fetching from DRAM
-    .hart_id_i        ('0                    ),
-    .irq_i            ('0                    ),
-    .ipi_i            ('0                    ),
-    .time_irq_i       ('0                    ),
-    .debug_req_i      ('0                    ),
-    .axi_req_o        (ariane_narrow_axi_req ),
-    .axi_resp_i       (ariane_narrow_axi_resp),
-    // Accelerator ports
-    .acc_req_o        (acc_req               ),
-    .acc_req_valid_o  (acc_req_valid         ),
-    .acc_req_ready_i  (acc_req_ready         ),
-    .acc_resp_i       (acc_resp              ),
-    .acc_resp_valid_i (acc_resp_valid        ),
-    .acc_resp_ready_o (acc_resp_ready        ),
-    .acc_cons_en_o    (acc_cons_en           ),
-    .inval_addr_i     (inval_addr            ),
-    .inval_valid_i    (inval_valid           ),
-    .inval_ready_o    (inval_ready           )
-  );
-
-  axi_dw_converter #(
-    .AxiSlvPortDataWidth(AxiNarrowDataWidth      ),
-    .AxiMstPortDataWidth(AxiWideDataWidth        ),
-    .AxiAddrWidth       (AxiAddrWidth            ),
-    .AxiIdWidth         (AxiCoreIdWidth          ),
-    .AxiMaxReads        (4                       ),
-    .ar_chan_t          (axi_core_ar_chan_t      ),
-    .mst_r_chan_t       (axi_core_wide_r_chan_t  ),
-    .slv_r_chan_t       (axi_core_narrow_r_chan_t),
-    .aw_chan_t          (axi_core_aw_chan_t      ),
-    .b_chan_t           (axi_core_b_chan_t       ),
-    .mst_w_chan_t       (axi_wide_w_chan_t       ),
-    .slv_w_chan_t       (axi_narrow_w_chan_t     ),
-    .axi_mst_req_t      (axi_core_wide_req_t     ),
-    .axi_mst_resp_t     (axi_core_wide_resp_t    ),
-    .axi_slv_req_t      (axi_core_narrow_req_t   ),
-    .axi_slv_resp_t     (axi_core_narrow_resp_t  )
-  ) i_ariane_axi_dwc (
-    .clk_i     (clk_i                 ),
-    .rst_ni    (rst_ni                ),
-    .slv_req_i (ariane_narrow_axi_req ),
-    .slv_resp_o(ariane_narrow_axi_resp),
-    .mst_req_o (ariane_axi_req        ),
-    .mst_resp_i(ariane_axi_resp       )
-  );
-
-  axi_inval_filter #(
-    .MaxTxns    (4                              ),
-    .AddrWidth  (AxiAddrWidth                   ),
-    .L1LineWidth(ariane_pkg::DCACHE_LINE_WIDTH/8),
-    .aw_chan_t  (axi_core_aw_chan_t             ),
-    .req_t      (axi_core_wide_req_t            ),
-    .resp_t     (axi_core_wide_resp_t           )
-  ) i_axi_inval_filter (
-    .clk_i        (clk_i             ),
-    .rst_ni       (rst_ni            ),
-    .en_i         (acc_cons_en       ),
-    .slv_req_i    (ara_axi_req       ),
-    .slv_resp_o   (ara_axi_resp      ),
-    .mst_req_o    (ara_axi_req_inval ),
-    .mst_resp_i   (ara_axi_resp_inval),
-    .inval_addr_o (inval_addr        ),
-    .inval_valid_o(inval_valid       ),
-    .inval_ready_i(inval_ready       )
-  );
-
-  ara #(
-    .NrLanes     (NrLanes               ),
-    .FPUSupport  (FPUSupport            ),
-    .AxiDataWidth(AxiWideDataWidth      ),
-    .AxiAddrWidth(AxiAddrWidth          ),
-    .axi_ar_t    (axi_core_ar_chan_t    ),
-    .axi_r_t     (axi_core_wide_r_chan_t),
-    .axi_aw_t    (axi_core_aw_chan_t    ),
-    .axi_w_t     (axi_wide_w_chan_t     ),
-    .axi_b_t     (axi_core_b_chan_t     ),
-    .axi_req_t   (axi_core_wide_req_t   ),
-    .axi_resp_t  (axi_core_wide_resp_t  )
-  ) i_ara (
-    .clk_i           (clk_i         ),
-    .rst_ni          (rst_ni        ),
-    .scan_enable_i   (scan_enable_i ),
-    .scan_data_i     (1'b0          ),
-    .scan_data_o     (/* Unused */  ),
-    .acc_req_i       (acc_req       ),
-    .acc_req_valid_i (acc_req_valid ),
-    .acc_req_ready_o (acc_req_ready ),
-    .acc_resp_o      (acc_resp      ),
-    .acc_resp_valid_o(acc_resp_valid),
-    .acc_resp_ready_i(acc_resp_ready),
-    .axi_req_o       (ara_axi_req   ),
-    .axi_resp_i      (ara_axi_resp  )
+  ara_system #(
+    .NrLanes           (NrLanes              ),
+    .FPUSupport        (FPUSupport           ),
+    .ArianeCfg         (ArianeAraConfig      ),
+    .AxiAddrWidth      (AxiAddrWidth         ),
+    .AxiIdWidth        (AxiCoreIdWidth       ),
+    .AxiNarrowDataWidth(AxiNarrowDataWidth   ),
+    .AxiWideDataWidth  (AxiDataWidth         ),
+    .ara_axi_ar_t      (ara_axi_ar_chan_t    ),
+    .ara_axi_aw_t      (ara_axi_aw_chan_t    ),
+    .ara_axi_b_t       (ara_axi_b_chan_t     ),
+    .ara_axi_r_t       (ara_axi_r_chan_t     ),
+    .ara_axi_w_t       (ara_axi_w_chan_t     ),
+    .ara_axi_req_t     (ara_axi_req_t        ),
+    .ara_axi_resp_t    (ara_axi_resp_t       ),
+    .ariane_axi_ar_t   (ariane_axi_ar_chan_t ),
+    .ariane_axi_aw_t   (ariane_axi_aw_chan_t ),
+    .ariane_axi_b_t    (ariane_axi_b_chan_t  ),
+    .ariane_axi_r_t    (ariane_axi_r_chan_t  ),
+    .ariane_axi_w_t    (ariane_axi_w_chan_t  ),
+    .ariane_axi_req_t  (ariane_axi_req_t     ),
+    .ariane_axi_resp_t (ariane_axi_resp_t    ),
+    .system_axi_ar_t   (system_ar_chan_t     ),
+    .system_axi_aw_t   (system_aw_chan_t     ),
+    .system_axi_b_t    (system_b_chan_t      ),
+    .system_axi_r_t    (system_r_chan_t      ),
+    .system_axi_w_t    (system_w_chan_t      ),
+    .system_axi_req_t  (system_req_t         ),
+    .system_axi_resp_t (system_resp_t        )
+  ) i_system (
+    .clk_i        (clk_i            ),
+    .rst_ni       (rst_ni           ),
+    .boot_addr_i  (DRAMBase         ), // start fetching from DRAM
+    .scan_enable_i(1'b0             ),
+    .scan_data_i  (1'b0             ),
+    .scan_data_o  (/* Unconnected */),
+    .axi_req_o    (system_axi_req   ),
+    .axi_resp_i   (system_axi_resp  )
   );
 
   //////////////////

--- a/hardware/src/ara_system.sv
+++ b/hardware/src/ara_system.sv
@@ -1,0 +1,212 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+// Description:
+// Ara's System, containing Ariane and Ara.
+
+module ara_system import axi_pkg::*; import ara_pkg::*; #(
+    // RVV Parameters
+    parameter int                      unsigned NrLanes            = 0,                               // Number of parallel vector lanes.
+    // Support for floating-point data types
+    parameter fpu_support_e                     FPUSupport         = FPUSupportHalfSingleDouble,
+    // Ariane configuration
+    parameter ariane_pkg::ariane_cfg_t          ArianeCfg          = ariane_pkg::ArianeDefaultConfig,
+    // AXI Interface
+    parameter int                      unsigned AxiAddrWidth       = 64,
+    parameter int                      unsigned AxiIdWidth         = 6,
+    parameter int                      unsigned AxiNarrowDataWidth = 64,
+    parameter int                      unsigned AxiWideDataWidth   = 64*NrLanes/2,
+    parameter type                              ariane_axi_ar_t    = logic,
+    parameter type                              ariane_axi_r_t     = logic,
+    parameter type                              ariane_axi_aw_t    = logic,
+    parameter type                              ariane_axi_w_t     = logic,
+    parameter type                              ariane_axi_b_t     = logic,
+    parameter type                              ariane_axi_req_t   = logic,
+    parameter type                              ariane_axi_resp_t  = logic,
+    parameter type                              ara_axi_ar_t       = logic,
+    parameter type                              ara_axi_r_t        = logic,
+    parameter type                              ara_axi_aw_t       = logic,
+    parameter type                              ara_axi_w_t        = logic,
+    parameter type                              ara_axi_b_t        = logic,
+    parameter type                              ara_axi_req_t      = logic,
+    parameter type                              ara_axi_resp_t     = logic,
+    parameter type                              system_axi_ar_t    = logic,
+    parameter type                              system_axi_r_t     = logic,
+    parameter type                              system_axi_aw_t    = logic,
+    parameter type                              system_axi_w_t     = logic,
+    parameter type                              system_axi_b_t     = logic,
+    parameter type                              system_axi_req_t   = logic,
+    parameter type                              system_axi_resp_t  = logic
+  ) (
+    input  logic                    clk_i,
+    input  logic                    rst_ni,
+    input  logic             [63:0] boot_addr_i,
+    // Scan chain
+    input  logic                    scan_enable_i,
+    input  logic                    scan_data_i,
+    output logic                    scan_data_o,
+    // AXI Interface
+    output system_axi_req_t         axi_req_o,
+    input  system_axi_resp_t        axi_resp_i
+  );
+
+  `include "axi/assign.svh"
+  `include "axi/typedef.svh"
+
+  ///////////
+  //  AXI  //
+  ///////////
+
+  ariane_axi_req_t  ariane_narrow_axi_req;
+  ariane_axi_resp_t ariane_narrow_axi_resp;
+  ara_axi_req_t     ariane_axi_req, ara_axi_req_inval, ara_axi_req;
+  ara_axi_resp_t    ariane_axi_resp, ara_axi_resp_inval, ara_axi_resp;
+
+  //////////////////////
+  //  Ara and Ariane  //
+  //////////////////////
+
+  import ariane_pkg::accelerator_req_t;
+  import ariane_pkg::accelerator_resp_t;
+
+  // Accelerator ports
+  accelerator_req_t                     acc_req;
+  logic                                 acc_req_valid;
+  logic                                 acc_req_ready;
+  accelerator_resp_t                    acc_resp;
+  logic                                 acc_resp_valid;
+  logic                                 acc_resp_ready;
+  logic                                 acc_cons_en;
+  logic              [AxiAddrWidth-1:0] inval_addr;
+  logic                                 inval_valid;
+  logic                                 inval_ready;
+
+  ariane #(
+    .ArianeCfg(ArianeCfg)
+  ) i_ariane (
+    .clk_i            (clk_i                 ),
+    .rst_ni           (rst_ni                ),
+    .boot_addr_i      (boot_addr_i           ),
+    .hart_id_i        ('0                    ),
+    .irq_i            ('0                    ),
+    .ipi_i            ('0                    ),
+    .time_irq_i       ('0                    ),
+    .debug_req_i      ('0                    ),
+    .axi_req_o        (ariane_narrow_axi_req ),
+    .axi_resp_i       (ariane_narrow_axi_resp),
+    // Accelerator ports
+    .acc_req_o        (acc_req               ),
+    .acc_req_valid_o  (acc_req_valid         ),
+    .acc_req_ready_i  (acc_req_ready         ),
+    .acc_resp_i       (acc_resp              ),
+    .acc_resp_valid_i (acc_resp_valid        ),
+    .acc_resp_ready_o (acc_resp_ready        ),
+    .acc_cons_en_o    (acc_cons_en           ),
+    .inval_addr_i     (inval_addr            ),
+    .inval_valid_i    (inval_valid           ),
+    .inval_ready_o    (inval_ready           )
+  );
+
+  axi_dw_converter #(
+    .AxiSlvPortDataWidth(AxiNarrowDataWidth),
+    .AxiMstPortDataWidth(AxiWideDataWidth  ),
+    .AxiAddrWidth       (AxiAddrWidth      ),
+    .AxiIdWidth         (AxiIdWidth        ),
+    .AxiMaxReads        (2                 ),
+    .ar_chan_t          (ariane_axi_ar_t   ),
+    .mst_r_chan_t       (ara_axi_r_t       ),
+    .slv_r_chan_t       (ariane_axi_r_t    ),
+    .aw_chan_t          (ariane_axi_aw_t   ),
+    .b_chan_t           (ariane_axi_b_t    ),
+    .mst_w_chan_t       (ara_axi_w_t       ),
+    .slv_w_chan_t       (ariane_axi_w_t    ),
+    .axi_mst_req_t      (ara_axi_req_t     ),
+    .axi_mst_resp_t     (ara_axi_resp_t    ),
+    .axi_slv_req_t      (ariane_axi_req_t  ),
+    .axi_slv_resp_t     (ariane_axi_resp_t )
+  ) i_ariane_axi_dwc (
+    .clk_i     (clk_i                 ),
+    .rst_ni    (rst_ni                ),
+    .slv_req_i (ariane_narrow_axi_req ),
+    .slv_resp_o(ariane_narrow_axi_resp),
+    .mst_req_o (ariane_axi_req        ),
+    .mst_resp_i(ariane_axi_resp       )
+  );
+
+  axi_inval_filter #(
+    .MaxTxns    (4                              ),
+    .AddrWidth  (AxiAddrWidth                   ),
+    .L1LineWidth(ariane_pkg::DCACHE_LINE_WIDTH/8),
+    .aw_chan_t  (ara_axi_aw_t                   ),
+    .req_t      (ara_axi_req_t                  ),
+    .resp_t     (ara_axi_resp_t                 )
+  ) i_axi_inval_filter (
+    .clk_i        (clk_i             ),
+    .rst_ni       (rst_ni            ),
+    .en_i         (acc_cons_en       ),
+    .slv_req_i    (ara_axi_req       ),
+    .slv_resp_o   (ara_axi_resp      ),
+    .mst_req_o    (ara_axi_req_inval ),
+    .mst_resp_i   (ara_axi_resp_inval),
+    .inval_addr_o (inval_addr        ),
+    .inval_valid_o(inval_valid       ),
+    .inval_ready_i(inval_ready       )
+  );
+
+  ara #(
+    .NrLanes     (NrLanes         ),
+    .FPUSupport  (FPUSupport      ),
+    .AxiDataWidth(AxiWideDataWidth),
+    .AxiAddrWidth(AxiAddrWidth    ),
+    .axi_ar_t    (ara_axi_ar_t    ),
+    .axi_r_t     (ara_axi_r_t     ),
+    .axi_aw_t    (ara_axi_aw_t    ),
+    .axi_w_t     (ara_axi_w_t     ),
+    .axi_b_t     (ara_axi_b_t     ),
+    .axi_req_t   (ara_axi_req_t   ),
+    .axi_resp_t  (ara_axi_resp_t  )
+  ) i_ara (
+    .clk_i           (clk_i         ),
+    .rst_ni          (rst_ni        ),
+    .scan_enable_i   (scan_enable_i ),
+    .scan_data_i     (1'b0          ),
+    .scan_data_o     (/* Unused */  ),
+    .acc_req_i       (acc_req       ),
+    .acc_req_valid_i (acc_req_valid ),
+    .acc_req_ready_o (acc_req_ready ),
+    .acc_resp_o      (acc_resp      ),
+    .acc_resp_valid_o(acc_resp_valid),
+    .acc_resp_ready_i(acc_resp_ready),
+    .axi_req_o       (ara_axi_req   ),
+    .axi_resp_i      (ara_axi_resp  )
+  );
+
+  axi_mux #(
+    .SlvAxiIDWidth(AxiIdWidth       ),
+    .slv_ar_chan_t(ara_axi_ar_t     ),
+    .slv_aw_chan_t(ara_axi_aw_t     ),
+    .slv_b_chan_t (ara_axi_b_t      ),
+    .slv_r_chan_t (ara_axi_r_t      ),
+    .slv_req_t    (ara_axi_req_t    ),
+    .slv_resp_t   (ara_axi_resp_t   ),
+    .mst_ar_chan_t(system_axi_ar_t  ),
+    .mst_aw_chan_t(system_axi_aw_t  ),
+    .w_chan_t     (system_axi_w_t   ),
+    .mst_b_chan_t (system_axi_b_t   ),
+    .mst_r_chan_t (system_axi_r_t   ),
+    .mst_req_t    (system_axi_req_t ),
+    .mst_resp_t   (system_axi_resp_t),
+    .NoSlvPorts   (2                )
+  ) i_system_mux (
+    .clk_i      (clk_i                                ),
+    .rst_ni     (rst_ni                               ),
+    .test_i     (1'b0                                 ),
+    .slv_reqs_i ({ara_axi_req_inval, ariane_axi_req}  ),
+    .slv_resps_o({ara_axi_resp_inval, ariane_axi_resp}),
+    .mst_req_o  (axi_req_o                            ),
+    .mst_resp_i (axi_resp_i                           )
+  );
+
+endmodule : ara_system

--- a/hardware/tb/ara_testharness.sv
+++ b/hardware/tb/ara_testharness.sv
@@ -12,7 +12,7 @@ module ara_testharness #(
     parameter int unsigned NrLanes      = 0,
     // AXI Parameters
     parameter int unsigned AxiUserWidth = 1,
-    parameter int unsigned AxiIdWidth   = 6,
+    parameter int unsigned AxiIdWidth   = 5,
     parameter int unsigned AxiAddrWidth = 64,
     parameter int unsigned AxiDataWidth = 64*NrLanes/2
   ) (


### PR DESCRIPTION
This PR creates an `ara_system`, which contains Ara, Ariane, and an AXI mux. This module is then instantiated in the `ara_soc` module. The purpose of this is to simplify our implementation scripts, which can PnR the system without worrying about the SoC logic present in `ara_soc`. 

## Changelog

### Changed

- Create \`ara_system\` wrapper containing Ara, Ariane, and an AXI mux, instantiated from within Ara's SoC

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
