### PR TITLE
cva6: Widen AXI data width

### DIFF
--- a/hardware/src/ara_system.sv
+++ b/hardware/src/ara_system.sv
@@ -84,7 +84,16 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
   logic                                 inval_ready;
 
   ariane #(
-    .ArianeCfg(ArianeCfg)
+    .ArianeCfg     (ArianeCfg            ),
+    .AxiAddrWidth  (AxiAddrWidth         ),
+    .AxiDataWidth  (AxiNarrowDataWidth   ),
+    .AxiIdWidth    (AxiIdWidth           ),
+    .AxiUserWidth  (ariane_axi::UserWidth),
+    .axi_ar_chan_t (ariane_axi_ar_t      ),
+    .axi_aw_chan_t (ariane_axi_aw_t      ),
+    .axi_w_chan_t  (ariane_axi_w_t       ),
+    .axi_req_t     (ariane_axi_req_t     ),
+    .axi_rsp_t     (ariane_axi_resp_t    )
   ) i_ariane (
     .clk_i            (clk_i                 ),
     .rst_ni           (rst_ni                ),


### PR DESCRIPTION
Set Ariane's AXI data width to its data cache width (currently 512 bit)

## Changelog

### Changed

- Update to CVA6 version with parametrised AXI data width
- Separate AXI types for Ariane and Peripherals (so that the data widths are independent)

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed
