### PR TITLE
Hotfix - Main Sequencer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Avoid corner-case in which the sequencer issues the same instruction multiple times when two units become non-ready at the same time
  - The lane sequencer now calculates the correct number of elements to be requested by the `MASKU` operand requesters
  - When the instruction queue of the SLDU is not empty, read from it to update the commit counter, and not from the incoming request
- - If an instruction targets more FUs, all of them must be ready to let the instruction be dispatched by the sequencer
+ - Masked operations now target the MASKU as well for the issue checks in the main sequencer
+ - The granularity of the issue checks/gold tickets is now at a PE level
+ - Avoid losing hazard-related information in the pipeline between the main sequencer and the operand requesters
+ - Fix anticipated grant bug from operand requester to LDU, SLDU, MASKU, because of the stream registers. Now, the three units wait for a final true grant before commiting
+ - The mask unit does not require synchronized lanes anymore to commit an instruction
 
 ## Added
 
@@ -19,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Vector indexed unordered/ordered load (`vluxei8`, `vluxei16`, `vluxei32`, `vluxei64`, `vloxei8`, `vloxei16`, `vloxei32`, `vloxei64`)
  - Vector indexed unordered/ordered stores (`vsuxei8`, `vsuxei16`, `vsuxei32`, `vsuxei64`, `vsoxei8`, `vsoxei16`, `vsoxei32`, `vsoxei64`)
  - Vector integer reductions (`vredsum`, `vredmaxu`, `vredmax`, `vredminu`, `vredmin`, `vredand`, `vredor`, `vredxor`, `vwredsumu`, `vwredsum`)
+ - Introduce the global hazard table in the main sequencer, to provide up-to-date information to the operand requesters about the status of the different dependant instructions
 
 ## Changed
 

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -116,43 +116,47 @@ module ara import ara_pkg::*; #(
   /////////////////
 
   // Interface with the PEs
-  pe_req_t                pe_req;
-  logic                   pe_req_valid;
-  logic     [NrPEs-1:0]   pe_req_ready;
-  logic     [NrVInsn-1:0] pe_vinsn_running;
-  pe_resp_t [NrPEs-1:0]   pe_resp;
+  pe_req_t                         pe_req;
+  logic                            pe_req_valid;
+  logic              [NrPEs-1:0]   pe_req_ready;
+  logic              [NrVInsn-1:0] pe_vinsn_running;
+  pe_resp_t          [NrPEs-1:0]   pe_resp;
   // Interface with the address generator
-  logic                   addrgen_ack;
-  logic                   addrgen_error;
-  vlen_t                  addrgen_error_vl;
-  logic     [NrLanes-1:0] alu_vinsn_done;
-  logic     [NrLanes-1:0] mfpu_vinsn_done;
+  logic                            addrgen_ack;
+  logic                            addrgen_error;
+  vlen_t                           addrgen_error_vl;
+  logic              [NrLanes-1:0] alu_vinsn_done;
+  logic              [NrLanes-1:0] mfpu_vinsn_done;
+  // Interface with the operand requesters
+  logic [NrVInsn-1:0][NrVInsn-1:0] global_hazard_table;
 
   ara_sequencer #(.NrLanes(NrLanes)) i_sequencer (
-    .clk_i                 (clk_i             ),
-    .rst_ni                (rst_ni            ),
+    .clk_i                 (clk_i              ),
+    .rst_ni                (rst_ni             ),
     // Interface with the dispatcher
-    .ara_req_i             (ara_req           ),
-    .ara_req_valid_i       (ara_req_valid     ),
-    .ara_req_ready_o       (ara_req_ready     ),
-    .ara_resp_o            (ara_resp          ),
-    .ara_resp_valid_o      (ara_resp_valid    ),
-    .ara_idle_o            (ara_idle          ),
+    .ara_req_i             (ara_req            ),
+    .ara_req_valid_i       (ara_req_valid      ),
+    .ara_req_ready_o       (ara_req_ready      ),
+    .ara_resp_o            (ara_resp           ),
+    .ara_resp_valid_o      (ara_resp_valid     ),
+    .ara_idle_o            (ara_idle           ),
     // Interface with the PEs
-    .pe_req_o              (pe_req            ),
-    .pe_req_valid_o        (pe_req_valid      ),
-    .pe_vinsn_running_o    (pe_vinsn_running  ),
-    .pe_req_ready_i        (pe_req_ready      ),
-    .pe_resp_i             (pe_resp           ),
-    .alu_vinsn_done_i      (alu_vinsn_done[0] ),
-    .mfpu_vinsn_done_i     (mfpu_vinsn_done[0]),
+    .pe_req_o              (pe_req             ),
+    .pe_req_valid_o        (pe_req_valid       ),
+    .pe_vinsn_running_o    (pe_vinsn_running   ),
+    .pe_req_ready_i        (pe_req_ready       ),
+    .pe_resp_i             (pe_resp            ),
+    .alu_vinsn_done_i      (alu_vinsn_done[0]  ),
+    .mfpu_vinsn_done_i     (mfpu_vinsn_done[0] ),
+    // Interface with the operand requesters
+    .global_hazard_table_o (global_hazard_table),
     // Interface with the slide unit
-    .pe_scalar_resp_i      ('0                ),
-    .pe_scalar_resp_valid_i(1'b0              ),
+    .pe_scalar_resp_i      ('0                 ),
+    .pe_scalar_resp_valid_i(1'b0               ),
     // Interface with the address generator
-    .addrgen_ack_i         (addrgen_ack       ),
-    .addrgen_error_i       (addrgen_error     ),
-    .addrgen_error_vl_i    (addrgen_error_vl  )
+    .addrgen_ack_i         (addrgen_ack        ),
+    .addrgen_error_i       (addrgen_error      ),
+    .addrgen_error_vl_i    (addrgen_error_vl   )
   );
 
   /////////////
@@ -226,6 +230,7 @@ module ara import ara_pkg::*; #(
       .pe_resp_o                       (pe_resp[lane]                       ),
       .alu_vinsn_done_o                (alu_vinsn_done[lane]                ),
       .mfpu_vinsn_done_o               (mfpu_vinsn_done[lane]               ),
+      .global_hazard_table_i           (global_hazard_table                 ),
       // Interface with the slide unit
       .sldu_result_req_i               (sldu_result_req[lane]               ),
       .sldu_result_addr_i              (sldu_result_addr[lane]              ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -43,6 +43,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output `STRUCT_PORT(pe_resp_t)                         pe_resp_o,
     output logic                                           alu_vinsn_done_o,
     output logic                                           mfpu_vinsn_done_o,
+    input  logic                [NrVInsn-1:0][NrVInsn-1:0] global_hazard_table_i,
     // Interface with the Store unit
     output elen_t                                          stu_operand_o,
     output logic                                           stu_operand_valid_o,
@@ -114,7 +115,6 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   operand_request_cmd_t [NrOperandQueues-1:0] operand_request;
   logic                 [NrOperandQueues-1:0] operand_request_valid;
   logic                 [NrOperandQueues-1:0] operand_request_ready;
-  logic                 [NrVInsn-1:0]         vinsn_running;
   // Interface with the vector functional units
   vfu_operation_t                             vfu_operation;
   logic                                       vfu_operation_valid;
@@ -137,7 +137,6 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .operand_request_o      (operand_request      ),
     .operand_request_valid_o(operand_request_valid),
     .operand_request_ready_i(operand_request_ready),
-    .vinsn_running_o        (vinsn_running        ),
     .alu_vinsn_done_o       (alu_vinsn_done_o     ),
     .mfpu_vinsn_done_o      (mfpu_vinsn_done_o    ),
     // Interface with the VFUs
@@ -188,13 +187,14 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .NrLanes(NrLanes          ),
     .vaddr_t(vaddr_t          )
   ) i_operand_requester (
-    .clk_i                    (clk_i                   ),
-    .rst_ni                   (rst_ni                  ),
+    .clk_i                    (clk_i                  ),
+    .rst_ni                   (rst_ni                 ),
+    // Interface with the main sequencer
+    .global_hazard_table_i    (global_hazard_table_i  ),
     // Interface with the lane sequencer
-    .operand_request_i        (operand_request         ),
-    .operand_request_valid_i  (operand_request_valid   ),
-    .operand_request_ready_o  (operand_request_ready   ),
-    .vinsn_running_i          (vinsn_running           ),
+    .operand_request_i        (operand_request        ),
+    .operand_request_valid_i  (operand_request_valid  ),
+    .operand_request_ready_o  (operand_request_ready  ),
     // Interface with the VRF
     .vrf_req_o                (vrf_req                 ),
     .vrf_addr_o               (vrf_addr                ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -63,6 +63,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  strb_t                                          sldu_result_be_i,
     output logic                                           sldu_result_gnt_o,
     input  logic                                           sldu_red_valid_i,
+    output logic                                           sldu_result_final_gnt_o,
     // Interface with the Load unit
     input  logic                                           ldu_result_req_i,
     input  vid_t                                           ldu_result_id_i,
@@ -70,6 +71,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  elen_t                                          ldu_result_wdata_i,
     input  strb_t                                          ldu_result_be_i,
     output logic                                           ldu_result_gnt_o,
+    output logic                                           ldu_result_final_gnt_o,
     // Interface with the Mask unit
     output `STRUCT_VECT(elen_t, [NrMaskFUnits+2-1:0])      mask_operand_o,
     output logic                [NrMaskFUnits+2-1:0]       mask_operand_valid_o,
@@ -80,6 +82,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  elen_t                                          masku_result_wdata_i,
     input  strb_t                                          masku_result_be_i,
     output logic                                           masku_result_gnt_o,
+    output logic                                           masku_result_final_gnt_o,
     // Interface between the Mask unit and the VFUs
     input  strb_t                                          mask_i,
     input  logic                                           mask_valid_i,
@@ -187,14 +190,14 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .NrLanes(NrLanes          ),
     .vaddr_t(vaddr_t          )
   ) i_operand_requester (
-    .clk_i                    (clk_i                  ),
-    .rst_ni                   (rst_ni                 ),
+    .clk_i                    (clk_i                   ),
+    .rst_ni                   (rst_ni                  ),
     // Interface with the main sequencer
-    .global_hazard_table_i    (global_hazard_table_i  ),
+    .global_hazard_table_i    (global_hazard_table_i   ),
     // Interface with the lane sequencer
-    .operand_request_i        (operand_request        ),
-    .operand_request_valid_i  (operand_request_valid  ),
-    .operand_request_ready_o  (operand_request_ready  ),
+    .operand_request_i        (operand_request         ),
+    .operand_request_valid_i  (operand_request_valid   ),
+    .operand_request_ready_o  (operand_request_ready   ),
     // Interface with the VRF
     .vrf_req_o                (vrf_req                 ),
     .vrf_addr_o               (vrf_addr                ),
@@ -229,6 +232,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .masku_result_wdata_i     (masku_result_wdata_i    ),
     .masku_result_be_i        (masku_result_be_i       ),
     .masku_result_gnt_o       (masku_result_gnt_o      ),
+    .masku_result_final_gnt_o (masku_result_final_gnt_o),
     // Slide Unit
     .sldu_result_req_i        (sldu_result_req_i       ),
     .sldu_result_id_i         (sldu_result_id_i        ),
@@ -236,13 +240,15 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .sldu_result_wdata_i      (sldu_result_wdata_i     ),
     .sldu_result_be_i         (sldu_result_be_i        ),
     .sldu_result_gnt_o        (sldu_result_gnt_opqueues),
+    .sldu_result_final_gnt_o  (sldu_result_final_gnt_o ),
     // Load Unit
     .ldu_result_req_i         (ldu_result_req_i        ),
     .ldu_result_id_i          (ldu_result_id_i         ),
     .ldu_result_addr_i        (ldu_result_addr_i       ),
     .ldu_result_wdata_i       (ldu_result_wdata_i      ),
     .ldu_result_be_i          (ldu_result_be_i         ),
-    .ldu_result_gnt_o         (ldu_result_gnt_o        )
+    .ldu_result_gnt_o         (ldu_result_gnt_o        ),
+    .ldu_result_final_gnt_o   (ldu_result_final_gnt_o  )
   );
 
   ////////////////////////////

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -25,7 +25,6 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
     output operand_request_cmd_t [NrOperandQueues-1:0]    operand_request_o,
     output logic                 [NrOperandQueues-1:0]    operand_request_valid_o,
     input  logic                 [NrOperandQueues-1:0]    operand_request_ready_i,
-    output logic                 [NrVInsn-1:0]            vinsn_running_o,
     output logic                                          alu_vinsn_done_o,
     output logic                                          mfpu_vinsn_done_o,
     // Interface with the lane's VFUs
@@ -64,10 +63,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   //  Operand Request Command Queues  //
   //////////////////////////////////////
 
-  // We cannot use a simple FIFO because the operand request commands include
-  // bits that indicate whether there is a hazard between different vector
-  // instructions. Such hazards must be continuously cleared based on the
-  // value of the currently running loops from the main sequencer.
+  // Replace me with a FIFO
   operand_request_cmd_t [NrOperandQueues-1:0] operand_request_i;
   logic                 [NrOperandQueues-1:0] operand_request_push;
 
@@ -91,9 +87,6 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
         operand_request_d[queue]       = operand_request_i[queue];
         operand_request_valid_d[queue] = 1'b1;
       end
-
-      // Re-evaluate the hazards
-      operand_request_d[queue].hazard &= pe_vinsn_running_i;
     end
   end
 
@@ -114,8 +107,6 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   // Running instructions
   logic [NrVInsn-1:0] vinsn_done_d, vinsn_done_q;
   logic [NrVInsn-1:0] vinsn_running_d, vinsn_running_q;
-
-  assign vinsn_running_o = vinsn_running_q;
 
   // VFU operation
   vfu_operation_t vfu_operation_d;

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -63,7 +63,10 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   //  Operand Request Command Queues  //
   //////////////////////////////////////
 
-  // Replace me with a FIFO
+  // We cannot use a simple FIFO because the operand request commands include
+  // bits that indicate whether there is a hazard between different vector
+  // instructions. Such hazards must be continuously cleared based on the
+  // value of the currently running loops from the main sequencer.
   operand_request_cmd_t [NrOperandQueues-1:0] operand_request_i;
   logic                 [NrOperandQueues-1:0] operand_request_push;
 

--- a/hardware/src/lane/operand_requester.sv
+++ b/hardware/src/lane/operand_requester.sv
@@ -17,11 +17,12 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
   ) (
     input  logic                                       clk_i,
     input  logic                                       rst_ni,
+    // Interface with the main sequencer
+    input  logic            [NrVInsn-1:0][NrVInsn-1:0] global_hazard_table_i,
     // Interface with the lane sequencer
     input  operand_request_cmd_t [NrOperandQueues-1:0] operand_request_i,
     input  logic                 [NrOperandQueues-1:0] operand_request_valid_i,
     output logic                 [NrOperandQueues-1:0] operand_request_ready_o,
-    input  logic                 [NrVInsn-1:0]         vinsn_running_i,
     // Interface with the VRF
     output logic                 [NrBanks-1:0]         vrf_req_o,
     output vaddr_t               [NrBanks-1:0]         vrf_addr_o,
@@ -211,6 +212,8 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
 
     // Metadata required to request all elements of this vector operand
     struct packed {
+      // ID of the instruction for this requester
+      vid_t id;
       // Address of the next element to be read
       vaddr_t addr;
       // How many elements remain to be read
@@ -288,6 +291,7 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
 
             // Store the request
             requester_d = '{
+              id     : operand_request_i[requester].id,
               addr   : vaddr(operand_request_i[requester].vs, NrLanes) +
               (operand_request_i[requester].vstart >>
                 (int'(EW64) - int'(operand_request_i[requester].eew))),
@@ -315,8 +319,6 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
         end
 
         REQUESTING: begin
-          // Update hazards
-          requester_d.hazard = requester_q.hazard & vinsn_running_i;
           // Update waw counters
           for (int b = 0; b < NrVInsn; b++)
             if (vinsn_result_written_d[b])
@@ -371,6 +373,7 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Store the request
                 requester_d = '{
+                  id   : operand_request_i[requester].id,
                   addr : vaddr(operand_request_i[requester].vs, NrLanes) +
                   (operand_request_i[requester].vstart >>
                     (int'(EW64) - int'(operand_request_i[requester].eew))),
@@ -388,6 +391,8 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
           end
         end
       endcase
+      // Always keep the hazard bits up to date with the global hazard table
+      requester_d.hazard &= global_hazard_table_i[requester_d.id];
     end : operand_requester
 
     always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -34,10 +34,10 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
     output elen_t    [NrLanes-1:0] sldu_result_wdata_o,
     output strb_t    [NrLanes-1:0] sldu_result_be_o,
     input  logic     [NrLanes-1:0] sldu_result_gnt_i,
+    input  logic     [NrLanes-1:0] sldu_result_final_gnt_i,
     // Support for reductions
     output sldu_mux_e              sldu_mux_sel_o,
     output logic     [NrLanes-1:0] sldu_red_valid_o,
-    input  logic     [NrLanes-1:0] sldu_result_final_gnt_i,
     // Interface with the Mask Unit
     input  strb_t    [NrLanes-1:0] mask_i,
     input  logic     [NrLanes-1:0] mask_valid_i,
@@ -479,8 +479,9 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
 
     // All lanes accepted the VRF request
     // If this was the last request, wait for all the final grants!
+    // If this is a reduction, no need for the final grants
     if (!(|result_queue_valid_d[result_queue_read_pnt_q]) &&
-      (&result_final_gnt_d || commit_cnt_q > (NrLanes * 8)))
+      (vinsn_commit.vfu == VFU_Alu || (&result_final_gnt_d || commit_cnt_q > (NrLanes * 8))))
       // There is something waiting to be written
       if (!result_queue_empty) begin
         // Increment the read pointer

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -65,7 +65,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     output vaddr_t    [NrLanes-1:0] ldu_result_addr_o,
     output elen_t     [NrLanes-1:0] ldu_result_wdata_o,
     output strb_t     [NrLanes-1:0] ldu_result_be_o,
-    input  logic      [NrLanes-1:0] ldu_result_gnt_i
+    input  logic      [NrLanes-1:0] ldu_result_gnt_i,
+    input  logic      [NrLanes-1:0] ldu_result_final_gnt_i
   );
 
   ///////////////////
@@ -185,7 +186,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .ldu_result_id_o        (ldu_result_id_o           ),
     .ldu_result_wdata_o     (ldu_result_wdata_o        ),
     .ldu_result_be_o        (ldu_result_be_o           ),
-    .ldu_result_gnt_i       (ldu_result_gnt_i          )
+    .ldu_result_gnt_i       (ldu_result_gnt_i          ),
+    .ldu_result_final_gnt_i (ldu_result_final_gnt_i    )
   );
 
   /////////////////////////


### PR DESCRIPTION
# Merge me before https://github.com/pulp-platform/ara/pull/104

1) When the main sequencer dispatches an instruction in cycle C, it calculates the hazard bits for that instruction without checking if the offending instruction was already over or not. In the same cycle, the main sequencer assigns the ID to the dispatched instruction.
This means that instruction `B` (unknown ID) can depend upon instruction `A` (ID 1), and instruction `A` can finish before `B` is dispatched. When `B` is dispatched, it can take the same ID of instruction `A`. If this is the case (instruction `B` with ID 1), we will deadlock downstream. 
This is because the hazards bits were calculated without taking into consideration that `A` was already over. Since hazards bits are cleared ID-wise, instruction `B` will now have a hazard on ID 1, but ID 1 is instruction `B` itself! This brings to a deadlock downstream.
The solution is to clear the just calculated hazard bits if the offending instruction was already over.

2) The stream registers in the operand requesters give grants to MASKU, LDU, SLDU every time a result is accepted. This grant on the last result of an instruction tells the sequencer to clear the dependencies on that instruction since the instruction is considered over. This is wrong, as the result is maybe stalled in the operand requester due to banking conflicts: therefore the instruction was not committed yet, and some dependencies can break as a result of this early hazards clearing.
Now, the three units wait for a final grant before considering the instruction as committed.

3) Masked instructions were not targeting the MASKU during the issue checks in the main sequencer. Now, this was fixed.

Note: no timing degradation was observed after PnR.
Note: safe hash before rebasing `int_red` -> 85472bb6abe39694f4e0a7c730fa3441975d178c

## Changelog

### Fixed

- Avoid losing hazard-related information in the pipeline between the main sequencer and the operand requesters
- Fix anticipated grant bug from operand requester to LDU, SLDU, MASKU, because of the stream registers. Now, the three units wait for a final true grant before committing
- The mask unit does not require synchronized lanes anymore to commit an instruction
- Masked instructions now target the MASKU for the issue checks in the main sequencer
- The granularity for issue checks/gold tickets is now at a PE level

### Added

- Introduce the global hazard table in the main sequencer, to provide up-to-date information to the operand requesters about the status of the different dependant instructions

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
