### PR TITLE
🐛: moved assign statement out of always block

### DIFF
--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -392,6 +392,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
   // Information about which is the target FU of the request
   assign masku_operand_fu = (vinsn_issue.op inside {[VMFEQ:VMFGE]}) ? MaskFUMFpu : MaskFUAlu;
+  assign unbalanced_a = (|commit_cnt_q[idx_width(NrLanes)-1:0] != 1'b0) ? 1'b1 : 1'b0;
 
   always_comb begin: p_masku
     // Maintain state
@@ -509,7 +510,6 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     //  Write results to the lanes  //
     //////////////////////////////////
 
-    assign unbalanced_a = (|commit_cnt_q[idx_width(NrLanes)-1:0] != 1'b0) ? 1'b1 : 1'b0;
     last_incoming_a = ((commit_cnt_q - vrf_pnt_q) < NrLanes) ? 1'b1 : 1'b0;
     for (int unsigned i = 1; i < NrLanes; i++)
       if (i >= {1'b0, commit_cnt_q[idx_width(NrLanes)-1:0]})


### PR DESCRIPTION
Description of PR that completes issue here...

## Changelog

### Fixed

- Backend flow would crash due to procedural-continuous assignment not supported by synthesis (VER-966)

### Changed

- moved assign statement out of always block

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
