### PR TITLE
Fix interference between idx mem ops and reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - VALU can step from normalOp->reduction and vice-versa without issues
  - VALU's counters can now count bits when operating on mask vectors
  - Fix the vector length for mask instructions that run on the VALU/VMFPU
+ - Don't let indexed memory operations interfere with the reductions in MASKU
 
 ### Added
 


### PR DESCRIPTION
Hotfix for the SLDU. Don't let the SLDU run during an indexed memory operation.

## Changelog

### Fixed

- Don't let indexed memory operations interfere with the reductions in MASKU

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
