### PR TITLE
Integer Reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
  - Avoid corner-case in which the sequencer issues the same instruction multiple times when two units become non-ready at the same time
  - The lane sequencer now calculates the correct number of elements to be requested by the `MASKU` operand requesters
+ - When the instruction queue of the SLDU is not empty, read from it to update the commit counter, and not from the incoming request
+ - If an instruction targets more FUs, all of them must be ready to let the instruction be dispatched by the sequencer
 
 ## Added
 
  - The sequencer can issue instructions to non-full units even if the other units are full
  - Vector indexed unordered/ordered load (`vluxei8`, `vluxei16`, `vluxei32`, `vluxei64`, `vloxei8`, `vloxei16`, `vloxei32`, `vloxei64`)
  - Vector indexed unordered/ordered stores (`vsuxei8`, `vsuxei16`, `vsuxei32`, `vsuxei64`, `vsoxei8`, `vsoxei16`, `vsoxei32`, `vsoxei64`)
+ - Vector integer reductions (`vredsum`, `vredmaxu`, `vredmax`, `vredminu`, `vredmin`, `vredand`, `vredor`, `vredxor`, `vwredsumu`, `vwredsum`)
 
 ## Changed
 

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -53,6 +53,11 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 - Vector widening floating-point/integer type-convert instructions: `vfwcvt.xu.f`, `vfwcvt.x.f`, `vfwcvt.rtz.xu.f`, `vfwcvt.rtz.x.f`, `vfwcvt.f.xu`, `vfwcvt.f.x`, `vfwcvt.f.f`
 - Vector narrowing floating-point/integer type-convert instructions: `vfncvt.xu.f`, `vfncvt.x.f`, `vfncvt.rtz.xu.f`, `vfncvt.rtz.x.f`, `vfncvt.f.xu`, `vfncvt.f.x`, `vfncvt.f.f`
 
+## Vector Reduction Operations
+
+- Vector single-width integer reduction instructions: `vredsum`, `vredmaxu`, `vredmax`, `vredminu`, `vredmin`, `vredand`, `vredor`, `vredxor`
+- Vector widening integer reductions: `vwredsumu`, `vwredsum`
+
 ## Vector mask instructions
 
 - Vector mask-register logical instructions: `vmand`, `vmnand`, `vmandnot`, `vmxor`, `vmor`, `vmnor`, `vmornot`, `vmxnor`

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -68,6 +68,8 @@ rv64uv_sc_tests = vadd \
                   vredand \
                   vredor \
                   vredxor \
+                  vwredsumu \
+                  vwredsum \
                   vfadd \
                   vfsub \
                   vfrsub \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -60,6 +60,14 @@ rv64uv_sc_tests = vadd \
                   vmerge \
                   vmv \
                   vmvnrr \
+                  vredsum \
+                  vredmaxu \
+                  vredmax \
+                  vredminu \
+                  vredmin \
+                  vredand \
+                  vredor \
+                  vredxor \
                   vfadd \
                   vfsub \
                   vfrsub \

--- a/apps/riscv-tests/isa/rv64uv/vredand.c
+++ b/apps/riscv-tests/isa/rv64uv/vredand.c
@@ -1,0 +1,93 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(12, e8, m1);
+  VLOAD_8(v1, 0xff, 0xf1, 0xf0, 0xff, 0xf1, 0xf0, 0xff, 0xf1, 0xf0, 0xff, 0xf1,
+          0xf0);
+  VLOAD_8(v2, 0xf0);
+  asm volatile("vredand.vs v3, v1, v2");
+  VCMP_U8(1, v3, 0xf0);
+
+  VSET(12, e16, m1);
+  VLOAD_16(v1, 0xffff, 0x0301, 0xf1f0, 0xffff, 0x0101, 0xf7f0, 0xffff, 0x0701,
+           0xfff0, 0xffff, 0x0101, 0xf1f0);
+  VLOAD_16(v2, 0xefff);
+  asm volatile("vredand.vs v3, v1, v2");
+  VCMP_U16(2, v3, 0x0100);
+
+  VSET(12, e32, m1);
+  VLOAD_32(v1, 0xffffffff, 0x100ff001, 0xf0f0f0f0, 0xffffffff, 0x100ff001,
+           0xf0f0f0f0, 0xffffffff, 0x100ff001, 0xf0f0f0f0, 0xffffffff,
+           0x100ff001, 0xf0f0f0f0);
+  VLOAD_32(v2, 0x00f010f0);
+  asm volatile("vredand.vs v3, v1, v2");
+  VCMP_U32(3, v3, 0x00001000);
+
+  VSET(12, e64, m1);
+  VLOAD_64(v1, 0xffffffffffffffff, 0x1000000000000001, 0xf0f0f0f0f0f0f0f0,
+           0xffffffffffffffff, 0x1000000000000001, 0xf0f0f0f0f0f0f0f0,
+           0xffffffffffffffff, 0x1000000000000001, 0xf0f0f0f0f0f0f0f0,
+           0xffffffffffffffff, 0x1000000000000001, 0xf0f0f0f0f0f0f0f0);
+  VLOAD_64(v2, 0xfffffffffffffff7);
+  asm volatile("vredand.vs v3, v1, v2");
+  VCMP_U64(4, v3, 0x1000000000000000);
+}
+
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(12, e8, m1);
+  VLOAD_8(v0, 0xf7, 0xff);
+  VLOAD_8(v1, 0xff, 0xf1, 0xff, 0x00, 0xf1, 0xf0, 0xff, 0xf1, 0xf0, 0xff, 0xf1,
+          0xf0);
+  VLOAD_8(v2, 0xf0);
+  VLOAD_8(v3, 1);
+  asm volatile("vredand.vs v3, v1, v2, v0.t");
+  VCMP_U8(5, v3, 0xf0);
+
+  VSET(12, e16, m1);
+  VLOAD_8(v0, 0x00, 0x08);
+  VLOAD_16(v1, 0xffff, 0x0301, 0xf1f0, 0xffff, 0x0101, 0xf7f0, 0xffff, 0x9701,
+           0xfff0, 0xffff, 0x0101, 0xf1f0);
+  VLOAD_16(v2, 0xefff);
+  VLOAD_16(v3, 1);
+  asm volatile("vredand.vs v3, v1, v2, v0.t");
+  VCMP_U16(6, v3, 0xe1f0);
+
+  VSET(12, e32, m1);
+  VLOAD_8(v0, 0xfe, 0xff);
+  VLOAD_32(v1, 0x00000000, 0x100ff001, 0xf0f0f0f0, 0xffffffff, 0x100ff001,
+           0xf0f0f0f0, 0xffffffff, 0x100ff001, 0xf0f0f0f0, 0xffffffff,
+           0x100ff001, 0xf0f0f0f0);
+  VLOAD_32(v2, 0x00f010f0);
+  VLOAD_32(v3, 1);
+  asm volatile("vredand.vs v3, v1, v2, v0.t");
+  VCMP_U32(7, v3, 0x00001000);
+
+  VSET(12, e64, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_64(v1, 0xffffffffffffffff, 0x1000000000000001, 0xf0f0f0f0f0f0f0f0,
+           0xffffffffffffffff, 0x1000000000000001, 0xf0f0f0f0f0f0f0f0,
+           0xffffffffffffffff, 0x1000000000000001, 0xf0f0f0f0f0f0f0f0,
+           0xffffffffffffffff, 0x1000000000000001, 0xf0f0f0f0f0f0f0f0);
+  VLOAD_64(v2, 0xfffffffffffffff7);
+  VLOAD_64(v3, 1);
+  asm volatile("vredand.vs v3, v1, v2, v0.t");
+  VCMP_U64(8, v3, 0x1000000000000000);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vredmax.c
+++ b/apps/riscv-tests/isa/rv64uv/vredmax.c
@@ -1,0 +1,79 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, -7, 8, 1, 9, 3, 4, 5, -6, 7, 8);
+  VLOAD_8(v2, -1);
+  asm volatile("vredmax.vs v3, v1, v2");
+  VCMP_U8(1, v3, 9);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v1, -1, 2, -3, 4, 5, 6, 7, 8, 1, 2, 3, -4, 5, 6, 7, 8);
+  VLOAD_16(v2, 9);
+  asm volatile("vredmax.vs v3, v1, v2");
+  VCMP_U16(2, v3, 9);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 9, 2, 3, -4, 5, 6, 7, 8, 1, 2, 3, 4, -5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  asm volatile("vredmax.vs v3, v1, v2");
+  VCMP_U32(3, v3, 9);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v1, -1, 2, 3, -4, 5, 6, 7, 9, 1, 2, 3, 4, 5, 6, 7, -8);
+  VLOAD_64(v2, -1);
+  asm volatile("vredmax.vs v3, v1, v2");
+  VCMP_U64(4, v3, 9);
+}
+
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v0, 0x03, 0x00);
+  VLOAD_8(v1, -1, 2, 3, -4, 5, 6, 7, 9, 1, -2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  VLOAD_8(v3, 1);
+  asm volatile("vredmax.vs v3, v1, v2, v0.t");
+  VCMP_U8(5, v3, 2);
+
+  VSET(16, e16, m1);
+  VLOAD_8(v0, 0x00, 0xc0);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, -7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 9);
+  VLOAD_16(v3, 1);
+  asm volatile("vredmax.vs v3, v1, v2, v0.t");
+  VCMP_U16(6, v3, 9);
+
+  VSET(16, e32, m1);
+  VLOAD_8(v0, 0x00, 0xc0);
+  VLOAD_32(v1, -1, 2, 3, 4, 5, 6, 7, -8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  VLOAD_32(v3, 1);
+  asm volatile("vredmax.vs v3, v1, v2, v0.t");
+  VCMP_U32(7, v3, 8);
+
+  VSET(16, e64, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_64(v1, 1, -2, 3, 4, 5, 6, -7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 4);
+  VLOAD_64(v3, 1);
+  asm volatile("vredmax.vs v3, v1, v2, v0.t");
+  VCMP_U64(8, v3, 8);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vredmaxu.c
+++ b/apps/riscv-tests/isa/rv64uv/vredmaxu.c
@@ -1,0 +1,106 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 9, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2");
+  VCMP_U8(1, v3, 9);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 9);
+  asm volatile("vredmaxu.vs v3, v1, v2");
+  VCMP_U16(2, v3, 9);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 9, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2");
+  VCMP_U32(3, v3, 9);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 9, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2");
+  VCMP_U64(4, v3, 9);
+}
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v0, 0x03, 0x00);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 9, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  VLOAD_8(v3, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2, v0.t");
+  VCMP_U8(5, v3, 2);
+
+  VSET(16, e16, m1);
+  VLOAD_8(v0, 0x00, 0xc0);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 9);
+  VLOAD_16(v3, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2, v0.t");
+  VCMP_U16(6, v3, 9);
+
+  VSET(16, e32, m1);
+  VLOAD_8(v0, 0x00, 0xc0);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  VLOAD_32(v3, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2, v0.t");
+  VCMP_U32(7, v3, 8);
+
+  VSET(16, e64, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 4);
+  VLOAD_64(v3, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2, v0.t");
+  VCMP_U64(8, v3, 8);
+}
+
+// Naive test with negative values
+void TEST_CASE3(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 9, -3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2");
+  VCMP_U8(9, v3, -3);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, -9);
+  asm volatile("vredmaxu.vs v3, v1, v2");
+  VCMP_U16(10, v3, -9);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 9, 2, 3, 4, -5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  asm volatile("vredmaxu.vs v3, v1, v2");
+  VCMP_U32(11, v3, -5);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, -4, 5, 6, 7, 9, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, -1);
+  asm volatile("vredmaxu.vs v3, v1, v2");
+  VCMP_U64(12, v3, -1);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vredmin.c
+++ b/apps/riscv-tests/isa/rv64uv/vredmin.c
@@ -1,0 +1,78 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 0, 1, 9, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  asm volatile("vredmin.vs v3, v1, v2");
+  VCMP_U8(1, v3, 0);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 1, 2, -3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 0);
+  asm volatile("vredmin.vs v3, v1, v2");
+  VCMP_U16(2, v3, -3);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 9, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, -1);
+  asm volatile("vredmin.vs v3, v1, v2");
+  VCMP_U32(3, v3, -1);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v1, -1, 2, 3, 4, 5, -6, 7, -9, -1, -2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, -1);
+  asm volatile("vredmin.vs v3, v1, v2");
+  VCMP_U64(4, v3, -9);
+}
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v0, 0x03, 0x00);
+  VLOAD_8(v1, 1, -2, 3, 4, 5, 6, 7, 9, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  VLOAD_8(v3, 1);
+  asm volatile("vredmin.vs v3, v1, v2, v0.t");
+  VCMP_U8(5, v3, -2);
+
+  VSET(16, e16, m1);
+  VLOAD_8(v0, 0x00, 0xc0);
+  VLOAD_16(v1, -1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 3);
+  VLOAD_16(v3, 1);
+  asm volatile("vredmin.vs v3, v1, v2, v0.t");
+  VCMP_U16(6, v3, 3);
+
+  VSET(16, e32, m1);
+  VLOAD_8(v0, 0x00, 0xc0);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 8);
+  VLOAD_32(v3, 1);
+  asm volatile("vredmin.vs v3, v1, v2, v0.t");
+  VCMP_U32(7, v3, 7);
+
+  VSET(16, e64, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 4);
+  VLOAD_64(v3, 1);
+  asm volatile("vredmin.vs v3, v1, v2, v0.t");
+  VCMP_U64(8, v3, 1);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vredminu.c
+++ b/apps/riscv-tests/isa/rv64uv/vredminu.c
@@ -1,0 +1,78 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 0, 1, 9, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  asm volatile("vredminu.vs v3, v1, v2");
+  VCMP_U8(1, v3, 0);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 1, 2, -3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 0);
+  asm volatile("vredminu.vs v3, v1, v2");
+  VCMP_U16(2, v3, 0);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 9, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, -1);
+  asm volatile("vredminu.vs v3, v1, v2");
+  VCMP_U32(3, v3, 1);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v1, -1, 2, 3, 4, 5, -6, 7, -9, -1, -2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, -1);
+  asm volatile("vredminu.vs v3, v1, v2");
+  VCMP_U64(4, v3, 2);
+}
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v0, 0x03, 0x00);
+  VLOAD_8(v1, 1, -2, 3, 4, 5, 6, 7, 9, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  VLOAD_8(v3, 1);
+  asm volatile("vredminu.vs v3, v1, v2, v0.t");
+  VCMP_U8(5, v3, 1);
+
+  VSET(16, e16, m1);
+  VLOAD_8(v0, 0x00, 0xc0);
+  VLOAD_16(v1, -1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 3);
+  VLOAD_16(v3, 1);
+  asm volatile("vredminu.vs v3, v1, v2, v0.t");
+  VCMP_U16(6, v3, 3);
+
+  VSET(16, e32, m1);
+  VLOAD_8(v0, 0x00, 0xc0);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 8);
+  VLOAD_32(v3, 1);
+  asm volatile("vredminu.vs v3, v1, v2, v0.t");
+  VCMP_U32(7, v3, 7);
+
+  VSET(16, e64, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 4);
+  VLOAD_64(v3, 1);
+  asm volatile("vredminu.vs v3, v1, v2, v0.t");
+  VCMP_U64(8, v3, 1);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vredor.c
+++ b/apps/riscv-tests/isa/rv64uv/vredor.c
@@ -1,0 +1,93 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(12, e8, m1);
+  VLOAD_8(v1, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x01,
+          0x00);
+  VLOAD_8(v2, 0x10);
+  asm volatile("vredor.vs v3, v1, v2");
+  VCMP_U8(1, v3, 0x11);
+
+  VSET(12, e16, m1);
+  VLOAD_16(v1, 0x0000, 0x0301, 0x0100, 0x0000, 0x0101, 0x0700, 0x0000, 0x0701,
+           0x0000, 0x0000, 0x0101, 0x0100);
+  VLOAD_16(v2, 0xe000);
+  asm volatile("vredor.vs v3, v1, v2");
+  VCMP_U16(2, v3, 0xe701);
+
+  VSET(12, e32, m1);
+  VLOAD_32(v1, 0x00000000, 0x10000001, 0x00000000, 0x00000000, 0x10000001,
+           0x00000000, 0x00000000, 0x10000001, 0x00000000, 0x00000000,
+           0x10000001, 0x00000000);
+  VLOAD_32(v2, 0x00001000);
+  asm volatile("vredor.vs v3, v1, v2");
+  VCMP_U32(3, v3, 0x10001001);
+
+  VSET(12, e64, m1);
+  VLOAD_64(v1, 0x0000000000000000, 0x1000000000000001, 0x0000000000000000,
+           0x0000000000000000, 0x1000000000000001, 0x0000000000000000,
+           0x0000000000000000, 0x1000000000000001, 0x0000000000000000,
+           0x0000000000000000, 0x1000000000000001, 0x0000000000000000);
+  VLOAD_64(v2, 0x0000000000000007);
+  asm volatile("vredor.vs v3, v1, v2");
+  VCMP_U64(4, v3, 0x1000000000000007);
+}
+
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(12, e8, m1);
+  VLOAD_8(v0, 0x07, 0x00);
+  VLOAD_8(v1, 0x00, 0x01, 0x00, 0xff, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x01,
+          0x00);
+  VLOAD_8(v2, 0x00);
+  VLOAD_8(v3, 1);
+  asm volatile("vredor.vs v3, v1, v2, v0.t");
+  VCMP_U8(5, v3, 0x01);
+
+  VSET(12, e16, m1);
+  VLOAD_8(v0, 0x00, 0x08);
+  VLOAD_16(v1, 0x0f00, 0x0301, 0x0100, 0x0000, 0x0101, 0x0700, 0x0000, 0x9701,
+           0x0000, 0x0000, 0x0101, 0x0100);
+  VLOAD_16(v2, 0xe000);
+  VLOAD_16(v3, 1);
+  asm volatile("vredor.vs v3, v1, v2, v0.t");
+  VCMP_U16(6, v3, 0xe100);
+
+  VSET(12, e32, m1);
+  VLOAD_8(v0, 0x0e, 0x00);
+  VLOAD_32(v1, 0xf0000fff, 0x10000001, 0x00000000, 0x00000000, 0x10000001,
+           0x00000000, 0x00000000, 0x10000001, 0x00000000, 0x00000000,
+           0x10000001, 0x00000000);
+  VLOAD_32(v2, 0x00001000);
+  VLOAD_32(v3, 1);
+  asm volatile("vredor.vs v3, v1, v2, v0.t");
+  VCMP_U32(7, v3, 0x10001001);
+
+  VSET(12, e64, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_64(v1, 0x0000000000000000, 0x1000000000000001, 0x0000f00000000000,
+           0x0000000000000000, 0x1000000000000001, 0x0000000000000000,
+           0x0000000000000000, 0x1000000000000001, 0x0000000000000000,
+           0x0000000000000000, 0x1000000000000001, 0x0000000000000000);
+  VLOAD_64(v2, 0x0000000000000007);
+  VLOAD_64(v3, 1);
+  asm volatile("vredor.vs v3, v1, v2, v0.t");
+  VCMP_U64(8, v3, 0x1000000000000007);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vredsum.c
+++ b/apps/riscv-tests/isa/rv64uv/vredsum.c
@@ -1,0 +1,178 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U8(1, v3, 73);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U16(2, v3, 73);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U32(3, v3, 73);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U64(4, v3, 73);
+}
+
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1);
+  VLOAD_8(v3, 1);
+  asm volatile("vredsum.vs v3, v1, v2, v0.t");
+  VCMP_U8(5, v3, 37);
+
+  VSET(16, e16, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1);
+  VLOAD_16(v3, 1);
+  asm volatile("vredsum.vs v3, v1, v2, v0.t");
+  VCMP_U16(6, v3, 37);
+
+  VSET(16, e32, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  VLOAD_32(v3, 1);
+  asm volatile("vredsum.vs v3, v1, v2, v0.t");
+  VCMP_U32(7, v3, 37);
+
+  VSET(16, e64, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1);
+  VLOAD_64(v3, 1);
+  asm volatile("vredsum.vs v3, v1, v2, v0.t");
+  VCMP_U64(8, v3, 37);
+}
+
+// Are we respecting the undisturbed tail policy?
+void TEST_CASE3(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U8(9, v3, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U16(10, v3, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U32(11, v3, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U64(12, v3, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+// Odd number of elements, undisturbed policy
+void TEST_CASE4(void) {
+  VSET(15, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U8(13, v3, 65, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(1, e16, m1);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U16(14, v3, 2, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(3, e32, m1);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U32(15, v3, 7, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(7, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U64(16, v3, 29, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(15, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2");
+  VCMP_U64(17, v3, 65, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+// Odd number of elements, undisturbed policy, and mask
+void TEST_CASE5(void) {
+  VSET(15, e8, m1);
+  VLOAD_8(v0, 0x00, 0x40);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 100, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2, v0.t");
+  VCMP_U8(18, v3, 107, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(1, e16, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2, v0.t");
+  VCMP_U16(19, v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(3, e32, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v3, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vredsum.vs v3, v1, v2, v0.t");
+  VCMP_U32(20, v3, 3, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vredxor.c
+++ b/apps/riscv-tests/isa/rv64uv/vredxor.c
@@ -1,0 +1,44 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(4, e8, m1);
+  VLOAD_8(v1, 0x00, 0x01, 0x01, 0x00);
+  VLOAD_8(v2, 0x11);
+  asm volatile("vredxor.vs v3, v1, v2");
+  VCMP_U8(1, v3, 0x11);
+
+  VSET(4, e16, m1);
+  VLOAD_16(v1, 0x8000, 0x0301, 0x0101, 0x0001);
+  VLOAD_16(v2, 0xe001);
+  asm volatile("vredxor.vs v3, v1, v2");
+  VCMP_U16(2, v3, 0x6200);
+
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 0x00000001, 0x10000001, 0x00000000, 0x00000000);
+  VLOAD_32(v2, 0x00001000);
+  asm volatile("vredxor.vs v3, v1, v2");
+  VCMP_U32(3, v3, 0x10001000);
+
+  VSET(4, e64, m1);
+  VLOAD_64(v1, 0x0000000000000000, 0x1000000000000001, 0x0000000000000000,
+           0x0000000000000000);
+  VLOAD_64(v2, 0x0000000000000007);
+  asm volatile("vredxor.vs v3, v1, v2");
+  VCMP_U64(4, v3, 0x1000000000000006);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vwredsum.c
+++ b/apps/riscv-tests/isa/rv64uv/vwredsum.c
@@ -1,0 +1,153 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 255);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U16(1, v4, 327);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U32(2, v4, 73);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U64(3, v4, 73);
+}
+
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 255);
+  VLOAD_16(v4, 1);
+  asm volatile("vwredsum.vs v4, v6, v2, v0.t");
+  VCMP_U16(4, v4, 291);
+
+  VSET(16, e16, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  VLOAD_32(v4, 1);
+  asm volatile("vwredsum.vs v4, v6, v2, v0.t");
+  VCMP_U32(5, v4, 37);
+
+  VSET(16, e32, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1);
+  VLOAD_64(v4, 1);
+  asm volatile("vwredsum.vs v4, v6, v2, v0.t");
+  VCMP_U64(6, v4, 37);
+}
+
+// Are we respecting the undisturbed tail policy?
+void TEST_CASE3(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U16(7, v4, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U32(8, v4, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U64(9, v4, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+// Odd number of elements, undisturbed policy
+void TEST_CASE4(void) {
+  VSET(15, e8, m1);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U16(10, v4, 65, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(1, e16, m1);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U32(11, v4, 2, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(3, e32, m1);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U64(12, v4, 7, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+// Odd number of elements, undisturbed policy, and mask
+void TEST_CASE5(void) {
+  VSET(15, e8, m1);
+  VLOAD_8(v0, 0x00, 0x40);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 100, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2, v0.t");
+  VCMP_U16(13, v4, 107, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(1, e16, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2, v0.t");
+  VCMP_U32(14, v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(3, e32, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsum.vs v4, v6, v2, v0.t");
+  VCMP_U64(15, v4, 3, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+// Test difference from vwredsumu
+void TEST_CASE6(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 255, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 255);
+  asm volatile("vwredsum.vs v4, v6, v2");
+  VCMP_U16(16, v4, 325);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+  TEST_CASE6();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vwredsumu.c
+++ b/apps/riscv-tests/isa/rv64uv/vwredsumu.c
@@ -1,0 +1,153 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+// Naive test
+void TEST_CASE1(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 255);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U16(1, v4, 327);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U32(2, v4, 73);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U64(3, v4, 73);
+}
+
+// Masked naive test
+void TEST_CASE2(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 255);
+  VLOAD_16(v4, 1);
+  asm volatile("vwredsumu.vs v4, v6, v2, v0.t");
+  VCMP_U16(4, v4, 291);
+
+  VSET(16, e16, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1);
+  VLOAD_32(v4, 1);
+  asm volatile("vwredsumu.vs v4, v6, v2, v0.t");
+  VCMP_U32(5, v4, 37);
+
+  VSET(16, e32, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1);
+  VLOAD_64(v4, 1);
+  asm volatile("vwredsumu.vs v4, v6, v2, v0.t");
+  VCMP_U64(6, v4, 37);
+}
+
+// Are we respecting the undisturbed tail policy?
+void TEST_CASE3(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U16(7, v4, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e16, m1);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U32(8, v4, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U64(9, v4, 73, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+// Odd number of elements, undisturbed policy
+void TEST_CASE4(void) {
+  VSET(15, e8, m1);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U16(10, v4, 65, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(1, e16, m1);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U32(11, v4, 2, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(3, e32, m1);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U64(12, v4, 7, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+// Odd number of elements, undisturbed policy, and mask
+void TEST_CASE5(void) {
+  VSET(15, e8, m1);
+  VLOAD_8(v0, 0x00, 0x40);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 100, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2, v0.t");
+  VCMP_U16(13, v4, 107, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(1, e16, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_16(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_32(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2, v0.t");
+  VCMP_U32(14, v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+
+  VSET(3, e32, m1);
+  VLOAD_8(v0, 0xaa, 0x55);
+  VLOAD_32(v6, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_64(v4, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vwredsumu.vs v4, v6, v2, v0.t");
+  VCMP_U64(15, v4, 3, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+}
+
+// Test difference from vwredsumu
+void TEST_CASE6(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v6, 1, 2, 3, 4, 5, 6, 7, 8, 255, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_16(v2, 255);
+  asm volatile("vwredsumu.vs v4, v6, v2");
+  VCMP_U16(16, v4, 581);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+  TEST_CASE6();
+
+  EXIT_CHECK();
+}

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -174,10 +174,12 @@ package ara_pkg;
 
   // The FPU needs to know if, during the conversion, there is also a width change
   // Moreover, the operand requester treats widening instructions differently for handling WAW
+  // CVT_WIDE is equal to 2'b00 since these bits are reused with reductions
+  // (this is a hack to save wires)
   typedef enum logic [1:0] {
-    CVT_SAME,
-    CVT_WIDE,
-    CVT_NARROW
+    CVT_WIDE   = 2'b00,
+    CVT_SAME   = 2'b01,
+    CVT_NARROW = 2'b10
   } resize_e;
 
   // Floating-Point structs for re-encoding during widening FP operations
@@ -868,6 +870,7 @@ package ara_pkg;
     rvv_pkg::vew_e eew;        // Effective element width
     vlen_t vl;                 // Vector length
     opqueue_conversion_e conv; // Type conversion
+    logic [1:0] ntr_red;       // Neutral bits for reductions
     target_fu_e target_fu;     // Target FU of the opqueue (if it is not clear)
   } operand_queue_cmd_t;
 

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -102,6 +102,8 @@ package ara_pkg;
     VSLL, VSRL, VSRA, VNSRL, VNSRA,
     // Merge
     VMERGE,
+    // Integer Reductions
+    VREDSUM, VREDAND, VREDOR, VREDXOR, VREDMINU, VREDMIN, VREDMAXU, VREDMAX, VWREDSUMU, VWREDSUM,
     // Mul/Mul-Add
     VMUL, VMULH, VMULHU, VMULHSU, VMACC, VNMSAC, VMADD, VNMSUB,
     // Div
@@ -136,6 +138,12 @@ package ara_pkg;
     is_store = op inside {[VSE:VSXE]};
   endfunction : is_store
 
+  typedef enum logic [1:0] {
+    NO_RED,
+    ALU_RED,
+    MFPU_RED
+  } sldu_mux_e;
+
   ////////////////////////
   //  Width conversion  //
   ////////////////////////
@@ -147,7 +155,7 @@ package ara_pkg;
   // an element of width SEW for the functional units. The operand queues support the following
   // type conversions:
 
-  localparam int unsigned NumConversions = 9;
+  localparam int unsigned NumConversions = 10;
 
   typedef enum logic [$clog2(NumConversions)-1:0] {
     OpQueueConversionNone,
@@ -158,6 +166,7 @@ package ara_pkg;
     OpQueueConversionZExt8,
     OpQueueConversionSExt8,
     OpQueueConversionWideFP2,
+    OpQueueReductionZExt,
     OpQueueAdjustFPCvt
   } opqueue_conversion_e;
   // OpQueueAdjustFPCvt is introduced to support widening FP conversions, to comply with the
@@ -295,7 +304,7 @@ package ara_pkg;
   // scale also are with index given by NrLanes plus the following offset.
   //
   // The load and the store unit must be at the beginning of this enumeration.
-  typedef enum {
+  typedef enum logic [1:0] {
     OffsetLoad, OffsetStore, OffsetMask, OffsetSlide
   } vfu_offset_e;
 

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -207,7 +207,6 @@ module ara import ara_pkg::*; #(
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
       .NrLanes   (NrLanes   ),
-      .LaneIdx   (lane      ),
       .FPUSupport(FPUSupport)
     ) i_lane (
       .clk_i                           (clk_i                               ),

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -168,8 +168,11 @@ module ara import ara_pkg::*; #(
   elen_t     [NrLanes-1:0]                     sldu_addrgen_operand;
   target_fu_e[NrLanes-1:0]                     sldu_addrgen_operand_target_fu;
   logic      [NrLanes-1:0]                     sldu_addrgen_operand_valid;
-  logic                                        sldu_operand_ready;
+  logic      [NrLanes-1:0]                     sldu_operand_ready;
+  sldu_mux_e                                   sldu_mux_sel;
   logic                                        addrgen_operand_ready;
+  logic      [NrLanes-1:0]                     sldu_red_valid;
+
   // Mask unit operands
   elen_t     [NrLanes-1:0][NrMaskFUnits+2-1:0] masku_operand;
   logic      [NrLanes-1:0][NrMaskFUnits+2-1:0] masku_operand_valid;
@@ -204,6 +207,7 @@ module ara import ara_pkg::*; #(
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
       .NrLanes   (NrLanes   ),
+      .LaneIdx   (lane      ),
       .FPUSupport(FPUSupport)
     ) i_lane (
       .clk_i                           (clk_i                               ),
@@ -246,7 +250,9 @@ module ara import ara_pkg::*; #(
       .sldu_addrgen_operand_target_fu_o(sldu_addrgen_operand_target_fu[lane]),
       .sldu_addrgen_operand_valid_o    (sldu_addrgen_operand_valid[lane]    ),
       .addrgen_operand_ready_i         (addrgen_operand_ready               ),
-      .sldu_operand_ready_i            (sldu_operand_ready                  ),
+      .sldu_mux_sel_i                  (sldu_mux_sel                        ),
+      .sldu_operand_ready_i            (sldu_operand_ready[lane]            ),
+      .sldu_red_valid_i                (sldu_red_valid[lane]                ),
       // Interface with the mask unit
       .mask_operand_o                  (masku_operand[lane]                 ),
       .mask_operand_valid_o            (masku_operand_valid[lane]           ),
@@ -358,6 +364,8 @@ module ara import ara_pkg::*; #(
     .sldu_result_be_o        (sldu_result_be                   ),
     .sldu_result_wdata_o     (sldu_result_wdata                ),
     .sldu_result_gnt_i       (sldu_result_gnt                  ),
+    .sldu_mux_sel_o          (sldu_mux_sel                     ),
+    .sldu_red_valid_o        (sldu_red_valid                   ),
     // Interface with the Mask unit
     .mask_i                  (mask                             ),
     .mask_valid_i            (mask_valid                       ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -510,6 +510,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       default:;
                     endcase
                   end
+                  // Reductions encode in cvt_resize the neutral value bits
+                  // CVT_WIDE is 2'b00 (hack to save wires)
                   6'b110000: begin
                     ara_req_d.op = ara_pkg::VWREDSUMU;
                     ara_req_d.emul           = next_lmul(vtype_q.vlmul);
@@ -944,37 +946,47 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Decode based on the func6 field
                 unique case (insn.varith_type.func6)
+                  // Encode, for each reduction, the bits of the neutral
+                  // value of each operation
                   6'b000000: begin
                     ara_req_d.op             = ara_pkg::VREDSUM;
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.cvt_resize     = resize_e'(2'b00);
                   end
                   6'b000001: begin
                     ara_req_d.op             = ara_pkg::VREDAND;
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.cvt_resize     = resize_e'(2'b11);
                   end
                   6'b000010: begin
                     ara_req_d.op             = ara_pkg::VREDOR;
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.cvt_resize     = resize_e'(2'b00);
                   end
                   6'b000011: begin
                     ara_req_d.op             = ara_pkg::VREDXOR;
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.cvt_resize     = resize_e'(2'b00);
                   end
                   6'b000100: begin
                     ara_req_d.op             = ara_pkg::VREDMINU;
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.cvt_resize     = resize_e'(2'b11);
                   end
                   6'b000101: begin
                     ara_req_d.op             = ara_pkg::VREDMIN;
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.cvt_resize     = resize_e'(2'b01);
                   end
                   6'b000110: begin
                     ara_req_d.op             = ara_pkg::VREDMAXU;
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.cvt_resize     = resize_e'(2'b00);
                   end
                   6'b000111: begin
                     ara_req_d.op             = ara_pkg::VREDMAX;
                     ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.cvt_resize     = resize_e'(2'b10);
                   end
                   6'b011000: begin
                     ara_req_d.op        = ara_pkg::VMANDNOT;

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -510,6 +510,22 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       default:;
                     endcase
                   end
+                  6'b110000: begin
+                    ara_req_d.op = ara_pkg::VWREDSUMU;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.conversion_vs2 = OpQueueConversionZExt2;
+                    ara_req_d.cvt_resize     = CVT_WIDE;
+                  end
+                  6'b110001: begin
+                    ara_req_d.op = ara_pkg::VWREDSUM;
+                    ara_req_d.emul           = next_lmul(vtype_q.vlmul);
+                    ara_req_d.vtype.vsew     = vtype_q.vsew.next();
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                    ara_req_d.conversion_vs2 = OpQueueConversionSExt2;
+                    ara_req_d.cvt_resize     = CVT_WIDE;
+                  end
                   default: illegal_insn = 1'b1;
                 endcase
 
@@ -928,6 +944,38 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Decode based on the func6 field
                 unique case (insn.varith_type.func6)
+                  6'b000000: begin
+                    ara_req_d.op             = ara_pkg::VREDSUM;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                  end
+                  6'b000001: begin
+                    ara_req_d.op             = ara_pkg::VREDAND;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                  end
+                  6'b000010: begin
+                    ara_req_d.op             = ara_pkg::VREDOR;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                  end
+                  6'b000011: begin
+                    ara_req_d.op             = ara_pkg::VREDXOR;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                  end
+                  6'b000100: begin
+                    ara_req_d.op             = ara_pkg::VREDMINU;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                  end
+                  6'b000101: begin
+                    ara_req_d.op             = ara_pkg::VREDMIN;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                  end
+                  6'b000110: begin
+                    ara_req_d.op             = ara_pkg::VREDMAXU;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                  end
+                  6'b000111: begin
+                    ara_req_d.op             = ara_pkg::VREDMAX;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
+                  end
                   6'b011000: begin
                     ara_req_d.op        = ara_pkg::VMANDNOT;
                     ara_req_d.use_vd_op = 1'b1;

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -124,7 +124,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   // This function determines the VFU responsible for handling this operation.
   function automatic vfu_e vfu(ara_op_e op);
     unique case (op) inside
-      [VADD:VMERGE]        : vfu = VFU_Alu;
+      [VADD:VREDSUM]       : vfu = VFU_Alu;
       [VMUL:VFCVTFF]       : vfu = VFU_MFpu;
       [VMFEQ:VMXNOR]       : vfu = VFU_MaskUnit;
       [VLE:VLXE]           : vfu = VFU_LoadUnit;
@@ -142,6 +142,9 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
       [VADD:VMERGE]:
         for (int i = 0; i < NrVFUs; i++)
           if (i == VFU_Alu) target_vfus[i] = 1'b1;
+      VREDSUM:
+        for (int i = 0; i < NrVFUs; i++)
+          if (i == VFU_Alu || i == VFU_SlideUnit) target_vfus[i] = 1'b1;
       [VMUL:VFCVTFF]:
         for (int i = 0; i < NrVFUs; i++)
           if (i == VFU_MFpu) target_vfus[i] = 1'b1;

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -124,7 +124,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   // This function determines the VFU responsible for handling this operation.
   function automatic vfu_e vfu(ara_op_e op);
     unique case (op) inside
-      [VADD:VREDSUM]       : vfu = VFU_Alu;
+      [VADD:VWREDSUM]      : vfu = VFU_Alu;
       [VMUL:VFCVTFF]       : vfu = VFU_MFpu;
       [VMFEQ:VMXNOR]       : vfu = VFU_MaskUnit;
       [VLE:VLXE]           : vfu = VFU_LoadUnit;
@@ -142,7 +142,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
       [VADD:VMERGE]:
         for (int i = 0; i < NrVFUs; i++)
           if (i == VFU_Alu) target_vfus[i] = 1'b1;
-      VREDSUM:
+      [VREDSUM:VWREDSUM]:
         for (int i = 0; i < NrVFUs; i++)
           if (i == VFU_Alu || i == VFU_SlideUnit) target_vfus[i] = 1'b1;
       [VMUL:VFCVTFF]:

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -421,7 +421,6 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   assign sldu_alu_gnt                 = sldu_operand_ready_i & (sldu_mux_sel_q == ALU_RED);
 
   assign sldu_alu_valid = sldu_red_valid_i & (sldu_mux_sel_q == ALU_RED);
-  // Warning: this is an in2out path! It can be timing-critical
   assign sldu_result_gnt_o = sldu_mux_sel_q == NO_RED ? sldu_result_gnt_opqueues : sldu_alu_ready;
 
   //////////////////

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -188,61 +188,61 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .NrLanes(NrLanes          ),
     .vaddr_t(vaddr_t          )
   ) i_operand_requester (
-    .clk_i                    (clk_i                  ),
-    .rst_ni                   (rst_ni                 ),
+    .clk_i                    (clk_i                   ),
+    .rst_ni                   (rst_ni                  ),
     // Interface with the lane sequencer
-    .operand_request_i        (operand_request        ),
-    .operand_request_valid_i  (operand_request_valid  ),
-    .operand_request_ready_o  (operand_request_ready  ),
-    .vinsn_running_i          (vinsn_running          ),
+    .operand_request_i        (operand_request         ),
+    .operand_request_valid_i  (operand_request_valid   ),
+    .operand_request_ready_o  (operand_request_ready   ),
+    .vinsn_running_i          (vinsn_running           ),
     // Interface with the VRF
-    .vrf_req_o                (vrf_req                ),
-    .vrf_addr_o               (vrf_addr               ),
-    .vrf_wen_o                (vrf_wen                ),
-    .vrf_wdata_o              (vrf_wdata              ),
-    .vrf_be_o                 (vrf_be                 ),
-    .vrf_tgt_opqueue_o        (vrf_tgt_opqueue        ),
+    .vrf_req_o                (vrf_req                 ),
+    .vrf_addr_o               (vrf_addr                ),
+    .vrf_wen_o                (vrf_wen                 ),
+    .vrf_wdata_o              (vrf_wdata               ),
+    .vrf_be_o                 (vrf_be                  ),
+    .vrf_tgt_opqueue_o        (vrf_tgt_opqueue         ),
     // Interface with the operand queues
-    .operand_issued_o         (operand_issued         ),
-    .operand_queue_ready_i    (operand_queue_ready    ),
-    .operand_queue_cmd_o      (operand_queue_cmd      ),
-    .operand_queue_cmd_valid_o(operand_queue_cmd_valid),
+    .operand_issued_o         (operand_issued          ),
+    .operand_queue_ready_i    (operand_queue_ready     ),
+    .operand_queue_cmd_o      (operand_queue_cmd       ),
+    .operand_queue_cmd_valid_o(operand_queue_cmd_valid ),
     // Interface with the VFUs
     // ALU
-    .alu_result_req_i         (alu_result_req         ),
-    .alu_result_id_i          (alu_result_id          ),
-    .alu_result_addr_i        (alu_result_addr        ),
-    .alu_result_wdata_i       (alu_result_wdata       ),
-    .alu_result_be_i          (alu_result_be          ),
-    .alu_result_gnt_o         (alu_result_gnt         ),
+    .alu_result_req_i         (alu_result_req          ),
+    .alu_result_id_i          (alu_result_id           ),
+    .alu_result_addr_i        (alu_result_addr         ),
+    .alu_result_wdata_i       (alu_result_wdata        ),
+    .alu_result_be_i          (alu_result_be           ),
+    .alu_result_gnt_o         (alu_result_gnt          ),
     // MFPU
-    .mfpu_result_req_i        (mfpu_result_req        ),
-    .mfpu_result_id_i         (mfpu_result_id         ),
-    .mfpu_result_addr_i       (mfpu_result_addr       ),
-    .mfpu_result_wdata_i      (mfpu_result_wdata      ),
-    .mfpu_result_be_i         (mfpu_result_be         ),
-    .mfpu_result_gnt_o        (mfpu_result_gnt        ),
+    .mfpu_result_req_i        (mfpu_result_req         ),
+    .mfpu_result_id_i         (mfpu_result_id          ),
+    .mfpu_result_addr_i       (mfpu_result_addr        ),
+    .mfpu_result_wdata_i      (mfpu_result_wdata       ),
+    .mfpu_result_be_i         (mfpu_result_be          ),
+    .mfpu_result_gnt_o        (mfpu_result_gnt         ),
     // Mask Unit
-    .masku_result_req_i       (masku_result_req_i     ),
-    .masku_result_id_i        (masku_result_id_i      ),
-    .masku_result_addr_i      (masku_result_addr_i    ),
-    .masku_result_wdata_i     (masku_result_wdata_i   ),
-    .masku_result_be_i        (masku_result_be_i      ),
-    .masku_result_gnt_o       (masku_result_gnt_o     ),
+    .masku_result_req_i       (masku_result_req_i      ),
+    .masku_result_id_i        (masku_result_id_i       ),
+    .masku_result_addr_i      (masku_result_addr_i     ),
+    .masku_result_wdata_i     (masku_result_wdata_i    ),
+    .masku_result_be_i        (masku_result_be_i       ),
+    .masku_result_gnt_o       (masku_result_gnt_o      ),
     // Slide Unit
-    .sldu_result_req_i        (sldu_result_req_i      ),
-    .sldu_result_id_i         (sldu_result_id_i       ),
-    .sldu_result_addr_i       (sldu_result_addr_i     ),
-    .sldu_result_wdata_i      (sldu_result_wdata_i    ),
-    .sldu_result_be_i         (sldu_result_be_i       ),
+    .sldu_result_req_i        (sldu_result_req_i       ),
+    .sldu_result_id_i         (sldu_result_id_i        ),
+    .sldu_result_addr_i       (sldu_result_addr_i      ),
+    .sldu_result_wdata_i      (sldu_result_wdata_i     ),
+    .sldu_result_be_i         (sldu_result_be_i        ),
     .sldu_result_gnt_o        (sldu_result_gnt_opqueues),
     // Load Unit
-    .ldu_result_req_i         (ldu_result_req_i       ),
-    .ldu_result_id_i          (ldu_result_id_i        ),
-    .ldu_result_addr_i        (ldu_result_addr_i      ),
-    .ldu_result_wdata_i       (ldu_result_wdata_i     ),
-    .ldu_result_be_i          (ldu_result_be_i        ),
-    .ldu_result_gnt_o         (ldu_result_gnt_o       )
+    .ldu_result_req_i         (ldu_result_req_i        ),
+    .ldu_result_id_i          (ldu_result_id_i         ),
+    .ldu_result_addr_i        (ldu_result_addr_i       ),
+    .ldu_result_wdata_i       (ldu_result_wdata_i      ),
+    .ldu_result_be_i          (ldu_result_be_i         ),
+    .ldu_result_gnt_o         (ldu_result_gnt_o        )
   );
 
   ////////////////////////////
@@ -420,7 +420,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   assign sldu_operand_opqueues_ready  = sldu_operand_ready_i & (sldu_mux_sel_q == NO_RED);
   assign sldu_alu_gnt                 = sldu_operand_ready_i & (sldu_mux_sel_q == ALU_RED);
 
-  assign sldu_alu_valid = sldu_red_valid_i & (sldu_mux_sel_q == ALU_RED);
+  assign sldu_alu_valid    = sldu_red_valid_i & (sldu_mux_sel_q == ALU_RED);
   assign sldu_result_gnt_o = sldu_mux_sel_q == NO_RED ? sldu_result_gnt_opqueues : sldu_alu_ready;
 
   //////////////////

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -11,7 +11,6 @@
 
 module lane import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int           unsigned NrLanes         = 1, // Number of lanes
-    parameter  int           unsigned LaneIdx         = 0,                                   // Lane index. From 0 to NrLanes-1
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport      = FPUSupportHalfSingleDouble,
     // Dependant parameters. DO NOT CHANGE!
@@ -293,11 +292,12 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic sldu_addrgen_operand_opqueues_valid;
 
   operand_queues_stage #(
-    .FPUSupport(FPUSupport),
-    .LaneIdx(LaneIdx)
+    .NrLanes   (NrLanes   ),
+    .FPUSupport(FPUSupport)
   ) i_operand_queues (
     .clk_i                            (clk_i                              ),
     .rst_ni                           (rst_ni                             ),
+    .lane_id_i                        (lane_id_i                          ),
     // Interface with the Vector Register File
     .operand_i                        (vrf_operand                        ),
     .operand_valid_i                  (vrf_operand_valid                  ),
@@ -343,12 +343,12 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
 
   vector_fus_stage #(
     .NrLanes   (NrLanes   ),
-    .LaneIdx   (LaneIdx   ),
     .FPUSupport(FPUSupport),
     .vaddr_t   (vaddr_t   )
   ) i_vfus (
     .clk_i                (clk_i                                  ),
     .rst_ni               (rst_ni                                 ),
+    .lane_id_i            (lane_id_i                              ),
     // Interface with CVA6
     .fflags_ex_o          (fflags_ex_o                            ),
     .fflags_ex_valid_o    (fflags_ex_valid_o                      ),

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -217,7 +217,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
 
       // Mute request if the instruction runs in the lane and the vl is zero.
       // During a reduction, all the lanes must cooperate anyway.
-      if (vfu_operation_d.vl == '0 && (vfu_operation_d.vfu inside {VFU_Alu, VFU_MFpu}) && vfu_operation_d.op != VREDSUM) begin
+      if (vfu_operation_d.vl == '0 && (vfu_operation_d.vfu inside {VFU_Alu, VFU_MFpu}) && !(vfu_operation_d.op inside {[VREDSUM:VWREDSUM]})) begin
         vfu_operation_valid_d = 1'b0;
         // We are already done with this instruction
         vinsn_done_d[pe_req.id] |= 1'b1;
@@ -241,13 +241,13 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             id         : pe_req.id,
             vs         : pe_req.vs1,
             eew        : pe_req.eew_vs1,
-            conv       : pe_req.conversion_vs1,
+            // If reductions and vl == 0, we must replace with neutral values
+            conv       : (vfu_operation_d.vl == '0) ? OpQueueReductionZExt : pe_req.conversion_vs1,
             scale_vl   : pe_req.scale_vl,
             cvt_resize : pe_req.cvt_resize,
             vtype      : pe_req.vtype,
             // In case of reduction, AluA opqueue will keep the scalar element
-	        // If this lane does not need to perform the computation, do not fetch the scalar either
-            vl         : (pe_req.op == VREDSUM) ? (vfu_operation_d.vl != '0) : vfu_operation_d.vl,
+            vl         : (pe_req.op inside {[VREDSUM:VWREDSUM]}) ? 1 : vfu_operation_d.vl,
             vstart     : vfu_operation_d.vstart,
             hazard     : pe_req.hazard_vs1 | pe_req.hazard_vd,
             default    : '0
@@ -258,11 +258,15 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             id         : pe_req.id,
             vs         : pe_req.vs2,
             eew        : pe_req.eew_vs2,
-            conv       : pe_req.conversion_vs2,
+            // If reductions and vl == 0, we must replace with neutral values
+            conv       : (vfu_operation_d.vl == '0) ? OpQueueReductionZExt : pe_req.conversion_vs2,
             scale_vl   : pe_req.scale_vl,
             cvt_resize : pe_req.cvt_resize,
             vtype      : pe_req.vtype,
-            vl         : vfu_operation_d.vl,
+            // If reductions and vl == 0, we must replace the operands with neutral
+            // values in the opqueues. So, vl must be 1 at least
+            vl         : (pe_req.op inside {[VREDSUM:VWREDSUM]} && vfu_operation_d.vl == '0)
+                         ? 1 : vfu_operation_d.vl,
             vstart     : vfu_operation_d.vstart,
             hazard     : pe_req.hazard_vs2 | pe_req.hazard_vd,
             default    : '0

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -48,9 +48,6 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   // Lane 0 has different logic than Lanes != 0
   // A parameter would be perfect to save HW, but our hierarchical
   // synth/pnr flow needs that all lanes are the same
-  // False path this for better timing results
-  logic lane_id_0;
-  assign lane_id_0 = lane_id_i == '0;
 
   //////////////////////
   //  Command Buffer  //
@@ -218,7 +215,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
       end
 
       OpQueueReductionZExt: begin
-        if (lane_id_0) begin
+        if (lane_id_i == '0) begin
           unique case (cmd.eew)
             EW8 : conv_operand = {{7{ntrh, { 7{ntrl}}}}, ibuf_operand[7:0]};
             EW16: conv_operand = {{3{ntrh, {15{ntrl}}}}, ibuf_operand[15:0]};

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -11,20 +11,21 @@
 module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     parameter  int           unsigned BufferDepth    = 2,
     parameter  int           unsigned NrSlaves       = 1,
+    parameter  int           unsigned NrLanes        = 0,
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport     = FPUSupportHalfSingleDouble,
     // Supported conversions
     parameter  logic                  SupportIntExt2 = 1'b0,
     parameter  logic                  SupportIntExt4 = 1'b0,
     parameter  logic                  SupportIntExt8 = 1'b0,
-    // Lane index
-    parameter  int           unsigned LaneIdx        = 0,
     // Dependant parameters. DO NOT CHANGE!
     localparam int           unsigned DataWidth      = $bits(elen_t),
     localparam int           unsigned StrbWidth      = DataWidth/8
   ) (
     input  logic                              clk_i,
     input  logic                              rst_ni,
+    // Lane ID
+    input  logic [idx_width(NrLanes)-1:0]     lane_id_i,
     // Interface with the Operand Requester
     input  operand_queue_cmd_t                operand_queue_cmd_i,
     input  logic                              operand_queue_cmd_valid_i,
@@ -39,6 +40,17 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     output logic                              operand_valid_o,
     input  logic               [NrSlaves-1:0] operand_ready_i
   );
+
+  /////////////
+  // Lane ID //
+  /////////////
+
+  // Lane 0 has different logic than Lanes != 0
+  // A parameter would be perfect to save HW, but our hierarchical
+  // synth/pnr flow needs that all lanes are the same
+  // False path this for better timing results
+  logic lane_id_0;
+  assign lane_id_0 = lane_id_i == '0;
 
   //////////////////////
   //  Command Buffer  //
@@ -206,7 +218,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
       end
 
       OpQueueReductionZExt: begin
-        if (LaneIdx == 0) begin
+        if (lane_id_0) begin
           unique case (cmd.eew)
             EW8 : conv_operand = {{7{ntrh, { 7{ntrl}}}}, ibuf_operand[7:0]};
             EW16: conv_operand = {{3{ntrh, {15{ntrl}}}}, ibuf_operand[15:0]};

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -6,13 +6,14 @@
 // Description:
 // This stage holds the operand queues, holding elements for the VRFs.
 
-module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
+module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
+    parameter int     unsigned NrLanes = 0,
     // Support for floating-point data types
-    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble,
-    parameter int  unsigned LaneIdx    = 0
+    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble
   ) (
     input  logic                                     clk_i,
     input  logic                                     rst_ni,
+    input  logic            [idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with the Vector Register File
     input  elen_t              [NrOperandQueues-1:0] operand_i,
     input  logic               [NrOperandQueues-1:0] operand_valid_i,
@@ -53,13 +54,14 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
   operand_queue #(
     .BufferDepth   (5         ),
     .FPUSupport    (FPUSupport),
+    .NrLanes       (NrLanes   ),
     .SupportIntExt2(1'b1      ),
     .SupportIntExt4(1'b1      ),
-    .SupportIntExt8(1'b1      ),
-    .LaneIdx       (LaneIdx   )
+    .SupportIntExt8(1'b1      )
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
+    .lane_id_i                (lane_id_i                      ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[AluA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[AluA]),
     .operand_i                (operand_i[AluA]                ),
@@ -75,13 +77,14 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
   operand_queue #(
     .BufferDepth   (5         ),
     .FPUSupport    (FPUSupport),
+    .NrLanes       (NrLanes   ),
     .SupportIntExt2(1'b1      ),
     .SupportIntExt4(1'b1      ),
-    .SupportIntExt8(1'b1      ),
-    .LaneIdx       (LaneIdx   )
+    .SupportIntExt8(1'b1      )
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
+    .lane_id_i                (lane_id_i                      ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[AluB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[AluB]),
     .operand_i                (operand_i[AluB]                ),
@@ -101,10 +104,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
   operand_queue #(
     .BufferDepth   (5         ),
     .FPUSupport    (FPUSupport),
+    .NrLanes       (NrLanes   ),
     .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_a (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
+    .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUA]),
     .operand_i                (operand_i[MulFPUA]                ),
@@ -120,10 +125,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
   operand_queue #(
     .BufferDepth   (5         ),
     .FPUSupport    (FPUSupport),
+    .NrLanes       (NrLanes   ),
     .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_b (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
+    .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUB]),
     .operand_i                (operand_i[MulFPUB]                ),
@@ -139,10 +146,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
   operand_queue #(
     .BufferDepth   (5         ),
     .FPUSupport    (FPUSupport),
+    .NrLanes       (NrLanes   ),
     .SupportIntExt2(1'b1      )
   ) i_operand_queue_mfpu_c (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
+    .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUC]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUC]),
     .operand_i                (operand_i[MulFPUC]                ),
@@ -161,10 +170,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
 
   operand_queue #(
     .BufferDepth(2         ),
-    .FPUSupport (FPUSupport)
+    .FPUSupport (FPUSupport),
+    .NrLanes    (NrLanes   )
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
+    .lane_id_i                (lane_id_i                     ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[StA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[StA]),
     .operand_i                (operand_i[StA]                ),
@@ -183,10 +194,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
 
   operand_queue #(
     .BufferDepth(2         ),
-    .FPUSupport (FPUSupport)
+    .FPUSupport (FPUSupport),
+    .NrLanes    (NrLanes   )
   ) i_operand_queue_slide_addrgen_a (
     .clk_i                    (clk_i                                         ),
     .rst_ni                   (rst_ni                                        ),
+    .lane_id_i                (lane_id_i                                     ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[SlideAddrGenA]            ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[SlideAddrGenA]      ),
     .operand_i                (operand_i[SlideAddrGenA]                      ),
@@ -205,10 +218,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
 
   operand_queue #(
     .BufferDepth(1         ),
-    .FPUSupport (FPUSupport)
+    .FPUSupport (FPUSupport),
+    .NrLanes    (NrLanes   )
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),
+    .lane_id_i                (lane_id_i                       ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MaskB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MaskB]),
     .operand_i                (operand_i[MaskB]                ),
@@ -222,10 +237,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
   );
 
   operand_queue #(
-    .BufferDepth(1)
+    .BufferDepth(1         ),
+    .NrLanes    (NrLanes   )
   ) i_operand_queue_mask_m (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),
+    .lane_id_i                (lane_id_i                       ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MaskM]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MaskM]),
     .operand_i                (operand_i[MaskM]                ),

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -8,7 +8,8 @@
 
 module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
     // Support for floating-point data types
-    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble
+    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble,
+    parameter int  unsigned LaneIdx    = 0
   ) (
     input  logic                                     clk_i,
     input  logic                                     rst_ni,
@@ -54,7 +55,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
     .FPUSupport    (FPUSupport),
     .SupportIntExt2(1'b1      ),
     .SupportIntExt4(1'b1      ),
-    .SupportIntExt8(1'b1      )
+    .SupportIntExt8(1'b1      ),
+    .LaneIdx       (LaneIdx   )
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -75,7 +77,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; #(
     .FPUSupport    (FPUSupport),
     .SupportIntExt2(1'b1      ),
     .SupportIntExt4(1'b1      ),
-    .SupportIntExt8(1'b1      )
+    .SupportIntExt8(1'b1      ),
+    .LaneIdx       (LaneIdx   )
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),

--- a/hardware/src/lane/operand_requester.sv
+++ b/hardware/src/lane/operand_requester.sv
@@ -275,12 +275,13 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
               // but the requester must refer to the old EEW (eew here)
               // This reasoning cannot be applied also to widening instructions, which modify vsew
               // treating it as the EEW of vd
-              vl  : (operand_request_i[requester].scale_vl) ?
-                      ((operand_request_i[requester].vl <<
-                      operand_request_i[requester].vtype.vsew) >>
-                      operand_request_i[requester].eew) :
-                      operand_request_i[requester].vl,
-              conv: operand_request_i[requester].conv,
+              vl       : (operand_request_i[requester].scale_vl) ?
+                           ((operand_request_i[requester].vl <<
+                           operand_request_i[requester].vtype.vsew) >>
+                           operand_request_i[requester].eew) :
+                           operand_request_i[requester].vl,
+              conv     : operand_request_i[requester].conv,
+              ntr_red  : operand_request_i[requester].cvt_resize,
               target_fu: operand_request_i[requester].target_fu
             };
             operand_queue_cmd_valid_o[requester] = 1'b1;
@@ -356,13 +357,14 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Send a command to the operand queue
                 operand_queue_cmd_o[requester] = '{
-                  eew : operand_request_i[requester].eew,
-                  vl  : (operand_request_i[requester].scale_vl) ?
-                          ((operand_request_i[requester].vl <<
-                          operand_request_i[requester].vtype.vsew) >>
-                          operand_request_i[requester].eew) :
-                          operand_request_i[requester].vl,
-                  conv: operand_request_i[requester].conv,
+                  eew      : operand_request_i[requester].eew,
+                  vl       : (operand_request_i[requester].scale_vl) ?
+                               ((operand_request_i[requester].vl <<
+                               operand_request_i[requester].vtype.vsew) >>
+                               operand_request_i[requester].eew) :
+                               operand_request_i[requester].vl,
+                  conv     : operand_request_i[requester].conv,
+                  ntr_red  : operand_request_i[requester].cvt_resize,
                   target_fu: operand_request_i[requester].target_fu
                 };
                 operand_queue_cmd_valid_o[requester] = 1'b1;

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -98,7 +98,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
       unique case (op_i)
         // Logical operations
         VAND, VREDAND: res = operand_a_i & operand_b_i;
-        VOR, VREDOR: res = operand_a_i | operand_b_i;
+        VOR, VREDOR  : res = operand_a_i | operand_b_i;
         VXOR, VREDXOR: res = operand_a_i ^ operand_b_i;
 
         // Mask logical operations

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -45,7 +45,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
 
   // Comparison instructions that use signed operands
   logic is_signed;
-  assign is_signed = op_i inside {VMAX, VMIN, VMSLT, VMSLE, VMSGT};
+  assign is_signed = op_i inside {VMAX, VREDMAX, VMIN, VREDMIN, VMSLT, VMSLE, VMSGT};
   // Compare operands.
   // For vew_i = EW8, all bits are valid.
   // For vew_i = EW16, bits 0, 2, 4, and 6 are valid.
@@ -97,9 +97,9 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     if (valid_i)
       unique case (op_i)
         // Logical operations
-        VAND: res = operand_a_i & operand_b_i;
-        VOR : res = operand_a_i | operand_b_i;
-        VXOR: res = operand_a_i ^ operand_b_i;
+        VAND, VREDAND: res = operand_a_i & operand_b_i;
+        VOR, VREDOR: res = operand_a_i | operand_b_i;
+        VXOR, VREDXOR: res = operand_a_i ^ operand_b_i;
 
         // Mask logical operations
         VMAND   : res = operand_a_i & operand_b_i;
@@ -112,7 +112,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VMXNOR  : res = ~(operand_a_i ^ operand_b_i);
 
         // Arithmetic instructions
-        VADD, VADC, VMADC, VREDSUM: unique case (vew_i)
+        VADD, VADC, VMADC, VREDSUM, VWREDSUMU, VWREDSUM: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b] +
                 logic'(op_i inside {VADC, VMADC} && mask_i[1*b] && !vm_i);
@@ -208,15 +208,16 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
           endcase
 
         // Comparison instructions
-        VMIN, VMINU, VMAX, VMAXU: unique case (vew_i)
+        VMIN, VMINU, VMAX, VMAXU,
+        VREDMINU, VREDMIN, VREDMAXU, VREDMAX: unique case (vew_i)
             EW8 : for (int b = 0; b < 8; b++) res.w8 [b] =
-                (less[1*b] ^ (op_i == VMAX || op_i == VMAXU)) ? opb.w8 [b] : opa.w8 [b];
+                (less[1*b] ^ (op_i == VMAX || op_i == VMAXU || op_i == VREDMAXU || op_i == VREDMAX)) ? opb.w8 [b] : opa.w8 [b];
             EW16: for (int b = 0; b < 4; b++) res.w16[b] =
-                (less[2*b] ^ (op_i == VMAX || op_i == VMAXU)) ? opb.w16[b] : opa.w16[b];
+                (less[2*b] ^ (op_i == VMAX || op_i == VMAXU || op_i == VREDMAXU || op_i == VREDMAX)) ? opb.w16[b] : opa.w16[b];
             EW32: for (int b = 0; b < 2; b++) res.w32[b] =
-                (less[4*b] ^ (op_i == VMAX || op_i == VMAXU)) ? opb.w32[b] : opa.w32[b];
+                (less[4*b] ^ (op_i == VMAX || op_i == VMAXU || op_i == VREDMAXU || op_i == VREDMAX)) ? opb.w32[b] : opa.w32[b];
             EW64: for (int b = 0; b < 1; b++) res.w64[b] =
-                (less[8*b] ^ (op_i == VMAX || op_i == VMAXU)) ? opb.w64[b] : opa.w64[b];
+                (less[8*b] ^ (op_i == VMAX || op_i == VMAXU || op_i == VREDMAXU || op_i == VREDMAX)) ? opb.w64[b] : opa.w64[b];
           endcase
         VMSEQ, VMSNE: unique case (vew_i)
             EW8 : for (int b = 0; b < 8; b++) res.w8 [b][1:0] =

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -112,7 +112,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VMXNOR  : res = ~(operand_a_i ^ operand_b_i);
 
         // Arithmetic instructions
-        VADD, VADC, VMADC: unique case (vew_i)
+        VADD, VADC, VMADC, VREDSUM: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b] +
                 logic'(op_i inside {VADC, VMADC} && mask_i[1*b] && !vm_i);

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -265,8 +265,12 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
   typedef enum logic [2:0] {NO_REDUCTION, INTRA_LANE_REDUCTION, INTER_LANES_REDUCTION, WAIT_STATE, SIMD_REDUCTION, PASS_THRU_REDUCTION} alu_state_e;
   alu_state_e alu_state_d, alu_state_q;
 
-  // Neutral value to be used within a reduction operation
-  elen_t neutral_value;
+  // Filter the next valid from the slide unit
+  // This signal is used to give the ready to the sldu 1 cycle later, so we must not sample the
+  // valid signal twice
+  logic  filter_sldu_alu_valid_d, filter_sldu_alu_valid_q;
+  logic  sldu_alu_ready_d;
+  assign filter_sldu_alu_valid_d = sldu_alu_ready_d;
 
   // Input multiplexers.
   elen_t reduction_op_a, simd_red_operand, alu_operand_1_masked;
@@ -342,7 +346,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
     sldu_transactions_cnt_d = sldu_transactions_cnt_q;
     red_hs_synch_d = red_hs_synch_q;
     alu_red_valid_o      = 1'b0;
-    sldu_alu_ready_o     = 1'b0;
+    sldu_alu_ready_d     = 1'b0;
     simd_red_cnt_max_d   = simd_red_cnt_max_q;
     simd_red_operand     = '0;
     red_mask             = '0;
@@ -516,28 +520,28 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
             // This unit should still process data for the inter-lane reduction.
             // Ready to accept incoming operands from the slide unit.
             alu_red_valid_o = red_hs_synch_q;
-            if (sldu_alu_valid_i) begin
+            if (sldu_alu_valid_i && !filter_sldu_alu_valid_q) begin
               // Issue the operation
               valu_valid = 1'b1;
-              sldu_alu_ready_o = 1'b1;
+              sldu_alu_ready_d = 1'b1;
               reduction_rx_cnt_d = reduction_rx_cnt_q - 1;
               result_queue_d[result_queue_write_pnt_q].wdata = valu_result;
             end
           end
           // Count the successful transaction with the SLDU
-          if (sldu_alu_valid_i && sldu_alu_ready_o) begin
+          if (sldu_alu_valid_i && sldu_alu_ready_d) begin
             sldu_transactions_cnt_d = sldu_transactions_cnt_q - 1;
           end
           if (alu_red_valid_o && alu_red_ready_i) red_hs_synch_d = 1'b0;
-          if (sldu_alu_valid_i && sldu_alu_ready_o) red_hs_synch_d = 1'b1;
+          if (sldu_alu_valid_i && sldu_alu_ready_d) red_hs_synch_d = 1'b1;
         end
         WAIT_STATE: begin
           // Acknowledge the sliding unit even if it is not forwarding anything useful
-          sldu_alu_ready_o = sldu_alu_valid_i;
+          sldu_alu_ready_d = sldu_alu_valid_i & ~filter_sldu_alu_valid_q;
           alu_red_valid_o  = red_hs_synch_q;
           // If lane 0, wait for the inter-lane reduced operand, to perform a SIMD reduction
           if (LaneIdx == 0) begin
-            if (sldu_alu_valid_i) begin
+            if (sldu_alu_valid_i && !filter_sldu_alu_valid_q) begin
               if (sldu_transactions_cnt_q == 1) begin
                 result_queue_d[result_queue_write_pnt_q].wdata = sldu_operand_i;
                 unique case (vinsn_issue_q.vtype.vsew)
@@ -555,11 +559,11 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
             alu_state_d = is_reduction(vinsn_issue_q.op) && vinsn_issue_valid ? INTRA_LANE_REDUCTION : NO_REDUCTION;
             commit_cnt_d = '0;
           end
-          if (sldu_alu_valid_i && sldu_alu_ready_o) begin
+          if (sldu_alu_valid_i && sldu_alu_ready_d) begin
             sldu_transactions_cnt_d = sldu_transactions_cnt_q - 1;
           end
           if (alu_red_valid_o && alu_red_ready_i) red_hs_synch_d = 1'b0;
-          if (sldu_alu_valid_i && sldu_alu_ready_o) red_hs_synch_d = 1'b1;
+          if (sldu_alu_valid_i && sldu_alu_ready_d) red_hs_synch_d = 1'b1;
         end
         SIMD_REDUCTION: begin
           if (LaneIdx == 0) begin
@@ -697,6 +701,8 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
       sldu_transactions_cnt_q <= '0;
       red_hs_synch_q          <= 1'b0;
       simd_red_cnt_max_q      <= '0;
+      filter_sldu_alu_valid_q <= 1'b0;
+      sldu_alu_ready_o        <= 1'b0;
     end else begin
       issue_cnt_q             <= issue_cnt_d;
       commit_cnt_q            <= commit_cnt_d;
@@ -708,6 +714,8 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
       sldu_transactions_cnt_q <= sldu_transactions_cnt_d;
       red_hs_synch_q          <= red_hs_synch_d;
       simd_red_cnt_max_q      <= simd_red_cnt_max_d;
+      filter_sldu_alu_valid_q <= filter_sldu_alu_valid_d;
+      sldu_alu_ready_o        <= sldu_alu_ready_d;
     end
   end
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -305,6 +305,10 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
   logic  filter_sldu_alu_valid_d, filter_sldu_alu_valid_q;
   logic  sldu_alu_ready_d;
   assign filter_sldu_alu_valid_d = sldu_alu_ready_d;
+  // This signal is used to cut a in2reg bad path
+  // This works since the signal is never checked
+  // twice in two consecutive cycles
+  logic  alu_red_ready_q;
 
   // Input multiplexers.
   elen_t simd_red_operand;
@@ -532,7 +536,9 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
           if (reduction_rx_cnt_q == '0) begin
             // This unit has finished processing data for this reduction instruction, send the partial result to the sliding unit
             alu_red_valid_o = 1'b1;
-            if (alu_red_ready_i) begin
+            // We can simply delay the ready since we will immediately change state,
+            // so, no risk to re-sample alu_red_ready_i with side effects
+            if (alu_red_ready_q) begin
               alu_state_d = WAIT_STATE;
                 if (!lane_id_0) begin
                 // Bump issue counter and pointers
@@ -732,6 +738,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
       simd_red_cnt_max_q      <= '0;
       filter_sldu_alu_valid_q <= 1'b0;
       sldu_alu_ready_o        <= 1'b0;
+      alu_red_ready_q         <= 1'b0;
     end else begin
       issue_cnt_q             <= issue_cnt_d;
       commit_cnt_q            <= commit_cnt_d;
@@ -745,6 +752,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
       simd_red_cnt_max_q      <= simd_red_cnt_max_d;
       filter_sldu_alu_valid_q <= filter_sldu_alu_valid_d;
       sldu_alu_ready_o        <= sldu_alu_ready_d;
+      alu_red_ready_q         <= alu_red_ready_i;
     end
   end
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -225,7 +225,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
   // sliding unit (inter-lane and SIMD reduction).
   function automatic logic is_reduction(ara_op_e op);
     is_reduction = 1'b0;
-    if (op inside {VREDSUM})
+    if (op inside {[VREDSUM:VWREDSUM]})
       is_reduction = 1'b1;
   endfunction: is_reduction
 
@@ -262,7 +262,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
   logic first_op_d, first_op_q;
 
   // Signal to indicate the state of the ALU
-  typedef enum logic [2:0] {NO_REDUCTION, INTRA_LANE_REDUCTION, INTER_LANES_REDUCTION, WAIT_STATE, SIMD_REDUCTION, PASS_THRU_REDUCTION} alu_state_e;
+  typedef enum logic [2:0] {NO_REDUCTION, INTRA_LANE_REDUCTION, INTER_LANES_REDUCTION, WAIT_STATE, SIMD_REDUCTION} alu_state_e;
   alu_state_e alu_state_d, alu_state_q;
 
   // Filter the next valid from the slide unit
@@ -273,30 +273,21 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
   assign filter_sldu_alu_valid_d = sldu_alu_ready_d;
 
   // Input multiplexers.
-  elen_t reduction_op_a, simd_red_operand, alu_operand_1_masked;
-  logic [7:0] safe_red_byte;
+  elen_t simd_red_operand;
   strb_t red_mask;
-  elen_t alu_operand_a;
   // During the first cycle, the reduction adds a scalar value kept into a
   // vector register to the first group of vector elements. Then, one of the operand is always
   // the accumulator.
   // For lane[0], the scalar value is actually a value. For the other lanes the value is a neutral one.
+  elen_t alu_operand_a;
   elen_t alu_operand_b;
-  always_comb begin
-    safe_red_byte  = vinsn_issue_q.op == VREDSUM ? 8'h00 : 8'hff;
 
-    for (int b = 0; b < 8; b++)
-      alu_operand_1_masked[b*8 +: 8] = red_mask[b] ? alu_operand_i[1][b*8 +: 8] : alu_operand_i[1][b*8 +: 8] & safe_red_byte;
-
-    reduction_op_a = alu_state_q == SIMD_REDUCTION ? simd_red_operand : sldu_operand_i;
-
-    alu_operand_a  = (alu_state_q == INTER_LANES_REDUCTION || alu_state_q == SIMD_REDUCTION || alu_state_q == INTRA_LANE_REDUCTION && !first_op_q)
-                   ? result_queue_q[result_queue_write_pnt_q].wdata
-                   : (vinsn_issue_q.use_scalar_op ? scalar_op : alu_operand_i[0]);
-    alu_operand_b  = (alu_state_q == INTER_LANES_REDUCTION || alu_state_q == SIMD_REDUCTION)
-                   ? reduction_op_a
-                   : alu_operand_1_masked;
-  end
+  assign alu_operand_a  = (alu_state_q == INTER_LANES_REDUCTION || alu_state_q == SIMD_REDUCTION || alu_state_q == INTRA_LANE_REDUCTION && !first_op_q)
+                        ? result_queue_q[result_queue_write_pnt_q].wdata
+                        : vinsn_issue_q.use_scalar_op ? scalar_op : alu_operand_i[0];
+  assign alu_operand_b  = (alu_state_q == INTER_LANES_REDUCTION || alu_state_q == SIMD_REDUCTION)
+                        ? alu_state_q == SIMD_REDUCTION ? simd_red_operand : sldu_operand_i
+                        : alu_operand_i[1];
 
   ///////////////////////
   //  SIMD Vector ALU  //
@@ -480,7 +471,12 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
               mask_ready_o = ~vinsn_issue_q.vm;
 
               // Reduction instruction, accumulate the result
-              result_queue_d[result_queue_write_pnt_q].wdata = valu_result;
+              for (int b = 0; b < 8; b++) begin
+                result_queue_d[result_queue_write_pnt_q].wdata[8*b +: 8] =
+                    red_mask[b]            ?
+                    valu_result[8*b +: 8]  :
+                    alu_operand_a[8*b +: 8];
+              end
               result_queue_d[result_queue_write_pnt_q].addr  = vaddr(vinsn_issue_q.vd, NrLanes);
               result_queue_d[result_queue_write_pnt_q].id    = vinsn_issue_q.id;
               result_queue_d[result_queue_write_pnt_q].be    = be(1, vinsn_issue_q.vtype.vsew);
@@ -660,7 +656,10 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
 
     if (!vinsn_queue_full && vfu_operation_valid_i &&
       (vfu_operation_i.vfu == VFU_Alu || vfu_operation_i.op inside {[VMSEQ:VMXNOR]})) begin
-      vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt] = vfu_operation_i;
+      vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt]    = vfu_operation_i;
+      // Do not wait for masks if, during a reduction, this lane is just a pass-through
+      // The only valid instructions here with vl == '0 are reductions
+      vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].vm = vfu_operation_i.vm | (vfu_operation_i.vl == '0);
 
       // The next will be the first operation of this instruction
       // This information is useful for reduction operation
@@ -670,11 +669,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
       // Initialize counters and alu state if this is the instruction queue was empty
       if (vinsn_queue_d.issue_cnt == '0) begin
         alu_state_d = is_reduction(vfu_operation_i.op) ? INTRA_LANE_REDUCTION : NO_REDUCTION;
-        // If the lane is not computing within the reduction, it will just pass the incoming values on
-		if (vfu_operation_i.vl == '0) begin
-          alu_state_d = INTER_LANES_REDUCTION;
-          result_queue_d[result_queue_write_pnt_q].wdata = elen_t'(safe_red_byte);
-        end
+
         sldu_transactions_cnt_d = $clog2(NrLanes) + 1;
         // Allow the first valid
         red_hs_synch_d = 1'b1;

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -9,6 +9,7 @@
 
 module valu import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int  unsigned NrLanes   = 0,
+    parameter int  unsigned LaneIdx    = 0,
     // Type used to address vector register file elements
     parameter  type          vaddr_t   = logic,
     // Dependant parameters. DO NOT CHANGE!
@@ -34,6 +35,12 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
     output elen_t                        alu_result_wdata_o,
     output strb_t                        alu_result_be_o,
     input  logic                         alu_result_gnt_i,
+    // Interface with the Slide Unit
+    output logic                         alu_red_valid_o,
+    input  logic                         alu_red_ready_i,
+    input  elen_t                        sldu_operand_i,
+    input  logic                         sldu_alu_valid_i,
+    output logic                         sldu_alu_ready_o,
     // Interface with the Mask unit
     output elen_t                        mask_operand_o,
     output logic                         mask_operand_valid_o,
@@ -209,6 +216,84 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
   // output EEW word we are producing.
   logic narrowing_select_d, narrowing_select_q;
 
+  //////////////////
+  //  Reductions  //
+  //////////////////
+
+  // This function returns 1'b1 if `op` is a reduction instruction, i.e.,
+  // it must accumulate the result (intra-lane reduction) before sending it to the
+  // sliding unit (inter-lane and SIMD reduction).
+  function automatic logic is_reduction(ara_op_e op);
+    is_reduction = 1'b0;
+    if (op inside {VREDSUM})
+      is_reduction = 1'b1;
+  endfunction: is_reduction
+
+  // During an inter-lane reduction (after the intra-lane reduction), the NrLanes partial results
+  // must be reduced to only one. The first reduction is done by NrLanes/2 FUs, then NrLanes/4, and
+  // so on. In the end, the result is collected in Lane 0 and the last SIMD reduction is performed.
+  // The following function determines how many partial results this lane must process during the
+  // inter-lane reduction.
+  typedef logic [idx_width(NrLanes/2):0] reduction_rx_cnt_t;
+  reduction_rx_cnt_t reduction_rx_cnt_d, reduction_rx_cnt_q;
+  reduction_rx_cnt_t simd_red_cnt_max_d, simd_red_cnt_max_q;
+
+  function automatic reduction_rx_cnt_t reduction_rx_cnt_init(int unsigned NrLanes, int unsigned LaneIdx);
+    // The even lanes do not receive intermediate results. Only Lane 0 will receive the final result, but this is not checked here.
+    int adjusted_idx = LaneIdx + 1;
+    reduction_rx_cnt_init = '0;
+    for (int i = 2; i <= NrLanes; i *= 2) if (!(adjusted_idx % i)) reduction_rx_cnt_init++;
+  endfunction: reduction_rx_cnt_init
+
+  // Count how many transactions we must do in total to complete the reduction operation
+  logic [idx_width($clog2(NrLanes)+1):0] sldu_transactions_cnt_d, sldu_transactions_cnt_q;
+
+  // Handshake synchronizer
+  // Since the SLDU must receive a valid signals also from lanes that should not send anything,
+  // we need to synchronize the dummy valids. A valid is given, then it is deleted after an
+  // handshake. It will be given again only after a valid_o by the SLDU
+  logic red_hs_synch_d, red_hs_synch_q;
+
+  // Counter to drive SIMD reductions
+  logic [1:0] simd_red_cnt_d, simd_red_cnt_q;
+
+  // Signal the first operation of an instruction. The first operation of a reduction instruction
+  // the operation is performed between the first vector element and the scalar.
+  logic first_op_d, first_op_q;
+
+  // Signal to indicate the state of the ALU
+  typedef enum logic [2:0] {NO_REDUCTION, INTRA_LANE_REDUCTION, INTER_LANES_REDUCTION, WAIT_STATE, SIMD_REDUCTION, PASS_THRU_REDUCTION} alu_state_e;
+  alu_state_e alu_state_d, alu_state_q;
+
+  // Neutral value to be used within a reduction operation
+  elen_t neutral_value;
+
+  // Input multiplexers.
+  elen_t reduction_op_a, simd_red_operand, alu_operand_1_masked;
+  logic [7:0] safe_red_byte;
+  strb_t red_mask;
+  elen_t alu_operand_a;
+  // During the first cycle, the reduction adds a scalar value kept into a
+  // vector register to the first group of vector elements. Then, one of the operand is always
+  // the accumulator.
+  // For lane[0], the scalar value is actually a value. For the other lanes the value is a neutral one.
+  elen_t alu_operand_b;
+  always_comb begin
+    safe_red_byte  = vinsn_issue_q.op == VREDSUM ? 8'h00 : 8'hff;
+
+    for (int b = 0; b < 8; b++)
+      alu_operand_1_masked[b*8 +: 8] = red_mask[b] ? alu_operand_i[1][b*8 +: 8] : alu_operand_i[1][b*8 +: 8] & safe_red_byte;
+
+    reduction_op_a = alu_state_q == SIMD_REDUCTION ? simd_red_operand : sldu_operand_i;
+
+    alu_operand_a  = (alu_state_q == INTER_LANES_REDUCTION || alu_state_q == SIMD_REDUCTION || alu_state_q == INTRA_LANE_REDUCTION && !first_op_q)
+                   ? result_queue_q[result_queue_write_pnt_q].wdata
+                   : (vinsn_issue_q.use_scalar_op ? scalar_op : alu_operand_i[0]);
+    alu_operand_b  = (alu_state_q == INTER_LANES_REDUCTION || alu_state_q == SIMD_REDUCTION)
+                   ? reduction_op_a
+                   : alu_operand_1_masked;
+  end
+
   ///////////////////////
   //  SIMD Vector ALU  //
   ///////////////////////
@@ -217,8 +302,8 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
   logic  valu_valid;
 
   simd_alu i_simd_alu (
-    .operand_a_i       (vinsn_issue_q.use_scalar_op ? scalar_op : alu_operand_i[0]      ),
-    .operand_b_i       (alu_operand_i[1]                                                ),
+    .operand_a_i       (alu_operand_a                                                   ),
+    .operand_b_i       (alu_operand_b                                                   ),
     .valid_i           (valu_valid                                                      ),
     .vm_i              (vinsn_issue_q.vm                                                ),
     .mask_i            ((mask_valid_i && !vinsn_issue_q.vm) ? mask_i : {StrbWidth{1'b1}}),
@@ -251,8 +336,20 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
 
     narrowing_select_d = narrowing_select_q;
 
+    first_op_d           = first_op_q;
+    simd_red_cnt_d       = simd_red_cnt_q;
+    reduction_rx_cnt_d   = reduction_rx_cnt_q;
+    sldu_transactions_cnt_d = sldu_transactions_cnt_q;
+    red_hs_synch_d = red_hs_synch_q;
+    alu_red_valid_o      = 1'b0;
+    sldu_alu_ready_o     = 1'b0;
+    simd_red_cnt_max_d   = simd_red_cnt_max_q;
+    simd_red_operand     = '0;
+    red_mask             = '0;
+
     // Do not issue any operations
     valu_valid = 1'b0;
+    alu_state_d = alu_state_q;
 
     // Inform our status to the lane controller
     alu_ready_o      = !vinsn_queue_full;
@@ -266,99 +363,258 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
     //  Write data into the result queue  //
     ////////////////////////////////////////
 
-    // There is a vector instruction ready to be issued
-    if (vinsn_issue_valid && !result_queue_full) begin
-      // Do we have all the operands necessary for this instruction?
-      if ((alu_operand_valid_i[1] || !vinsn_issue_q.use_vs2) &&
-          (alu_operand_valid_i[0] || !vinsn_issue_q.use_vs1) &&
-          (mask_valid_i || vinsn_issue_q.vm)) begin
-        // How many elements are we committing with this word?
-        automatic logic [3:0] element_cnt = (1 << (int'(EW64) - int'(vinsn_issue_q.vtype.vsew)));
-        if (element_cnt > issue_cnt_q) element_cnt = issue_cnt_q;
+    if (vinsn_issue_valid || alu_state_q != NO_REDUCTION) begin
+      case (alu_state_q)
+        NO_REDUCTION: begin
+          if (!result_queue_full) begin
+            // Do we have all the operands necessary for this instruction?
+            if ((alu_operand_valid_i[1] || !vinsn_issue_q.use_vs2) &&
+                (alu_operand_valid_i[0] || !vinsn_issue_q.use_vs1) &&
+                (mask_valid_i || vinsn_issue_q.vm)) begin
+              // How many elements are we committing with this word?
+              automatic logic [3:0] element_cnt = (1 << (int'(EW64) - int'(vinsn_issue_q.vtype.vsew)));
+              if (element_cnt > issue_cnt_q)
+                element_cnt = issue_cnt_q;
 
-        // Issue the operation
-        valu_valid = 1'b1;
+              // Issue the operation
+              valu_valid = 1'b1;
 
-        // Acknowledge the operands of this instruction
-        alu_operand_ready_o = {vinsn_issue_q.use_vs2, vinsn_issue_q.use_vs1};
-        // Narrowing instructions might need an extra cycle before acknowledging the mask operands
-        // If the results are being sent to the Mask Unit, it is up to it to acknowledge the
-        // operands.
-        if (!narrowing(vinsn_issue_q.op) && vinsn_issue_q != VFU_MaskUnit)
-          mask_ready_o = !vinsn_issue_q.vm;
+              // Acknowledge the operands of this instruction
+              alu_operand_ready_o = {vinsn_issue_q.use_vs2, vinsn_issue_q.use_vs1};
+              // Narrowing instructions might need an extra cycle before acknowledging the mask operands
+              // If the results are being sent to the Mask Unit, it is up to it to acknowledge the operands.
+              if (!narrowing(vinsn_issue_q.op) && vinsn_issue_q != VFU_MaskUnit)
+                mask_ready_o = !vinsn_issue_q.vm;
 
-        // Store the result in the result queue
-        result_queue_d[result_queue_write_pnt_q].wdata =
-          result_queue_q[result_queue_write_pnt_q].wdata | valu_result;
-        result_queue_d[result_queue_write_pnt_q].addr = vaddr(vinsn_issue_q.vd, NrLanes) +
-          ((vinsn_issue_q.vl - issue_cnt_q) >> (int'(EW64) - vinsn_issue_q.vtype.vsew));
-        result_queue_d[result_queue_write_pnt_q].id   = vinsn_issue_q.id;
-        result_queue_d[result_queue_write_pnt_q].mask = vinsn_issue_q.vfu == VFU_MaskUnit;
-        if (!narrowing(vinsn_issue_q.op) || !narrowing_select_q)
-          result_queue_d[result_queue_write_pnt_q].be = be(element_cnt, vinsn_issue_q.vtype.vsew) &
-          (vinsn_issue_q.vm || vinsn_issue_q.op inside {VMERGE, VADC, VSBC} ?
-            {StrbWidth{1'b1}} :
-            mask_i);
+              // Store the result in the result queue
+              result_queue_d[result_queue_write_pnt_q].wdata = result_queue_q[result_queue_write_pnt_q].wdata | valu_result;
+              result_queue_d[result_queue_write_pnt_q].addr  = vaddr(vinsn_issue_q.vd, NrLanes) + ((vinsn_issue_q.vl - issue_cnt_q) >> (int'(EW64) - vinsn_issue_q.vtype.vsew));
+              result_queue_d[result_queue_write_pnt_q].id    = vinsn_issue_q.id;
+              result_queue_d[result_queue_write_pnt_q].mask  = vinsn_issue_q.vfu == VFU_MaskUnit;
+              if (!narrowing(vinsn_issue_q.op) || !narrowing_select_q)
+                result_queue_d[result_queue_write_pnt_q].be = be(element_cnt, vinsn_issue_q.vtype.vsew) & (vinsn_issue_q.vm || vinsn_issue_q.op inside {VMERGE, VADC, VSBC} ? {StrbWidth{1'b1}} : mask_i);
 
-        // Is this a narrowing instruction?
-        if (narrowing(vinsn_issue_q.op)) begin
-          // How many elements did we calculate in this iteration?
-          automatic logic [3:0] element_cnt_narrow =
-            (1 << (int'(EW64) - int'(vinsn_issue_q.vtype.vsew))) / 2;
-          if (element_cnt_narrow > issue_cnt_q) element_cnt_narrow = issue_cnt_q;
+              // Is this a narrowing instruction?
+              if (narrowing(vinsn_issue_q.op)) begin
+                // How many elements did we calculate in this iteration?
+                automatic logic [3:0] element_cnt_narrow = (1 << (int'(EW64) - int'(vinsn_issue_q.vtype.vsew))) / 2;
+                if (element_cnt_narrow > issue_cnt_q)
+                  element_cnt_narrow = issue_cnt_q;
 
-          // Account for the issued operands
-          issue_cnt_d = issue_cnt_q - element_cnt_narrow;
+                // Account for the issued operands
+                issue_cnt_d = issue_cnt_q - element_cnt_narrow;
 
-          // Write the next half of the results in the next cycle.
-          narrowing_select_d = !narrowing_select_q;
+                // Write the next half of the results in the next cycle.
+                narrowing_select_d = !narrowing_select_q;
 
-          // Did we fill up a word?
-          if (issue_cnt_d == '0 || !narrowing_select_d) begin
-            result_queue_valid_d[result_queue_write_pnt_q] = 1'b1;
+                // Did we fill up a word?
+                if (issue_cnt_d == '0 || !narrowing_select_d) begin
+                  result_queue_valid_d[result_queue_write_pnt_q] = 1'b1;
 
-            // Acknowledge the mask operand, if needed
-            if (vinsn_issue_q != VFU_MaskUnit) mask_ready_o = !vinsn_issue_q.vm;
+                  // Acknowledge the mask operand, if needed
+                  if (vinsn_issue_q != VFU_MaskUnit)
+                    mask_ready_o = !vinsn_issue_q.vm;
 
-            // Bump pointers and counters of the result queue
-            result_queue_cnt_d += 1;
-            if (result_queue_write_pnt_q == ResultQueueDepth-1) result_queue_write_pnt_d = 0;
-            else result_queue_write_pnt_d = result_queue_write_pnt_q + 1;
+                  // Bump pointers and counters of the result queue
+                  result_queue_cnt_d += 1;
+                  if (result_queue_write_pnt_q == ResultQueueDepth-1)
+                    result_queue_write_pnt_d = 0;
+                  else
+                    result_queue_write_pnt_d = result_queue_write_pnt_q + 1;
+                end
+              end else begin // Normal behavior
+                // Bump pointers and counters of the result queue
+                result_queue_valid_d[result_queue_write_pnt_q] = 1'b1;
+                result_queue_cnt_d += 1;
+                if (result_queue_write_pnt_q == ResultQueueDepth-1)
+                  result_queue_write_pnt_d = 0;
+                else
+                  result_queue_write_pnt_d = result_queue_write_pnt_q + 1;
+                issue_cnt_d = issue_cnt_q - element_cnt;
+              end
+
+              // Finished issuing the micro-operations of this vector instruction
+              if (vinsn_issue_valid && issue_cnt_d == '0) begin
+                // Reset the narrowing pointer
+                narrowing_select_d = 1'b0;
+
+                // Bump issue counter and pointers
+                vinsn_queue_d.issue_cnt -= 1;
+                if (vinsn_queue_q.issue_pnt == VInsnQueueDepth-1)
+                  vinsn_queue_d.issue_pnt = '0;
+                else
+                  vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
+
+                if (vinsn_queue_d.issue_cnt != 0)
+                  issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+              end
+            end
           end
-        end else begin // Normal behavior
-          // Bump pointers and counters of the result queue
-          result_queue_valid_d[result_queue_write_pnt_q] = 1'b1;
-          result_queue_cnt_d += 1;
-          if (result_queue_write_pnt_q == ResultQueueDepth-1) result_queue_write_pnt_d = 0;
-          else result_queue_write_pnt_d = result_queue_write_pnt_q + 1;
-          issue_cnt_d = issue_cnt_q - element_cnt;
         end
+        INTRA_LANE_REDUCTION: begin
+          // Stall only if this is the first operation for this reduction instruction and the result queue is full
+          if (!(first_op_q && result_queue_full)) begin
+            // Do we have all the operands necessary for this instruction?
+            // The second operand is needed only during the first operation of a reduction instruction
+            if ((alu_operand_valid_i[1] || !vinsn_issue_q.use_vs2) &&
+                (alu_operand_valid_i[0] || !vinsn_issue_q.use_vs1 || !first_op_q) &&
+                (mask_valid_i || vinsn_issue_q.vm)) begin
+              // How many elements are we committing with this word?
+              automatic logic [3:0] element_cnt = (1 << (int'(EW64) - int'(vinsn_issue_q.vtype.vsew)));
+              if (element_cnt > issue_cnt_q)
+                element_cnt = issue_cnt_q;
 
-        // Finished issuing the micro-operations of this vector instruction
-        if (vinsn_issue_valid && issue_cnt_d == '0) begin
-          // Reset the narrowing pointer
-          narrowing_select_d = 1'b0;
+              // Mask the inactive elements
+              red_mask = be(element_cnt, vinsn_issue_q.vtype.vsew) & ({StrbWidth{vinsn_issue_q.vm}} | mask_i);
 
-          // Bump issue counter and pointers
-          vinsn_queue_d.issue_cnt -= 1;
-          if (vinsn_queue_q.issue_pnt == VInsnQueueDepth-1) vinsn_queue_d.issue_pnt = '0;
-          else vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
+              // Issue the operation
+              valu_valid = 1'b1;
 
-          if (vinsn_queue_d.issue_cnt != 0) issue_cnt_d =
-            vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+              // Acknowledge the operands of this instruction
+              alu_operand_ready_o = {vinsn_issue_q.use_vs2, vinsn_issue_q.use_vs1 & first_op_q};
+              // Acknowledge the mask operands
+              mask_ready_o = ~vinsn_issue_q.vm;
+
+              // Reduction instruction, accumulate the result
+              result_queue_d[result_queue_write_pnt_q].wdata = valu_result;
+              result_queue_d[result_queue_write_pnt_q].addr  = vaddr(vinsn_issue_q.vd, NrLanes);
+              result_queue_d[result_queue_write_pnt_q].id    = vinsn_issue_q.id;
+              result_queue_d[result_queue_write_pnt_q].be    = be(1, vinsn_issue_q.vtype.vsew);
+
+              // The first operation of this instruction has just been done
+              first_op_d = 1'b0;
+
+              issue_cnt_d = issue_cnt_q - element_cnt;
+
+              // Finished issuing the micro-operations of this vector instruction
+              if (vinsn_issue_valid && issue_cnt_d == '0) begin
+                // We can start the inter-lanes reduction
+                alu_state_d = INTER_LANES_REDUCTION;
+              end
+            end
+          end
         end
-      end
+        INTER_LANES_REDUCTION: begin
+          if (reduction_rx_cnt_q == '0) begin
+            // This unit has finished processing data for this reduction instruction, send the partial result to the sliding unit
+            alu_red_valid_o = 1'b1;
+            if (alu_red_ready_i) begin
+              alu_state_d = WAIT_STATE;
+   		      if (LaneIdx != 0) begin
+                // Bump issue counter and pointers
+                vinsn_queue_d.issue_cnt -= 1;
+                if (vinsn_queue_q.issue_pnt == VInsnQueueDepth-1)
+                  vinsn_queue_d.issue_pnt = '0;
+                else
+                  vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
+
+                if (vinsn_queue_d.issue_cnt != 0)
+                  issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+              end
+            end
+          end else begin
+            // This unit should still process data for the inter-lane reduction.
+            // Ready to accept incoming operands from the slide unit.
+            alu_red_valid_o = red_hs_synch_q;
+            if (sldu_alu_valid_i) begin
+              // Issue the operation
+              valu_valid = 1'b1;
+              sldu_alu_ready_o = 1'b1;
+              reduction_rx_cnt_d = reduction_rx_cnt_q - 1;
+              result_queue_d[result_queue_write_pnt_q].wdata = valu_result;
+            end
+          end
+          // Count the successful transaction with the SLDU
+          if (sldu_alu_valid_i && sldu_alu_ready_o) begin
+            sldu_transactions_cnt_d = sldu_transactions_cnt_q - 1;
+          end
+          if (alu_red_valid_o && alu_red_ready_i) red_hs_synch_d = 1'b0;
+          if (sldu_alu_valid_i && sldu_alu_ready_o) red_hs_synch_d = 1'b1;
+        end
+        WAIT_STATE: begin
+          // Acknowledge the sliding unit even if it is not forwarding anything useful
+          sldu_alu_ready_o = sldu_alu_valid_i;
+          alu_red_valid_o  = red_hs_synch_q;
+          // If lane 0, wait for the inter-lane reduced operand, to perform a SIMD reduction
+          if (LaneIdx == 0) begin
+            if (sldu_alu_valid_i) begin
+              if (sldu_transactions_cnt_q == 1) begin
+                result_queue_d[result_queue_write_pnt_q].wdata = sldu_operand_i;
+                unique case (vinsn_issue_q.vtype.vsew)
+                  EW8:  simd_red_cnt_max_d = 2'd3;
+                  EW16: simd_red_cnt_max_d = 2'd2;
+                  EW32: simd_red_cnt_max_d = 2'd1;
+                  EW64: simd_red_cnt_max_d = 2'd0;
+                endcase
+                simd_red_cnt_d = '0;
+                alu_state_d = SIMD_REDUCTION;
+              end
+            end
+          end else if (sldu_transactions_cnt_q == '0) begin
+            // If not lane 0, wait for the completion of the reduction
+            alu_state_d = is_reduction(vinsn_issue_q.op) && vinsn_issue_valid ? INTRA_LANE_REDUCTION : NO_REDUCTION;
+            commit_cnt_d = '0;
+          end
+          if (sldu_alu_valid_i && sldu_alu_ready_o) begin
+            sldu_transactions_cnt_d = sldu_transactions_cnt_q - 1;
+          end
+          if (alu_red_valid_o && alu_red_ready_i) red_hs_synch_d = 1'b0;
+          if (sldu_alu_valid_i && sldu_alu_ready_o) red_hs_synch_d = 1'b1;
+        end
+        SIMD_REDUCTION: begin
+          if (LaneIdx == 0) begin
+            valu_valid = (simd_red_cnt_q != simd_red_cnt_max_q);
+
+            unique case (simd_red_cnt_q)
+              2'd0: simd_red_operand = {32'b0, result_queue_q[result_queue_write_pnt_q].wdata[63:32]};
+              2'd1: simd_red_operand = {48'b0, result_queue_q[result_queue_write_pnt_q].wdata[31:16]};
+              2'd2: simd_red_operand = {56'b0, result_queue_q[result_queue_write_pnt_q].wdata[15:8]};
+              default:;
+            endcase
+
+            if (simd_red_cnt_q != simd_red_cnt_max_q) begin
+              simd_red_cnt_d = simd_red_cnt_q + 1;
+              result_queue_d[result_queue_write_pnt_q].wdata = valu_result;
+            end else begin
+              // Bump issue counter and pointers
+              vinsn_queue_d.issue_cnt -= 1;
+              if (vinsn_queue_q.issue_pnt == VInsnQueueDepth-1)
+                vinsn_queue_d.issue_pnt = '0;
+              else
+                vinsn_queue_d.issue_pnt = vinsn_queue_q.issue_pnt + 1;
+
+              if (vinsn_queue_d.issue_cnt != 0)
+                issue_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.issue_pnt].vl;
+
+              alu_state_d = is_reduction(vinsn_issue_d.op) && (vinsn_queue_d.issue_cnt != 0) ? INTRA_LANE_REDUCTION : NO_REDUCTION;
+              commit_cnt_d = '0;
+
+              // Bump pointers and counters of the result queue
+              result_queue_valid_d[result_queue_write_pnt_q] = 1'b1;
+              result_queue_cnt_d += 1;
+              if (result_queue_write_pnt_q == ResultQueueDepth-1)
+                result_queue_write_pnt_d = 0;
+              else
+                result_queue_write_pnt_d = result_queue_write_pnt_q + 1;
+              end
+          end
+        end
+        default:;
+      endcase
     end
 
     //////////////////////////////////
     //  Write results into the VRF  //
     //////////////////////////////////
 
-    alu_result_req_o = result_queue_valid_q[result_queue_read_pnt_q] &&
-      !result_queue_q[result_queue_read_pnt_q].mask;
+    alu_result_wdata_o = result_queue_q[result_queue_read_pnt_q].wdata;
+    if (alu_state_q == NO_REDUCTION || (alu_state_q == SIMD_REDUCTION && simd_red_cnt_q == simd_red_cnt_max_q)) begin
+      alu_result_req_o   = result_queue_valid_q[result_queue_read_pnt_q] & ((alu_state_q == SIMD_REDUCTION) || !result_queue_q[result_queue_read_pnt_q].mask);
+    end else begin
+      alu_result_req_o = 1'b0;
+    end
     alu_result_addr_o  = result_queue_q[result_queue_read_pnt_q].addr;
     alu_result_id_o    = result_queue_q[result_queue_read_pnt_q].id;
-    alu_result_wdata_o = result_queue_q[result_queue_read_pnt_q].wdata;
     alu_result_be_o    = result_queue_q[result_queue_read_pnt_q].be;
 
     // Received a grant from the VRF.
@@ -402,8 +658,24 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
       (vfu_operation_i.vfu == VFU_Alu || vfu_operation_i.op inside {[VMSEQ:VMXNOR]})) begin
       vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt] = vfu_operation_i;
 
-      // Initialize counters
-      if (vinsn_queue_d.issue_cnt == '0) issue_cnt_d = vfu_operation_i.vl;
+      // The next will be the first operation of this instruction
+      // This information is useful for reduction operation
+      first_op_d         = 1'b1;
+      reduction_rx_cnt_d = reduction_rx_cnt_init(NrLanes, LaneIdx);
+
+      // Initialize counters and alu state if this is the instruction queue was empty
+      if (vinsn_queue_d.issue_cnt == '0) begin
+        alu_state_d = is_reduction(vfu_operation_i.op) ? INTRA_LANE_REDUCTION : NO_REDUCTION;
+        // If the lane is not computing within the reduction, it will just pass the incoming values on
+		if (vfu_operation_i.vl == '0) begin
+          alu_state_d = INTER_LANES_REDUCTION;
+          result_queue_d[result_queue_write_pnt_q].wdata = elen_t'(safe_red_byte);
+        end
+        sldu_transactions_cnt_d = $clog2(NrLanes) + 1;
+        // Allow the first valid
+        red_hs_synch_d = 1'b1;
+        issue_cnt_d = vfu_operation_i.vl;
+      end
       if (vinsn_queue_d.commit_cnt == '0) commit_cnt_d = vfu_operation_i.vl;
 
       // Bump pointers and counters of the vector instruction queue
@@ -415,13 +687,27 @@ module valu import ara_pkg::*; import rvv_pkg::*; #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      issue_cnt_q        <= '0;
-      commit_cnt_q       <= '0;
-      narrowing_select_q <= 1'b0;
+      issue_cnt_q             <= '0;
+      commit_cnt_q            <= '0;
+      narrowing_select_q      <= 1'b0;
+      simd_red_cnt_q          <= '0;
+      alu_state_q             <= NO_REDUCTION;
+      reduction_rx_cnt_q      <= '0;
+      first_op_q              <= 1'b0;
+      sldu_transactions_cnt_q <= '0;
+      red_hs_synch_q          <= 1'b0;
+      simd_red_cnt_max_q      <= '0;
     end else begin
-      issue_cnt_q        <= issue_cnt_d;
-      commit_cnt_q       <= commit_cnt_d;
-      narrowing_select_q <= narrowing_select_d;
+      issue_cnt_q             <= issue_cnt_d;
+      commit_cnt_q            <= commit_cnt_d;
+      narrowing_select_q      <= narrowing_select_d;
+      simd_red_cnt_q          <= simd_red_cnt_d;
+      alu_state_q             <= alu_state_d;
+      reduction_rx_cnt_q      <= reduction_rx_cnt_d;
+      first_op_q              <= first_op_d;
+      sldu_transactions_cnt_q <= sldu_transactions_cnt_d;
+      red_hs_synch_q          <= red_hs_synch_d;
+      simd_red_cnt_max_q      <= simd_red_cnt_max_d;
     end
   end
 

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -106,10 +106,10 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .alu_result_be_o      (alu_result_be_o                ),
     .alu_result_gnt_i     (alu_result_gnt_i               ),
     // Interface with the Slide Unit
-    .alu_red_valid_o      (sldu_alu_req_valid_o ),
-    .sldu_operand_i       (sldu_operand_i       ),
-    .sldu_alu_valid_i     (sldu_alu_valid_i     ),
-    .sldu_alu_ready_o     (sldu_alu_ready_o     ),
+    .alu_red_valid_o      (sldu_alu_req_valid_o           ),
+    .sldu_operand_i       (sldu_operand_i                 ),
+    .sldu_alu_valid_i     (sldu_alu_valid_i               ),
+    .sldu_alu_ready_o     (sldu_alu_ready_o               ),
     // Interface with the Slide Unit
     .alu_red_ready_i      (sldu_alu_gnt_i),
     // Interface with the Mask unit

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -9,6 +9,7 @@
 
 module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int           unsigned NrLanes    = 0,
+    parameter  int           unsigned LaneIdx    = 0,
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport = FPUSupportHalfSingleDouble,
     // Type used to address vector register file elements
@@ -50,6 +51,12 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
     output elen_t                             mfpu_result_wdata_o,
     output strb_t                             mfpu_result_be_o,
     input  logic                              mfpu_result_gnt_i,
+    // Interface with the Slide Unit
+    output logic                              sldu_alu_req_valid_o,
+    input  elen_t                             sldu_operand_i,
+    input  logic                              sldu_alu_valid_i,
+    output logic                              sldu_alu_ready_o,
+    input  logic                              sldu_alu_gnt_i,
     // Interface with the Mask unit
     output elen_t          [NrMaskFUnits-1:0] mask_operand_o,
     output logic           [NrMaskFUnits-1:0] mask_operand_valid_o,
@@ -77,6 +84,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
 
   valu #(
     .NrLanes(NrLanes),
+    .LaneIdx(LaneIdx),
     .vaddr_t(vaddr_t)
   ) i_valu (
     .clk_i                (clk_i                          ),
@@ -97,6 +105,13 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
     .alu_result_wdata_o   (alu_result_wdata_o             ),
     .alu_result_be_o      (alu_result_be_o                ),
     .alu_result_gnt_i     (alu_result_gnt_i               ),
+    // Interface with the Slide Unit
+    .alu_red_valid_o      (sldu_alu_req_valid_o ),
+    .sldu_operand_i       (sldu_operand_i       ),
+    .sldu_alu_valid_i     (sldu_alu_valid_i     ),
+    .sldu_alu_ready_o     (sldu_alu_ready_o     ),
+    // Interface with the Slide Unit
+    .alu_red_ready_i      (sldu_alu_gnt_i),
     // Interface with the Mask unit
     .mask_operand_o       (mask_operand_o[MaskFUAlu]      ),
     .mask_operand_valid_o (mask_operand_valid_o[MaskFUAlu]),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -7,9 +7,8 @@
 // This is Ara's vector execution stage. This contains the functional units
 // of each lane, namely the ALU and the Multiplier/FPU.
 
-module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
+module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     parameter  int           unsigned NrLanes    = 0,
-    parameter  int           unsigned LaneIdx    = 0,
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport = FPUSupportHalfSingleDouble,
     // Type used to address vector register file elements
@@ -20,6 +19,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
   ) (
     input  logic                              clk_i,
     input  logic                              rst_ni,
+    input  logic [idx_width(NrLanes)-1:0]     lane_id_i,
     // Interface with CVA6
     output logic           [4:0]              fflags_ex_o,
     output logic                              fflags_ex_valid_o,
@@ -84,11 +84,11 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; #(
 
   valu #(
     .NrLanes(NrLanes),
-    .LaneIdx(LaneIdx),
     .vaddr_t(vaddr_t)
   ) i_valu (
     .clk_i                (clk_i                          ),
     .rst_ni               (rst_ni                         ),
+    .lane_id_i            (lane_id_i                      ),
     // Interface with the lane sequencer
     .vfu_operation_i      (vfu_operation_i                ),
     .vfu_operation_valid_i(vfu_operation_valid_i          ),

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -275,9 +275,8 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
               // Writes
               out_pnt_d = {'0, red_stride_cnt_q, 3'b0};
 
-              // Initialize counters. Pretend to move NrLanes 64-bit elements for (clog2(NrLanes) + 1) times.
+              // Initialize issue cnt. Pretend to move NrLanes 64-bit elements for (clog2(NrLanes) + 1) times.
               issue_cnt_d  = (NrLanes * ($clog2(NrLanes) + 1)) << EW64;
-              commit_cnt_d = (NrLanes * ($clog2(NrLanes) + 1)) << EW64;
             end
           endcase
         end

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -550,25 +550,25 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      vinsn_running_q <= '0;
-      issue_cnt_q     <= '0;
-      commit_cnt_q    <= '0;
-      in_pnt_q        <= '0;
-      out_pnt_q       <= '0;
-      vrf_pnt_q       <= '0;
-      state_q         <= SLIDE_IDLE;
-      pe_resp_o       <= '0;
-      red_stride_cnt_q<= 1;
+      vinsn_running_q  <= '0;
+      issue_cnt_q      <= '0;
+      commit_cnt_q     <= '0;
+      in_pnt_q         <= '0;
+      out_pnt_q        <= '0;
+      vrf_pnt_q        <= '0;
+      state_q          <= SLIDE_IDLE;
+      pe_resp_o        <= '0;
+      red_stride_cnt_q <= 1;
     end else begin
-      vinsn_running_q <= vinsn_running_d;
-      issue_cnt_q     <= issue_cnt_d;
-      commit_cnt_q    <= commit_cnt_d;
-      in_pnt_q        <= in_pnt_d;
-      out_pnt_q       <= out_pnt_d;
-      vrf_pnt_q       <= vrf_pnt_d;
-      state_q         <= state_d;
-      pe_resp_o       <= pe_resp;
-      red_stride_cnt_q<= red_stride_cnt_d;
+      vinsn_running_q  <= vinsn_running_d;
+      issue_cnt_q      <= issue_cnt_d;
+      commit_cnt_q     <= commit_cnt_d;
+      in_pnt_q         <= in_pnt_d;
+      out_pnt_q        <= out_pnt_d;
+      vrf_pnt_q        <= vrf_pnt_d;
+      state_q          <= state_d;
+      pe_resp_o        <= pe_resp;
+      red_stride_cnt_q <= red_stride_cnt_d;
     end
   end
 

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -499,7 +499,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
 
       // Update the commit counter for the next instruction
       if (vinsn_queue_d.commit_cnt != '0) begin
-        commit_cnt_d = pe_req_i.op inside {VSLIDEUP, VSLIDEDOWN}
+        commit_cnt_d = vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].op inside {VSLIDEUP, VSLIDEDOWN}
                      ? vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].vl << int'(vinsn_queue_q.vinsn[vinsn_queue_d.commit_pnt].vtype.vsew)
                      : (NrLanes * ($clog2(NrLanes) + 1)) << EW64;
 

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -459,7 +459,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
 
       // Received a grant from the VRF (slide) or from the FUs (reduction).
       // Deactivate the request, but do not bump the pointers for now.
-      if ((vinsn_commit.vfu == VFU_Alu || sldu_result_req_o[lane]) && sldu_result_gnt_i[lane]) begin
+      if (((vinsn_commit.vfu == VFU_Alu && sldu_red_valid_o) || sldu_result_req_o[lane]) && sldu_result_gnt_i[lane]) begin
         result_queue_valid_d[result_queue_read_pnt_q][lane] = 1'b0;
         result_queue_d[result_queue_read_pnt_q][lane]       = '0;
       end

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -389,6 +389,9 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
   //  Support for misaligned stores  //
   /////////////////////////////////////
 
+  // AXI Request Generation signals, declared here for convenience
+  addrgen_req_t axi_addrgen_d, axi_addrgen_q;
+
   // Narrower AXI Data Byte-Width used for misaligned stores
   logic [$clog2(AxiDataWidth/8)-1:0]            narrow_axi_data_bwidth;
   // Helper signal to calculate the narrow_axi_data_bwidth
@@ -419,7 +422,6 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
   //  AXI Request Generation  //
   //////////////////////////////
 
-  addrgen_req_t axi_addrgen_d, axi_addrgen_q;
   enum logic [1:0] {
     AXI_ADDRGEN_IDLE, AXI_ADDRGEN_MISALIGNED, AXI_ADDRGEN_WAITING, AXI_ADDRGEN_REQUESTING
   } axi_addrgen_state_d, axi_addrgen_state_q;


### PR DESCRIPTION
# Merge https://github.com/pulp-platform/ara/pull/92 before this one

Add single-width and widening integer reductions to Ara, and solve some related bugs.

## Changelog

### Fixed

- When the instruction queue of the SLDU is not empty, read from it to update the commit counter, and not from the incoming request
- If an instruction targets more FUs, all of them must be ready to let the instruction be dispatched by the sequencer

### Added

- Vector integer reductions (`vredsum`, `vredmaxu`, `vredmax`, `vredminu`, `vredmin`, `vredand`, `vredor`, `vredxor`, `vwredsumu`, `vwredsum`)

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed