### PR TITLE
Sequencer upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+ - Avoid corner-case in which the sequencer issues the same instruction multiple times when two units become non-ready at the same time
+
+## Added
+
+ - The sequencer can issue instructions to non-full units even if the other units are full
+
+## Changed
+
+ - The main sequencer issues instructions every time the target unit has a non-full instruction queue
+ - The main sequencer stalls if the instructions target a lane, and its operand requesters are not ready
+ - New instructions enter the main sequencer with a token that marks them as new, and the related counter is updated upon arrival
+
 ## 2.2.0 - 2021-11-02
 
 ### Fixed

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -71,6 +71,17 @@ package ara_pkg;
   localparam int unsigned LatFNonComp     = 'd1;
   localparam int unsigned LatFConv        = 'd2;
 
+  // Define the maximum instruction queue depth
+  localparam MaxVInsnQueueDepth = 4;
+  // FUs instruction queue depth.
+  localparam int unsigned MfpuInsnQueueDepth = 4;
+  localparam int unsigned ValuInsnQueueDepth = 4;
+  localparam int unsigned VlduInsnQueueDepth = 4;
+  localparam int unsigned VstuInsnQueueDepth = 4;
+  localparam int unsigned SlduInsnQueueDepth = 2;
+  // Ara supports MaskuInsnQueueDepth = 1 only.
+  localparam int unsigned MaskuInsnQueueDepth = 1;
+
   ///////////////////
   //  Definitions  //
   ///////////////////
@@ -248,6 +259,10 @@ package ara_pkg;
     vlen_t vl;
     vlen_t vstart;
     rvv_pkg::vtype_t vtype;
+
+    // Request token, for registration in the sequencer
+    logic token;
+
   } ara_req_t;
 
   typedef struct packed {

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -141,7 +141,7 @@ module ara import ara_pkg::*; #(
     .pe_req_o              (pe_req            ),
     .pe_req_valid_o        (pe_req_valid      ),
     .pe_vinsn_running_o    (pe_vinsn_running  ),
-    .pe_req_ready_i        (pe_req_ready[0]   ),
+    .pe_req_ready_i        (pe_req_ready      ),
     .pe_resp_i             (pe_resp           ),
     .alu_vinsn_done_i      (alu_vinsn_done[0] ),
     .mfpu_vinsn_done_i     (mfpu_vinsn_done[0]),

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -128,29 +128,29 @@ module ara import ara_pkg::*; #(
   logic     [NrLanes-1:0] mfpu_vinsn_done;
 
   ara_sequencer #(.NrLanes(NrLanes)) i_sequencer (
-    .clk_i                 (clk_i           ),
-    .rst_ni                (rst_ni          ),
+    .clk_i                 (clk_i             ),
+    .rst_ni                (rst_ni            ),
     // Interface with the dispatcher
-    .ara_req_i             (ara_req         ),
-    .ara_req_valid_i       (ara_req_valid   ),
-    .ara_req_ready_o       (ara_req_ready   ),
-    .ara_resp_o            (ara_resp        ),
-    .ara_resp_valid_o      (ara_resp_valid  ),
-    .ara_idle_o            (ara_idle        ),
+    .ara_req_i             (ara_req           ),
+    .ara_req_valid_i       (ara_req_valid     ),
+    .ara_req_ready_o       (ara_req_ready     ),
+    .ara_resp_o            (ara_resp          ),
+    .ara_resp_valid_o      (ara_resp_valid    ),
+    .ara_idle_o            (ara_idle          ),
     // Interface with the PEs
-    .pe_req_o              (pe_req         ),
-    .pe_req_valid_o        (pe_req_valid   ),
-    .pe_vinsn_running_o    (pe_vinsn_running),
-    .pe_req_ready_i        (pe_req_ready[0]),
-    .pe_resp_i             (pe_resp        ),
+    .pe_req_o              (pe_req            ),
+    .pe_req_valid_o        (pe_req_valid      ),
+    .pe_vinsn_running_o    (pe_vinsn_running  ),
+    .pe_req_ready_i        (pe_req_ready[0]   ),
+    .pe_resp_i             (pe_resp           ),
     .alu_vinsn_done_i      (alu_vinsn_done[0] ),
     .mfpu_vinsn_done_i     (mfpu_vinsn_done[0]),
     // Interface with the slide unit
-    .pe_scalar_resp_i      ('0              ),
-    .pe_scalar_resp_valid_i(1'b0            ),
+    .pe_scalar_resp_i      ('0                ),
+    .pe_scalar_resp_valid_i(1'b0              ),
     // Interface with the address generator
-    .addrgen_ack_i         (addrgen_ack     ),
-    .addrgen_error_i       (addrgen_error   )
+    .addrgen_ack_i         (addrgen_ack       ),
+    .addrgen_error_i       (addrgen_error     )
   );
 
   /////////////

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -124,6 +124,8 @@ module ara import ara_pkg::*; #(
   // Interface with the address generator
   logic                   addrgen_ack;
   logic                   addrgen_error;
+  logic     [NrLanes-1:0] alu_vinsn_done;
+  logic     [NrLanes-1:0] mfpu_vinsn_done;
 
   ara_sequencer #(.NrLanes(NrLanes)) i_sequencer (
     .clk_i                 (clk_i           ),
@@ -136,11 +138,13 @@ module ara import ara_pkg::*; #(
     .ara_resp_valid_o      (ara_resp_valid  ),
     .ara_idle_o            (ara_idle        ),
     // Interface with the PEs
-    .pe_req_o              (pe_req          ),
-    .pe_req_valid_o        (pe_req_valid    ),
+    .pe_req_o              (pe_req         ),
+    .pe_req_valid_o        (pe_req_valid   ),
     .pe_vinsn_running_o    (pe_vinsn_running),
-    .pe_req_ready_i        (pe_req_ready    ),
-    .pe_resp_i             (pe_resp         ),
+    .pe_req_ready_i        (pe_req_ready[0]),
+    .pe_resp_i             (pe_resp        ),
+    .alu_vinsn_done_i      (alu_vinsn_done[0] ),
+    .mfpu_vinsn_done_i     (mfpu_vinsn_done[0]),
     // Interface with the slide unit
     .pe_scalar_resp_i      ('0              ),
     .pe_scalar_resp_valid_i(1'b0            ),
@@ -214,6 +218,8 @@ module ara import ara_pkg::*; #(
       .pe_vinsn_running_i          (pe_vinsn_running                  ),
       .pe_req_ready_o              (pe_req_ready[lane]                ),
       .pe_resp_o                   (pe_resp[lane]                     ),
+      .alu_vinsn_done_o            (alu_vinsn_done[lane]              ),
+      .mfpu_vinsn_done_o           (mfpu_vinsn_done[lane]             ),
       // Interface with the slide unit
       .sldu_result_req_i           (sldu_result_req[lane]             ),
       .sldu_result_addr_i          (sldu_result_addr[lane]            ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -233,6 +233,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     is_config            = 1'b0;
     ignore_zero_vl_check = 1'b0;
 
+    // The token must change at every new instruction
+    ara_req_d.token = (ara_req_valid_o && ara_req_ready_i) ? ~ara_req_o.token : ara_req_o.token;
+
     // Special states
     case (state_q)
       // Is Ara idle?

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -28,7 +28,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     output pe_req_t                 pe_req_o,
     output logic                    pe_req_valid_o,
     output logic      [NrVInsn-1:0] pe_vinsn_running_o,
-    input  logic      [NrLanes-1:0] pe_req_ready_i,
+    input  logic        [NrPEs-1:0] pe_req_ready_i,
     input  pe_resp_t    [NrPEs-1:0] pe_resp_i,
     input  logic                    alu_vinsn_done_i,
     input  logic                    mfpu_vinsn_done_i,
@@ -51,6 +51,12 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   logic [NrVInsn-1:0] vinsn_running_d, vinsn_running_q;
   vid_t               vinsn_id_n;
   logic               vinsn_running_full;
+
+  // NrLanes bits that indicate if the sequencer must stall because of a lane desynchronization.
+  logic [NrVInsn-1:0] stall_lanes_desynch_vec;
+  logic               stall_lanes_desynch;
+  // Transpose the matrix, as vertical slices are not allowed in System Verilog
+  logic [NrVInsn-1:0][NrPEs-1:0] pe_vinsn_running_q_trns;
 
   // Ara is idle if no instruction is currently running on it.
   assign ara_idle_o = !(|vinsn_running_q);
@@ -77,6 +83,23 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   end
 
   assign pe_vinsn_running_o = vinsn_running_q;
+
+  // Transpose the matrix
+  for (genvar r = 0; r < NrVInsn; r++) begin : gen_trans_mtx_r
+    for (genvar c = 0; c < NrPEs; c++) begin : gen_trans_mtx_c
+      assign pe_vinsn_running_q_trns[r][c] = pe_vinsn_running_q[c][r];
+    end
+  end
+
+  // Stall the sequencer if the lanes get de-synchronized
+  // and lane 0 is no more the last lane to finish the operation.
+  // This is because the instruction counters for ALU and MFPU refers
+  // to lane 0. If lane 0 finishes before the other lanes, the counter
+  // is not reflecting the real lane situations anymore.
+  for (genvar i = 0; i < NrVInsn; i++) begin : gen_stall_lane_desynch
+    assign stall_lanes_desynch_vec[i] = ~pe_vinsn_running_q[0][i] & |pe_vinsn_running_q_trns[i][NrLanes-1:1];
+  end
+  assign stall_lanes_desynch = |stall_lanes_desynch_vec;
 
   /////////////////
   //  Sequencer  //
@@ -227,8 +250,8 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
         // Received a new request
         end else if (ara_req_valid_i) begin
           // The target PE is ready, and we can handle another running vector instruction
-        // Let instructions with priority pass be issued
-          if ((|vinsn_queue_ready || |priority_pass) && !vinsn_running_full) begin
+          // Let instructions with priority pass be issued
+          if ((|vinsn_queue_ready || |priority_pass) && !stall_lanes_desynch && !vinsn_running_full) begin
             ///////////////
             //  Hazards  //
             ///////////////

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -41,6 +41,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  logic     [NrVInsn-1:0]                         pe_vinsn_running_i,
     output logic                                           pe_req_ready_o,
     output `STRUCT_PORT(pe_resp_t)                         pe_resp_o,
+    output logic                                           alu_vinsn_done_o,
+    output logic                                           mfpu_vinsn_done_o,
     // Interface with the Store unit
     output elen_t                                          stu_operand_o,
     output logic                                           stu_operand_valid_o,
@@ -133,6 +135,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .operand_request_valid_o(operand_request_valid),
     .operand_request_ready_i(operand_request_ready),
     .vinsn_running_o        (vinsn_running        ),
+    .alu_vinsn_done_o       (alu_vinsn_done_o     ),
+    .mfpu_vinsn_done_o      (mfpu_vinsn_done_o    ),
     // Interface with the VFUs
     .vfu_operation_o        (vfu_operation        ),
     .vfu_operation_valid_o  (vfu_operation_valid  ),

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -153,474 +153,474 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
     vfu_operation_d       = '0;
     vfu_operation_valid_d = 1'b0;
 
-      // If the operand requesters are busy, abort the request and wait for another cycle.
-      if (pe_req_valid) begin
-        unique case (pe_req.vfu)
-          VFU_Alu : begin
-            pe_req_ready = !(operand_request_valid_o[AluA] ||
-              operand_request_valid_o[AluB ] ||
-              operand_request_valid_o[MaskM]);
-          end
-          VFU_MFpu : begin
-            pe_req_ready = !(operand_request_valid_o[MulFPUA] ||
-              operand_request_valid_o[MulFPUB] ||
-              operand_request_valid_o[MulFPUC] ||
-              operand_request_valid_o[MaskM]);
-          end
-          VFU_LoadUnit : pe_req_ready = !(operand_request_valid_o[MaskM]);
-          VFU_SlideUnit: pe_req_ready = !(operand_request_valid_o[SlideAddrGenA]);
-          VFU_StoreUnit: begin
-            pe_req_ready = !(operand_request_valid_o[StA] ||
-              operand_request_valid_o[ MaskM]);
-          end
-          VFU_MaskUnit : begin
-            pe_req_ready = !(operand_request_valid_o[AluA] ||
-              operand_request_valid_o [AluB] ||
-              operand_request_valid_o[MaskB] ||
-              operand_request_valid_o[MaskM]);
-          end
-          default:;
-        endcase
+    // If the operand requesters are busy, abort the request and wait for another cycle.
+    if (pe_req_valid) begin
+      unique case (pe_req.vfu)
+        VFU_Alu : begin
+          pe_req_ready = !(operand_request_valid_o[AluA] ||
+            operand_request_valid_o[AluB ] ||
+            operand_request_valid_o[MaskM]);
+        end
+        VFU_MFpu : begin
+          pe_req_ready = !(operand_request_valid_o[MulFPUA] ||
+            operand_request_valid_o[MulFPUB] ||
+            operand_request_valid_o[MulFPUC] ||
+            operand_request_valid_o[MaskM]);
+        end
+        VFU_LoadUnit : pe_req_ready = !(operand_request_valid_o[MaskM]);
+        VFU_SlideUnit: pe_req_ready = !(operand_request_valid_o[SlideAddrGenA]);
+        VFU_StoreUnit: begin
+          pe_req_ready = !(operand_request_valid_o[StA] ||
+            operand_request_valid_o[ MaskM]);
+        end
+        VFU_MaskUnit : begin
+          pe_req_ready = !(operand_request_valid_o[AluA] ||
+            operand_request_valid_o [AluB] ||
+            operand_request_valid_o[MaskB] ||
+            operand_request_valid_o[MaskM]);
+        end
+        default:;
+      endcase
+    end
+
+    // We received a new vector instruction
+    if (pe_req_valid && pe_req_ready && !vinsn_running_d[pe_req.id]) begin
+      // Populate the VFU request
+      vfu_operation_d = '{
+        id             : pe_req.id,
+        op             : pe_req.op,
+        vm             : pe_req.vm,
+        vfu            : pe_req.vfu,
+        use_vs1        : pe_req.use_vs1,
+        use_vs2        : pe_req.use_vs2,
+        use_vd_op      : pe_req.use_vd_op,
+        scalar_op      : pe_req.scalar_op,
+        use_scalar_op  : pe_req.use_scalar_op,
+        vd             : pe_req.vd,
+        use_vd         : pe_req.use_vd,
+        swap_vs2_vd_op : pe_req.swap_vs2_vd_op,
+        fp_rm          : pe_req.fp_rm,
+        wide_fp_imm    : pe_req.wide_fp_imm,
+        cvt_resize     : pe_req.cvt_resize,
+        vtype          : pe_req.vtype,
+        default        : '0
+      };
+      vfu_operation_valid_d = 1'b1;
+
+      // Vector length calculation
+      vfu_operation_d.vl = pe_req.vl / NrLanes;
+      // If lane_id_i < vl % NrLanes, this lane has to execute one extra micro-operation.
+      if (lane_id_i < pe_req.vl[idx_width(NrLanes)-1:0]) vfu_operation_d.vl += 1;
+
+      // Mute request if the instruction runs in the lane and the vl is zero.
+      if (vfu_operation_d.vl == '0 && (vfu_operation_d.vfu inside {VFU_Alu, VFU_MFpu})) begin
+        vfu_operation_valid_d = 1'b0;
+        // We are already done with this instruction
+        vinsn_done_d[pe_req.id] |= 1'b1;
       end
 
-      // We received a new vector instruction
-      if (pe_req_valid && pe_req_ready && !vinsn_running_d[pe_req.id]) begin
-        // Populate the VFU request
-        vfu_operation_d = '{
-          id             : pe_req.id,
-          op             : pe_req.op,
-          vm             : pe_req.vm,
-          vfu            : pe_req.vfu,
-          use_vs1        : pe_req.use_vs1,
-          use_vs2        : pe_req.use_vs2,
-          use_vd_op      : pe_req.use_vd_op,
-          scalar_op      : pe_req.scalar_op,
-          use_scalar_op  : pe_req.use_scalar_op,
-          vd             : pe_req.vd,
-          use_vd         : pe_req.use_vd,
-          swap_vs2_vd_op : pe_req.swap_vs2_vd_op,
-          fp_rm          : pe_req.fp_rm,
-          wide_fp_imm    : pe_req.wide_fp_imm,
-          cvt_resize     : pe_req.cvt_resize,
-          vtype          : pe_req.vtype,
-          default        : '0
-        };
-        vfu_operation_valid_d = 1'b1;
+      // Vector start calculation
+      vfu_operation_d.vstart = pe_req.vstart / NrLanes;
+      // If lane_id_i < vstart % NrLanes, this lane needs to execute one micro-operation less.
+      if (lane_id_i < pe_req.vstart[idx_width(NrLanes)-1:0]) vfu_operation_d.vstart -= 1;
 
-        // Vector length calculation
-        vfu_operation_d.vl = pe_req.vl / NrLanes;
-        // If lane_id_i < vl % NrLanes, this lane has to execute one extra micro-operation.
-        if (lane_id_i < pe_req.vl[idx_width(NrLanes)-1:0]) vfu_operation_d.vl += 1;
+      // Mark the vector instruction as running
+      vinsn_running_d[pe_req.id] = 1'b1;
 
-        // Mute request if the instruction runs in the lane and the vl is zero.
-        if (vfu_operation_d.vl == '0 && (vfu_operation_d.vfu inside {VFU_Alu, VFU_MFpu})) begin
-          vfu_operation_valid_d = 1'b0;
-          // We are already done with this instruction
-          vinsn_done_d[pe_req.id] |= 1'b1;
+      ////////////////////////
+      //  Operand requests  //
+      ////////////////////////
+
+      unique case (pe_req.vfu)
+        VFU_Alu: begin
+          operand_request_i[AluA] = '{
+            id         : pe_req.id,
+            vs         : pe_req.vs1,
+            eew        : pe_req.eew_vs1,
+            conv       : pe_req.conversion_vs1,
+            scale_vl   : pe_req.scale_vl,
+            cvt_resize : pe_req.cvt_resize,
+            vtype      : pe_req.vtype,
+            vl         : vfu_operation_d.vl,
+            vstart     : vfu_operation_d.vstart,
+            hazard     : pe_req.hazard_vs1 | pe_req.hazard_vd,
+            default    : '0
+          };
+          operand_request_push[AluA] = pe_req.use_vs1;
+
+          operand_request_i[AluB] = '{
+            id         : pe_req.id,
+            vs         : pe_req.vs2,
+            eew        : pe_req.eew_vs2,
+            conv       : pe_req.conversion_vs2,
+            scale_vl   : pe_req.scale_vl,
+            cvt_resize : pe_req.cvt_resize,
+            vtype      : pe_req.vtype,
+            vl         : vfu_operation_d.vl,
+            vstart     : vfu_operation_d.vstart,
+            hazard     : pe_req.hazard_vs2 | pe_req.hazard_vd,
+            default    : '0
+          };
+          operand_request_push[AluB] = pe_req.use_vs2;
+
+          // This vector instruction uses masks
+          operand_request_i[MaskM] = '{
+            id     : pe_req.id,
+            vs     : VMASK,
+            eew    : pe_req.vtype.vsew,
+            vtype  : pe_req.vtype,
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vstart : vfu_operation_d.vstart,
+            hazard : pe_req.hazard_vm | pe_req.hazard_vd,
+            default: '0
+          };
+          if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+              NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
+          operand_request_push[MaskM] = !pe_req.vm;
+        end
+        VFU_MFpu: begin
+          operand_request_i[MulFPUA] = '{
+            id         : pe_req.id,
+            vs         : pe_req.vs1,
+            eew        : pe_req.eew_vs1,
+            conv       : pe_req.conversion_vs1,
+            scale_vl   : pe_req.scale_vl,
+            cvt_resize : pe_req.cvt_resize,
+            vtype      : pe_req.vtype,
+            vl         : vfu_operation_d.vl,
+            vstart     : vfu_operation_d.vstart,
+            hazard     : pe_req.hazard_vs1 | pe_req.hazard_vd,
+            default    : '0
+          };
+          operand_request_push[MulFPUA] = pe_req.use_vs1;
+
+          operand_request_i[MulFPUB] = '{
+            id         : pe_req.id,
+            vs         : pe_req.swap_vs2_vd_op ? pe_req.vd        : pe_req.vs2,
+            eew        : pe_req.swap_vs2_vd_op ? pe_req.eew_vd_op : pe_req.eew_vs2,
+            conv       : pe_req.conversion_vs2,
+            scale_vl   : pe_req.scale_vl,
+            cvt_resize : pe_req.cvt_resize,
+            vtype      : pe_req.vtype,
+            vl         : vfu_operation_d.vl,
+            vstart     : vfu_operation_d.vstart,
+            hazard     : (pe_req.swap_vs2_vd_op ?
+              pe_req.hazard_vd : (pe_req.hazard_vs2 | pe_req.hazard_vd)),
+            default: '0
+          };
+          operand_request_push[MulFPUB] = pe_req.swap_vs2_vd_op ?
+          pe_req.use_vd_op : pe_req.use_vs2;
+
+          operand_request_i[MulFPUC] = '{
+            id         : pe_req.id,
+            vs         : pe_req.swap_vs2_vd_op ? pe_req.vs2            : pe_req.vd,
+            eew        : pe_req.swap_vs2_vd_op ? pe_req.eew_vs2        : pe_req.eew_vd_op,
+            conv       : pe_req.swap_vs2_vd_op ? pe_req.conversion_vs2 : OpQueueConversionNone,
+            scale_vl   : pe_req.scale_vl,
+            cvt_resize : pe_req.cvt_resize,
+            vl         : vfu_operation_d.vl,
+            vstart     : vfu_operation_d.vstart,
+            vtype      : pe_req.vtype,
+            hazard     : pe_req.swap_vs2_vd_op ?
+              (pe_req.hazard_vs2 | pe_req.hazard_vd) : pe_req.hazard_vd,
+            default : '0
+          };
+          operand_request_push[MulFPUC] = pe_req.swap_vs2_vd_op ?
+          pe_req.use_vs2 : pe_req.use_vd_op;
+
+          // This vector instruction uses masks
+          operand_request_i[MaskM] = '{
+            id     : pe_req.id,
+            vs     : VMASK,
+            eew    : pe_req.vtype.vsew,
+            vtype  : pe_req.vtype,
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vstart : vfu_operation_d.vstart,
+            hazard : pe_req.hazard_vm | pe_req.hazard_vd,
+            default: '0
+          };
+          if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+              NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
+          operand_request_push[MaskM] = !pe_req.vm;
+        end
+        VFU_LoadUnit : begin
+          // This vector instruction uses masks
+          operand_request_i[MaskM] = '{
+            id     : pe_req.id,
+            vs     : VMASK,
+            eew    : pe_req.vtype.vsew,
+            vtype  : pe_req.vtype,
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vstart : vfu_operation_d.vstart,
+            hazard : pe_req.hazard_vm | pe_req.hazard_vd,
+            default: '0
+          };
+          if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+              NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
+          operand_request_push[MaskM] = !pe_req.vm;
+        end
+        VFU_StoreUnit : begin
+          operand_request_i[StA] = '{
+            id      : pe_req.id,
+            vs      : pe_req.vs1,
+            eew     : pe_req.eew_vs1,
+            conv    : pe_req.conversion_vs1,
+            scale_vl: pe_req.scale_vl,
+            vtype   : pe_req.vtype,
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            vl      : pe_req.vl / NrLanes,
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vs1 | pe_req.hazard_vd,
+            default : '0
+          };
+          if (operand_request_i[StA].vl * NrLanes != pe_req.vl) operand_request_i[StA].vl += 1;
+          operand_request_push[StA] = pe_req.use_vs1;
+
+          // This vector instruction uses masks
+          operand_request_i[MaskM] = '{
+            id     : pe_req.id,
+            vs     : VMASK,
+            eew    : pe_req.vtype.vsew,
+            vtype  : pe_req.vtype,
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vstart : vfu_operation_d.vstart,
+            hazard : pe_req.hazard_vm | pe_req.hazard_vd,
+            default: '0
+          };
+          if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+              NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
+          operand_request_push[MaskM] = !pe_req.vm;
         end
 
-        // Vector start calculation
-        vfu_operation_d.vstart = pe_req.vstart / NrLanes;
-        // If lane_id_i < vstart % NrLanes, this lane needs to execute one micro-operation less.
-        if (lane_id_i < pe_req.vstart[idx_width(NrLanes)-1:0]) vfu_operation_d.vstart -= 1;
+        VFU_SlideUnit: begin
+          operand_request_i[SlideAddrGenA] = '{
+            id      : pe_req.id,
+            vs      : pe_req.vs2,
+            eew     : pe_req.eew_vs2,
+            conv    : pe_req.conversion_vs2,
+            scale_vl: pe_req.scale_vl,
+            vtype   : pe_req.vtype,
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vs2 | pe_req.hazard_vd,
+            default : '0
+          };
+          operand_request_push[SlideAddrGenA] = pe_req.use_vs2;
 
-        // Mark the vector instruction as running
-        vinsn_running_d[pe_req.id] = 1'b1;
-
-        ////////////////////////
-        //  Operand requests  //
-        ////////////////////////
-
-        unique case (pe_req.vfu)
-          VFU_Alu: begin
-            operand_request_i[AluA] = '{
-              id         : pe_req.id,
-              vs         : pe_req.vs1,
-              eew        : pe_req.eew_vs1,
-              conv       : pe_req.conversion_vs1,
-              scale_vl   : pe_req.scale_vl,
-              cvt_resize : pe_req.cvt_resize,
-              vtype      : pe_req.vtype,
-              vl         : vfu_operation_d.vl,
-              vstart     : vfu_operation_d.vstart,
-              hazard     : pe_req.hazard_vs1 | pe_req.hazard_vd,
-              default    : '0
-            };
-            operand_request_push[AluA] = pe_req.use_vs1;
-
-            operand_request_i[AluB] = '{
-              id         : pe_req.id,
-              vs         : pe_req.vs2,
-              eew        : pe_req.eew_vs2,
-              conv       : pe_req.conversion_vs2,
-              scale_vl   : pe_req.scale_vl,
-              cvt_resize : pe_req.cvt_resize,
-              vtype      : pe_req.vtype,
-              vl         : vfu_operation_d.vl,
-              vstart     : vfu_operation_d.vstart,
-              hazard     : pe_req.hazard_vs2 | pe_req.hazard_vd,
-              default    : '0
-            };
-            operand_request_push[AluB] = pe_req.use_vs2;
-
-            // This vector instruction uses masks
-            operand_request_i[MaskM] = '{
-              id     : pe_req.id,
-              vs     : VMASK,
-              eew    : pe_req.vtype.vsew,
-              vtype  : pe_req.vtype,
+          case (pe_req.op)
+            VSLIDEUP: begin
+              // We need to trim full words from the end of the vector that are not used
+              // as operands by the slide unit.
               // Since this request goes outside of the lane, we might need to request an
               // extra operand regardless of whether it is valid in this lane or not.
-              vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
-              vstart : vfu_operation_d.vstart,
-              hazard : pe_req.hazard_vm | pe_req.hazard_vd,
-              default: '0
-            };
-            if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
-                NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
-            operand_request_push[MaskM] = !pe_req.vm;
-          end
-          VFU_MFpu: begin
-            operand_request_i[MulFPUA] = '{
-              id         : pe_req.id,
-              vs         : pe_req.vs1,
-              eew        : pe_req.eew_vs1,
-              conv       : pe_req.conversion_vs1,
-              scale_vl   : pe_req.scale_vl,
-              cvt_resize : pe_req.cvt_resize,
-              vtype      : pe_req.vtype,
-              vl         : vfu_operation_d.vl,
-              vstart     : vfu_operation_d.vstart,
-              hazard     : pe_req.hazard_vs1 | pe_req.hazard_vd,
-              default    : '0
-            };
-            operand_request_push[MulFPUA] = pe_req.use_vs1;
-
-            operand_request_i[MulFPUB] = '{
-              id         : pe_req.id,
-              vs         : pe_req.swap_vs2_vd_op ? pe_req.vd        : pe_req.vs2,
-              eew        : pe_req.swap_vs2_vd_op ? pe_req.eew_vd_op : pe_req.eew_vs2,
-              conv       : pe_req.conversion_vs2,
-              scale_vl   : pe_req.scale_vl,
-              cvt_resize : pe_req.cvt_resize,
-              vtype      : pe_req.vtype,
-              vl         : vfu_operation_d.vl,
-              vstart     : vfu_operation_d.vstart,
-              hazard     : (pe_req.swap_vs2_vd_op ?
-                pe_req.hazard_vd : (pe_req.hazard_vs2 | pe_req.hazard_vd)),
-              default: '0
-            };
-            operand_request_push[MulFPUB] = pe_req.swap_vs2_vd_op ?
-            pe_req.use_vd_op : pe_req.use_vs2;
-
-            operand_request_i[MulFPUC] = '{
-              id         : pe_req.id,
-              vs         : pe_req.swap_vs2_vd_op ? pe_req.vs2            : pe_req.vd,
-              eew        : pe_req.swap_vs2_vd_op ? pe_req.eew_vs2        : pe_req.eew_vd_op,
-              conv       : pe_req.swap_vs2_vd_op ? pe_req.conversion_vs2 : OpQueueConversionNone,
-              scale_vl   : pe_req.scale_vl,
-              cvt_resize : pe_req.cvt_resize,
-              vl         : vfu_operation_d.vl,
-              vstart     : vfu_operation_d.vstart,
-              vtype      : pe_req.vtype,
-              hazard     : pe_req.swap_vs2_vd_op ?
-                (pe_req.hazard_vs2 | pe_req.hazard_vd) : pe_req.hazard_vd,
-              default : '0
-            };
-            operand_request_push[MulFPUC] = pe_req.swap_vs2_vd_op ?
-            pe_req.use_vs2 : pe_req.use_vd_op;
-
-            // This vector instruction uses masks
-            operand_request_i[MaskM] = '{
-              id     : pe_req.id,
-              vs     : VMASK,
-              eew    : pe_req.vtype.vsew,
-              vtype  : pe_req.vtype,
-              // Since this request goes outside of the lane, we might need to request an
-              // extra operand regardless of whether it is valid in this lane or not.
-              vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
-              vstart : vfu_operation_d.vstart,
-              hazard : pe_req.hazard_vm | pe_req.hazard_vd,
-              default: '0
-            };
-            if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
-                NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
-            operand_request_push[MaskM] = !pe_req.vm;
-          end
-          VFU_LoadUnit : begin
-            // This vector instruction uses masks
-            operand_request_i[MaskM] = '{
-              id     : pe_req.id,
-              vs     : VMASK,
-              eew    : pe_req.vtype.vsew,
-              vtype  : pe_req.vtype,
-              // Since this request goes outside of the lane, we might need to request an
-              // extra operand regardless of whether it is valid in this lane or not.
-              vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
-              vstart : vfu_operation_d.vstart,
-              hazard : pe_req.hazard_vm | pe_req.hazard_vd,
-              default: '0
-            };
-            if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
-                NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
-            operand_request_push[MaskM] = !pe_req.vm;
-          end
-          VFU_StoreUnit : begin
-            operand_request_i[StA] = '{
-              id      : pe_req.id,
-              vs      : pe_req.vs1,
-              eew     : pe_req.eew_vs1,
-              conv    : pe_req.conversion_vs1,
-              scale_vl: pe_req.scale_vl,
-              vtype   : pe_req.vtype,
-              // Since this request goes outside of the lane, we might need to request an
-              // extra operand regardless of whether it is valid in this lane or not.
-              vl      : pe_req.vl / NrLanes,
-              vstart  : vfu_operation_d.vstart,
-              hazard  : pe_req.hazard_vs1 | pe_req.hazard_vd,
-              default : '0
-            };
-            if (operand_request_i[StA].vl * NrLanes != pe_req.vl) operand_request_i[StA].vl += 1;
-            operand_request_push[StA] = pe_req.use_vs1;
-
-            // This vector instruction uses masks
-            operand_request_i[MaskM] = '{
-              id     : pe_req.id,
-              vs     : VMASK,
-              eew    : pe_req.vtype.vsew,
-              vtype  : pe_req.vtype,
-              // Since this request goes outside of the lane, we might need to request an
-              // extra operand regardless of whether it is valid in this lane or not.
-              vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
-              vstart : vfu_operation_d.vstart,
-              hazard : pe_req.hazard_vm | pe_req.hazard_vd,
-              default: '0
-            };
-            if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
-                NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
-            operand_request_push[MaskM] = !pe_req.vm;
-          end
-
-          VFU_SlideUnit: begin
-            operand_request_i[SlideAddrGenA] = '{
-              id      : pe_req.id,
-              vs      : pe_req.vs2,
-              eew     : pe_req.eew_vs2,
-              conv    : pe_req.conversion_vs2,
-              scale_vl: pe_req.scale_vl,
-              vtype   : pe_req.vtype,
-              vstart  : vfu_operation_d.vstart,
-              hazard  : pe_req.hazard_vs2 | pe_req.hazard_vd,
-              default : '0
-            };
-            operand_request_push[SlideAddrGenA] = pe_req.use_vs2;
-
-            case (pe_req.op)
-              VSLIDEUP: begin
-                // We need to trim full words from the end of the vector that are not used
-                // as operands by the slide unit.
-                // Since this request goes outside of the lane, we might need to request an
-                // extra operand regardless of whether it is valid in this lane or not.
-                operand_request_i[SlideAddrGenA].vl =
-                (pe_req.vl - pe_req.stride + NrLanes - 1) / NrLanes;
-              end
-              VSLIDEDOWN: begin
-                // Extra elements to ask, because of the stride
-                logic [$clog2(8*NrLanes)-1:0] extra_stride;
-                // Need one bit more than vl, since we will also add the stride contribution
-                logic [$size(pe_req.vl):0] vl_tot;
-
-                // We need to trim full words from the start of the vector that are not used
-                // as operands by the slide unit.
-                operand_request_i[SlideAddrGenA].vstart = pe_req.stride / NrLanes;
-
-                // The stride move the initial address in boundaries of 8*NrLanes Byte.
-                // If the stride is not multiple of a full VRF word (8*NrLanes Byte),
-                // we must request it as well from the VRF
-
-                // Find the number of extra elements to ask, related to the stride
-                unique case (pe_req.eew_vs2)
-                  EW8 : extra_stride = pe_req.stride[$clog2(8*NrLanes)-1:0];
-                  EW16: extra_stride = {1'b0, pe_req.stride[$clog2(4*NrLanes)-1:0]};
-                  EW32: extra_stride = {2'b0, pe_req.stride[$clog2(2*NrLanes)-1:0]};
-                  EW64: extra_stride = {3'b0, pe_req.stride[$clog2(1*NrLanes)-1:0]};
-                  default:
-                    extra_stride = {3'b0, pe_req.stride[$clog2(1*NrLanes)-1:0]};
-                endcase
-
-                // Find the total number of elements to be asked
-                vl_tot = pe_req.vl;
-                if (!pe_req.use_scalar_op)
-                  vl_tot += extra_stride;
-
-                // Ask the elements, and ask one more if we do not perfectly divide NrLanes
-                operand_request_i[SlideAddrGenA].vl = vl_tot / NrLanes;
-                if (operand_request_i[SlideAddrGenA].vl * NrLanes != vl_tot)
-                  operand_request_i[SlideAddrGenA].vl += 1;
-              end
-            endcase
-
-            // This vector instruction uses masks
-            operand_request_i[MaskM] = '{
-              id     : pe_req.id,
-              vs     : VMASK,
-              eew    : pe_req.vtype.vsew,
-              vtype  : pe_req.vtype,
-              vstart : vfu_operation_d.vstart,
-              hazard : pe_req.hazard_vm | pe_req.hazard_vd,
-              default: '0
-            };
-            operand_request_push[MaskM] = !pe_req.vm;
-
-            case (pe_req.op)
-              VSLIDEUP: begin
-                // We need to trim full words from the end of the vector that are not used
-                // as operands by the slide unit.
-                // Since this request goes outside of the lane, we might need to request an
-                // extra operand regardless of whether it is valid in this lane or not.
-                operand_request_i[MaskM].vl =
-                ((pe_req.vl - pe_req.stride + NrLanes - 1) / 8 / NrLanes)
-                >> (int'(EW64) - int'(pe_req.vtype.vsew));
-
-                if (((operand_request_i[MaskM].vl + pe_req.stride) <<
-                      (int'(EW64) - int'(pe_req.vtype.vsew)) * NrLanes * 8 != pe_req.vl))
-                  operand_request_i[MaskM].vl += 1;
-              end
-              VSLIDEDOWN: begin
-                // Since this request goes outside of the lane, we might need to request an
-                // extra operand regardless of whether it is valid in this lane or not.
-                operand_request_i[MaskM].vl = ((pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(
-                      pe_req.vtype.vsew)));
-                if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
-                    NrLanes * 8 != pe_req.vl)
-                  operand_request_i[MaskM].vl += 1;
-              end
-            endcase
-          end
-          VFU_MaskUnit: begin
-            operand_request_i[AluA] = '{
-              id      : pe_req.id,
-              vs      : pe_req.vs1,
-              eew     : pe_req.eew_vs1,
-              scale_vl: pe_req.scale_vl,
-              vtype   : pe_req.vtype,
-              vstart  : vfu_operation_d.vstart,
-              hazard  : pe_req.hazard_vs1 | pe_req.hazard_vd,
-              default : '0
-            };
-
-            // This is an operation that runs normally on the ALU, and then gets *condensed* and
-            // reshuffled at the Mask Unit.
-            if (pe_req.op inside {[VMSEQ:VMSBC]}) begin
-              operand_request_i[AluA].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
+              operand_request_i[SlideAddrGenA].vl =
+              (pe_req.vl - pe_req.stride + NrLanes - 1) / NrLanes;
             end
-            // This is an operation that runs normally on the ALU, and then gets reshuffled at the
-            // Mask Unit.
-            else begin
+            VSLIDEDOWN: begin
+              // Extra elements to ask, because of the stride
+              logic [$clog2(8*NrLanes)-1:0] extra_stride;
+              // Need one bit more than vl, since we will also add the stride contribution
+              logic [$size(pe_req.vl):0] vl_tot;
+
+              // We need to trim full words from the start of the vector that are not used
+              // as operands by the slide unit.
+              operand_request_i[SlideAddrGenA].vstart = pe_req.stride / NrLanes;
+
+              // The stride move the initial address in boundaries of 8*NrLanes Byte.
+              // If the stride is not multiple of a full VRF word (8*NrLanes Byte),
+              // we must request it as well from the VRF
+
+              // Find the number of extra elements to ask, related to the stride
+              unique case (pe_req.eew_vs2)
+                EW8 : extra_stride = pe_req.stride[$clog2(8*NrLanes)-1:0];
+                EW16: extra_stride = {1'b0, pe_req.stride[$clog2(4*NrLanes)-1:0]};
+                EW32: extra_stride = {2'b0, pe_req.stride[$clog2(2*NrLanes)-1:0]};
+                EW64: extra_stride = {3'b0, pe_req.stride[$clog2(1*NrLanes)-1:0]};
+                default:
+                  extra_stride = {3'b0, pe_req.stride[$clog2(1*NrLanes)-1:0]};
+              endcase
+
+              // Find the total number of elements to be asked
+              vl_tot = pe_req.vl;
+              if (!pe_req.use_scalar_op)
+                vl_tot += extra_stride;
+
+              // Ask the elements, and ask one more if we do not perfectly divide NrLanes
+              operand_request_i[SlideAddrGenA].vl = vl_tot / NrLanes;
+              if (operand_request_i[SlideAddrGenA].vl * NrLanes != vl_tot)
+                operand_request_i[SlideAddrGenA].vl += 1;
+            end
+          endcase
+
+          // This vector instruction uses masks
+          operand_request_i[MaskM] = '{
+            id     : pe_req.id,
+            vs     : VMASK,
+            eew    : pe_req.vtype.vsew,
+            vtype  : pe_req.vtype,
+            vstart : vfu_operation_d.vstart,
+            hazard : pe_req.hazard_vm | pe_req.hazard_vd,
+            default: '0
+          };
+          operand_request_push[MaskM] = !pe_req.vm;
+
+          case (pe_req.op)
+            VSLIDEUP: begin
+              // We need to trim full words from the end of the vector that are not used
+              // as operands by the slide unit.
               // Since this request goes outside of the lane, we might need to request an
               // extra operand regardless of whether it is valid in this lane or not.
-              operand_request_i[AluA].vl = (pe_req.vl / NrLanes) >>
-              (int'(EW64) - int'(pe_req.eew_vs1));
-              if ((operand_request_i[AluA].vl << (int'(EW64) - int'(pe_req.eew_vs1))) * NrLanes !=
-                  pe_req.vl) operand_request_i[AluA].vl += 1;
-            end
-            operand_request_push[AluA] = pe_req.use_vs1 && !(pe_req.op inside {[VMFEQ:VMFGE]});
+              operand_request_i[MaskM].vl =
+              ((pe_req.vl - pe_req.stride + NrLanes - 1) / 8 / NrLanes)
+              >> (int'(EW64) - int'(pe_req.vtype.vsew));
 
-            operand_request_i[AluB] = '{
-              id      : pe_req.id,
-              vs      : pe_req.vs2,
-              eew     : pe_req.eew_vs2,
-              scale_vl: pe_req.scale_vl,
-              vtype   : pe_req.vtype,
-              vstart  : vfu_operation_d.vstart,
-              hazard  : pe_req.hazard_vs2 | pe_req.hazard_vd,
-              default : '0
-            };
-            // This is an operation that runs normally on the ALU, and then gets *condensed* and
-            // reshuffled at the Mask Unit.
-            if (pe_req.op inside {[VMSEQ:VMSBC]}) begin
-              operand_request_i[AluB].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
+              if (((operand_request_i[MaskM].vl + pe_req.stride) <<
+                    (int'(EW64) - int'(pe_req.vtype.vsew)) * NrLanes * 8 != pe_req.vl))
+                operand_request_i[MaskM].vl += 1;
             end
-            // This is an operation that runs normally on the ALU, and then gets reshuffled at the
-            // Mask Unit.
-            else begin
+            VSLIDEDOWN: begin
               // Since this request goes outside of the lane, we might need to request an
               // extra operand regardless of whether it is valid in this lane or not.
-              operand_request_i[AluB].vl = (pe_req.vl / NrLanes) >>
-              (int'(EW64) - int'(pe_req.eew_vs2));
-              if ((operand_request_i[AluB].vl << (int'(EW64) - int'(pe_req.eew_vs2))) * NrLanes !=
-                  pe_req.vl) operand_request_i[AluB].vl += 1;
+              operand_request_i[MaskM].vl = ((pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(
+                    pe_req.vtype.vsew)));
+              if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+                  NrLanes * 8 != pe_req.vl)
+                operand_request_i[MaskM].vl += 1;
             end
-            operand_request_push[AluB] = pe_req.use_vs2 && !(pe_req.op inside {[VMFEQ:VMFGE]});
+          endcase
+        end
+        VFU_MaskUnit: begin
+          operand_request_i[AluA] = '{
+            id      : pe_req.id,
+            vs      : pe_req.vs1,
+            eew     : pe_req.eew_vs1,
+            scale_vl: pe_req.scale_vl,
+            vtype   : pe_req.vtype,
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vs1 | pe_req.hazard_vd,
+            default : '0
+          };
 
-            operand_request_i[MulFPUA] = '{
-              id      : pe_req.id,
-              vs      : pe_req.vs1,
-              eew     : pe_req.eew_vs1,
-              scale_vl: pe_req.scale_vl,
-              vtype   : pe_req.vtype,
-              vstart  : vfu_operation_d.vstart,
-              hazard  : pe_req.hazard_vs1 | pe_req.hazard_vd,
-              default : '0
-            };
-
-            // This is an operation that runs normally on the ALU, and then gets *condensed* and
-            // reshuffled at the Mask Unit.
-            operand_request_i[MulFPUA].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
-            operand_request_push[MulFPUA] = pe_req.use_vs1 && pe_req.op inside {[VMFEQ:VMFGE]};
-
-            operand_request_i[MulFPUB] = '{
-              id      : pe_req.id,
-              vs      : pe_req.vs2,
-              eew     : pe_req.eew_vs2,
-              scale_vl: pe_req.scale_vl,
-              vtype   : pe_req.vtype,
-              vstart  : vfu_operation_d.vstart,
-              hazard  : pe_req.hazard_vs2 | pe_req.hazard_vd,
-              default : '0
-            };
-            // This is an operation that runs normally on the ALU, and then gets *condensed* and
-            // reshuffled at the Mask Unit.
-            operand_request_i[MulFPUB].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
-            operand_request_push[MulFPUB] = pe_req.use_vs2 && pe_req.op inside {[VMFEQ:VMFGE]};
-
-            operand_request_i[MaskB] = '{
-              id      : pe_req.id,
-              vs      : pe_req.vd,
-              eew     : pe_req.eew_vd_op,
-              scale_vl: pe_req.scale_vl,
-              vtype   : pe_req.vtype,
-              // Since this request goes outside of the lane, we might need to request an
-              // extra operand regardless of whether it is valid in this lane or not.
-              vl      : (pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)),
-              vstart  : vfu_operation_d.vstart,
-              hazard  : pe_req.hazard_vd,
-              default : '0
-            };
-            if ((pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)) !=
-                pe_req.vl) operand_request_i[MaskB].vl += 1;
-            operand_request_push[MaskB] = pe_req.use_vd_op;
-
-            operand_request_i[MaskM] = '{
-              id     : pe_req.id,
-              vs     : VMASK,
-              eew    : pe_req.vtype.vsew,
-              vtype  : pe_req.vtype,
-              // Since this request goes outside of the lane, we might need to request an
-              // extra operand regardless of whether it is valid in this lane or not.
-              vl     : (pe_req.vl / NrLanes / ELEN),
-              vstart : vfu_operation_d.vstart,
-              hazard : pe_req.hazard_vm,
-              default: '0
-            };
-            if ((operand_request_i[MaskM].vl * NrLanes * ELEN) != pe_req.vl) begin
-              operand_request_i[MaskM].vl += 1;
-            end
-            operand_request_push[MaskM] = !pe_req.vm;
+          // This is an operation that runs normally on the ALU, and then gets *condensed* and
+          // reshuffled at the Mask Unit.
+          if (pe_req.op inside {[VMSEQ:VMSBC]}) begin
+            operand_request_i[AluA].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
           end
-          default:;
-        endcase
-      end
+          // This is an operation that runs normally on the ALU, and then gets reshuffled at the
+          // Mask Unit.
+          else begin
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            operand_request_i[AluA].vl = (pe_req.vl / NrLanes) >>
+            (int'(EW64) - int'(pe_req.eew_vs1));
+            if ((operand_request_i[AluA].vl << (int'(EW64) - int'(pe_req.eew_vs1))) * NrLanes !=
+                pe_req.vl) operand_request_i[AluA].vl += 1;
+          end
+          operand_request_push[AluA] = pe_req.use_vs1 && !(pe_req.op inside {[VMFEQ:VMFGE]});
+
+          operand_request_i[AluB] = '{
+            id      : pe_req.id,
+            vs      : pe_req.vs2,
+            eew     : pe_req.eew_vs2,
+            scale_vl: pe_req.scale_vl,
+            vtype   : pe_req.vtype,
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vs2 | pe_req.hazard_vd,
+            default : '0
+          };
+          // This is an operation that runs normally on the ALU, and then gets *condensed* and
+          // reshuffled at the Mask Unit.
+          if (pe_req.op inside {[VMSEQ:VMSBC]}) begin
+            operand_request_i[AluB].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
+          end
+          // This is an operation that runs normally on the ALU, and then gets reshuffled at the
+          // Mask Unit.
+          else begin
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            operand_request_i[AluB].vl = (pe_req.vl / NrLanes) >>
+            (int'(EW64) - int'(pe_req.eew_vs2));
+            if ((operand_request_i[AluB].vl << (int'(EW64) - int'(pe_req.eew_vs2))) * NrLanes !=
+                pe_req.vl) operand_request_i[AluB].vl += 1;
+          end
+          operand_request_push[AluB] = pe_req.use_vs2 && !(pe_req.op inside {[VMFEQ:VMFGE]});
+
+          operand_request_i[MulFPUA] = '{
+            id      : pe_req.id,
+            vs      : pe_req.vs1,
+            eew     : pe_req.eew_vs1,
+            scale_vl: pe_req.scale_vl,
+            vtype   : pe_req.vtype,
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vs1 | pe_req.hazard_vd,
+            default : '0
+          };
+
+          // This is an operation that runs normally on the ALU, and then gets *condensed* and
+          // reshuffled at the Mask Unit.
+          operand_request_i[MulFPUA].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
+          operand_request_push[MulFPUA] = pe_req.use_vs1 && pe_req.op inside {[VMFEQ:VMFGE]};
+
+          operand_request_i[MulFPUB] = '{
+            id      : pe_req.id,
+            vs      : pe_req.vs2,
+            eew     : pe_req.eew_vs2,
+            scale_vl: pe_req.scale_vl,
+            vtype   : pe_req.vtype,
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vs2 | pe_req.hazard_vd,
+            default : '0
+          };
+          // This is an operation that runs normally on the ALU, and then gets *condensed* and
+          // reshuffled at the Mask Unit.
+          operand_request_i[MulFPUB].vl = (pe_req.vl + NrLanes - 1) / NrLanes;
+          operand_request_push[MulFPUB] = pe_req.use_vs2 && pe_req.op inside {[VMFEQ:VMFGE]};
+
+          operand_request_i[MaskB] = '{
+            id      : pe_req.id,
+            vs      : pe_req.vd,
+            eew     : pe_req.eew_vd_op,
+            scale_vl: pe_req.scale_vl,
+            vtype   : pe_req.vtype,
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            vl      : (pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vstart  : vfu_operation_d.vstart,
+            hazard  : pe_req.hazard_vd,
+            default : '0
+          };
+          if ((pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)) !=
+              pe_req.vl) operand_request_i[MaskB].vl += 1;
+          operand_request_push[MaskB] = pe_req.use_vd_op;
+
+          operand_request_i[MaskM] = '{
+            id     : pe_req.id,
+            vs     : VMASK,
+            eew    : pe_req.vtype.vsew,
+            vtype  : pe_req.vtype,
+            // Since this request goes outside of the lane, we might need to request an
+            // extra operand regardless of whether it is valid in this lane or not.
+            vl     : (pe_req.vl / NrLanes / ELEN),
+            vstart : vfu_operation_d.vstart,
+            hazard : pe_req.hazard_vm,
+            default: '0
+          };
+          if ((operand_request_i[MaskM].vl * NrLanes * ELEN) != pe_req.vl) begin
+            operand_request_i[MaskM].vl += 1;
+          end
+          operand_request_push[MaskM] = !pe_req.vm;
+        end
+        default:;
+      endcase
+    end
   end: sequencer
 
   always_ff @(posedge clk_i or negedge rst_ni) begin: p_sequencer_ff

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -121,6 +121,9 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   vfu_operation_t vfu_operation_d;
   logic           vfu_operation_valid_d;
 
+  // Cut the path
+  logic alu_vinsn_done_d, mfpu_vinsn_done_d;
+
   // Returns true if the corresponding lane VFU is ready.
   function automatic logic vfu_ready(vfu_e vfu, logic alu_ready_i, logic mfpu_ready_i);
     vfu_ready = 1'b1;
@@ -141,8 +144,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
 
     // Loops that finished execution
     vinsn_done_d         = alu_vinsn_done_i | mfpu_vinsn_done_i;
-    alu_vinsn_done_o     = |alu_vinsn_done_i;
-    mfpu_vinsn_done_o    = |mfpu_vinsn_done_i;
+    alu_vinsn_done_d     = |alu_vinsn_done_i;
+    mfpu_vinsn_done_d    = |mfpu_vinsn_done_i;
     pe_resp_o.vinsn_done = vinsn_done_q;
 
     // Make no requests to the operand requester
@@ -630,12 +633,18 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
 
       vfu_operation_o       <= '0;
       vfu_operation_valid_o <= 1'b0;
+
+      alu_vinsn_done_o  <= 1'b0;
+      mfpu_vinsn_done_o <= 1'b0;
     end else begin
       vinsn_done_q    <= vinsn_done_d;
       vinsn_running_q <= vinsn_running_d;
 
       vfu_operation_o       <= vfu_operation_d;
       vfu_operation_valid_o <= vfu_operation_valid_d;
+
+      alu_vinsn_done_o  <= alu_vinsn_done_d;
+      mfpu_vinsn_done_o <= mfpu_vinsn_done_d;
     end
   end
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -50,7 +50,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
   ////////////////////////////////
 
   // We store a certain number of in-flight vector instructions
-  localparam VInsnQueueDepth = 4;
+  localparam VInsnQueueDepth = ValuInsnQueueDepth;
 
   struct packed {
     vfu_operation_t [VInsnQueueDepth-1:0] vinsn;

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -55,7 +55,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*; #(
   ////////////////////////////////
 
   // We store a certain number of in-flight vector instructions
-  localparam VInsnQueueDepth = 4;
+  localparam VInsnQueueDepth = MfpuInsnQueueDepth;
 
   struct packed {
     vfu_operation_t [VInsnQueueDepth-1:0] vinsn;

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -94,7 +94,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
   // unit is only capable of handling one vector instruction at a time.
   // Optimizing this unit is left as future work.
 
-  localparam VInsnQueueDepth = 1;
+  localparam VInsnQueueDepth = MaskuInsnQueueDepth;
 
   struct packed {
     pe_req_t [VInsnQueueDepth-1:0] vinsn;

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -48,7 +48,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
   ////////////////////////////////
 
   // We store a certain number of in-flight vector instructions
-  localparam VInsnQueueDepth = 2;
+  localparam VInsnQueueDepth = SlduInsnQueueDepth;
 
   struct packed {
     pe_req_t [VInsnQueueDepth-1:0] vinsn;

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -60,7 +60,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
   ////////////////////////////////
 
   // We store a certain number of in-flight vector instructions
-  localparam VInsnQueueDepth = 4;
+  localparam VInsnQueueDepth = VlduInsnQueueDepth;
 
   struct packed {
     pe_req_t [VInsnQueueDepth-1:0] vinsn;

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -93,7 +93,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
   ////////////////////////////////
 
   // We store a certain number of in-flight vector instructions
-  localparam VInsnQueueDepth = 4;
+  localparam VInsnQueueDepth = VstuInsnQueueDepth;
 
   struct packed {
     pe_req_t [VInsnQueueDepth-1:0] vinsn;


### PR DESCRIPTION
# Merge `synth` branch before this one

With this PR, the sequencer is changed to:
1) Alleviate the timing pressure between the lanes and the main sequencer.
2) Allow the sequencer to issue instructions to non-full units, even if other units are full.

The sequencer now implements counters to check if a specific unit is ready or not, and instructions are counted (i.e. validated) upon entrance.

**Lane synchronization**: ALU and MFPU have only one dedicated counter each in the sequencer, and the related `done` signals come from `lane 0`. This mechanism works if `lane 0` is the last at finishing the execution. For this reason, in the case of a lane de-synchronization in which `lane 0` finishes executing an instruction and there is at least another lane that is still executing the same instruction, the sequencer stalls until all the lanes have finished executing that instruction. This costs an additional cycle, but this kind of lane de-synchronization is not common.

No timing degradation seen until commit 33ef369cf79b8454bef83cd049208339afa04a0e. The last commit was not used to P&R the architecture, but it should not be problematic at all.

**BE AWARE**: for some applications, this PR can lead to IPC degradations.

## Changelog

### Fixed

- Avoid corner-case in which the sequencer issues the same instruction multiple times when two units become non-ready at the same time. 

### Added

- The sequencer can issue instructions to non-full units even if the other units are full.

### Changed

- The main sequencer issues instructions every time the target unit has a non-full instruction queue.
- If the target unit is inside a lane, the instruction can be stalled if the target operand requesters are not ready.
- New instruction enters the main sequencer with a token that marks the instruction as new.
- The instructions are validated and counted when they enter the main sequencer.
- A priority-pass mechanism allows an early issue of instructions stalled in the sequencer.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
