### PR TITLE
MASKU hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Avoid losing hazard-related information in the pipeline between the main sequencer and the operand requesters
  - Fix anticipated grant bug from operand requester to LDU, SLDU, MASKU, because of the stream registers. Now, the three units wait for a final true grant before commiting
  - The mask unit does not require synchronized lanes anymore to commit an instruction
+ - MASKU does not wait anymore for valid incoming data from inactive lanes
+ - Fix corner-case comparison in MASKU to provide the expected behavior
+ - Fix MaskB-queue vector length in the lane sequencer
 
 ## Added
 

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -643,8 +643,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             hazard  : pe_req.hazard_vd,
             default : '0
           };
-          if ((pe_req.vl / NrLanes / ELEN) << (int'(EW64) - int'(pe_req.vtype.vsew)) !=
-              pe_req.vl) operand_request_i[MaskB].vl += 1;
+          if (((pe_req.vl / NrLanes / ELEN) * NrLanes * ELEN) !=
+            pe_req.vl) operand_request_i[MaskB].vl += 1;
           operand_request_push[MaskB] = pe_req.use_vd_op;
 
           operand_request_i[MaskM] = '{

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -257,7 +257,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       // from the previous value of the destination register (mask_operand_b_i). Byte strobes
       // do not work here, since this has to be done at a bit granularity. Therefore, the Mask Unit
       // received both operands, and does a masking depending on the value of the vl.
-      if (vinsn_issue.vl > ELEN*NrLanes)
+      if (vinsn_issue.vl >= ELEN*NrLanes)
         bit_enable = '1;
       else begin
         bit_enable[vinsn_issue.vl] = 1'b1;


### PR DESCRIPTION
Hotfixes for the MASKU.

A note on the commit "[hardware] bug MASKU does not wait for valid B data from inactive lanes": the valid from the inactive lanes is artificially created in the MASKU.

## Changelog

### Fixed

- MASKU does not wait anymore for valid incoming data from inactive lanes
- Fix corner-case comparison in MASKU to provide the expected behavior
- Fix MaskB-queue vector length in the lane sequencer

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
