### PR TITLE
minimal example that reproduce hang on ara-2-lanes.

### DIFF
--- a/apps/produce-hang/main.c
+++ b/apps/produce-hang/main.c
@@ -1,0 +1,16 @@
+// Author: Yanghao Hua <huayanghao@gmail.com>
+
+#include <stdint.h>
+#include <string.h>
+#include "runtime.h"
+
+#include "printf.h"
+
+extern int test_hang(int n, int m);
+
+int main() {
+  printf("test start ...\n");
+  int r = test_hang(256, 1);
+  printf("test done: %d\n", r);
+  return 0;
+}

--- a/apps/produce-hang/test.S
+++ b/apps/produce-hang/test.S
@@ -1,0 +1,35 @@
+# Auther: Yanghao Hua <huayanghao@gmail.com>
+
+.section .text
+.global test_hang
+# a0: parallel computes
+# a1: loops
+test_hang:
+	li a2, 0 # loop index
+	li a7, 3 # random value
+	vsetvli t0, a0, e16, m1, ta, ma
+	bne t0, a0, size_error
+
+core_loop:
+	# doesn't matter what are the values
+	# in the vector registers
+	vadd.vv v31, v28, v24, v0.t
+	srl t4, a2, a7
+	mv t4, zero
+	# slideup zero element means a copy
+	vslideup.vx v30, v28, t4
+	vadd.vv v16, v30, v27
+core_loop_end:
+	addi a2, a2, 1
+	ble  a2, a1, core_loop
+
+	li a0, 0
+debug:
+	ret
+
+size_error:
+	li a0, 1
+	ret
+
+test_end:
+	j test_end


### PR DESCRIPTION
Note: this minimal example is not as strong as the full blown
program, which not only hangs on ara-2-lanes but also ara-4-lanes.
And it seems there is a pattern that VL==128 hangs ara-2-lanes and
VL==256 hangs ara-4-lanes (those are reproduced), and maybe VL==512
would hang ara-8-lanes, VL==1024 would hang ara-16-lanes (those are
not tried out yet).