### PR TITLE
Hotfix - MASKU operand requesters bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Fixed
 
  - Avoid corner-case in which the sequencer issues the same instruction multiple times when two units become non-ready at the same time
+ - The lane sequencer now calculates the correct number of elements to be requested by the `MASKU` operand requesters
 
 ## Added
 

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -274,12 +274,12 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vtype  : pe_req.vtype,
             // Since this request goes outside of the lane, we might need to request an
             // extra operand regardless of whether it is valid in this lane or not.
-            vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vl     : (pe_req.vl / NrLanes / 8) >> int'(pe_req.vtype.vsew),
             vstart : vfu_operation_d.vstart,
             hazard : pe_req.hazard_vm | pe_req.hazard_vd,
             default: '0
           };
-          if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+          if ((operand_request_i[MaskM].vl << int'(pe_req.vtype.vsew)) *
               NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
           operand_request_push[MaskM] = !pe_req.vm;
         end
@@ -341,12 +341,12 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vtype  : pe_req.vtype,
             // Since this request goes outside of the lane, we might need to request an
             // extra operand regardless of whether it is valid in this lane or not.
-            vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vl     : (pe_req.vl / NrLanes / 8) >> int'(pe_req.vtype.vsew),
             vstart : vfu_operation_d.vstart,
             hazard : pe_req.hazard_vm | pe_req.hazard_vd,
             default: '0
           };
-          if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+          if ((operand_request_i[MaskM].vl << int'(pe_req.vtype.vsew)) *
               NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
           operand_request_push[MaskM] = !pe_req.vm;
         end
@@ -359,12 +359,12 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vtype  : pe_req.vtype,
             // Since this request goes outside of the lane, we might need to request an
             // extra operand regardless of whether it is valid in this lane or not.
-            vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vl     : (pe_req.vl / NrLanes / 8) >> int'(pe_req.vtype.vsew),
             vstart : vfu_operation_d.vstart,
             hazard : pe_req.hazard_vm | pe_req.hazard_vd,
             default: '0
           };
-          if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+          if ((operand_request_i[MaskM].vl << int'(pe_req.vtype.vsew)) *
               NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
           operand_request_push[MaskM] = !pe_req.vm;
 
@@ -415,12 +415,12 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vtype  : pe_req.vtype,
             // Since this request goes outside of the lane, we might need to request an
             // extra operand regardless of whether it is valid in this lane or not.
-            vl     : (pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(pe_req.vtype.vsew)),
+            vl     : (pe_req.vl / NrLanes / 8) >> int'(pe_req.vtype.vsew),
             vstart : vfu_operation_d.vstart,
             hazard : pe_req.hazard_vm | pe_req.hazard_vd,
             default: '0
           };
-          if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+          if ((operand_request_i[MaskM].vl << int'(pe_req.vtype.vsew)) *
               NrLanes * 8 != pe_req.vl) operand_request_i[MaskM].vl += 1;
           operand_request_push[MaskM] = !pe_req.vm;
 
@@ -525,18 +525,18 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
               // extra operand regardless of whether it is valid in this lane or not.
               operand_request_i[MaskM].vl =
               ((pe_req.vl - pe_req.stride + NrLanes - 1) / 8 / NrLanes)
-              >> (int'(EW64) - int'(pe_req.vtype.vsew));
+              >> int'(pe_req.vtype.vsew);
 
               if (((operand_request_i[MaskM].vl + pe_req.stride) <<
-                    (int'(EW64) - int'(pe_req.vtype.vsew)) * NrLanes * 8 != pe_req.vl))
+                    int'(pe_req.vtype.vsew) * NrLanes * 8 != pe_req.vl))
                 operand_request_i[MaskM].vl += 1;
             end
             VSLIDEDOWN: begin
               // Since this request goes outside of the lane, we might need to request an
               // extra operand regardless of whether it is valid in this lane or not.
-              operand_request_i[MaskM].vl = ((pe_req.vl / NrLanes / 8) >> (int'(EW64) - int'(
-                    pe_req.vtype.vsew)));
-              if ((operand_request_i[MaskM].vl << (int'(EW64) - int'(pe_req.vtype.vsew))) *
+              operand_request_i[MaskM].vl = ((pe_req.vl / NrLanes / 8) >> int'(
+                    pe_req.vtype.vsew));
+              if ((operand_request_i[MaskM].vl << int'(pe_req.vtype.vsew)) *
                   NrLanes * 8 != pe_req.vl)
                 operand_request_i[MaskM].vl += 1;
             end


### PR DESCRIPTION
Thank you @yanghao for your toy example that allowed us to find this bug.

The lane sequencer was calculating a wrong `vl` for the mask-unit operand requester. 
We fixed this in this PR.

## Changelog

### Fixed

- The lane sequencer now calculates the correct number of elements to be requested by the `MASKU` operand requesters.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
