### PR TITLE
Hotfixes for int Reductions and MASKU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - MASKU does not wait anymore for valid incoming data from inactive lanes
  - Fix corner-case comparison in MASKU to provide the expected behavior
  - Fix MaskB-queue vector length in the lane sequencer
+ - VALU cleans up the partial result of a reduction when no more needed
+ - VALU can step from normalOp->reduction and vice-versa without issues
+ - VALU's counters can now count bits when operating on mask vectors
+ - Fix the vector length for mask instructions that run on the VALU/VMFPU
 
 ### Added
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -428,7 +428,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
               alu_operand_ready_o = {vinsn_issue_q.use_vs2, vinsn_issue_q.use_vs1};
               // Narrowing instructions might need an extra cycle before acknowledging the mask operands
               // If the results are being sent to the Mask Unit, it is up to it to acknowledge the operands.
-              if (!narrowing(vinsn_issue_q.op) && vinsn_issue_q != VFU_MaskUnit)
+              if (!narrowing(vinsn_issue_q.op))
                 mask_ready_o = !vinsn_issue_q.vm;
 
               // Store the result in the result queue
@@ -457,8 +457,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                   result_queue_valid_d[result_queue_write_pnt_q] = 1'b1;
 
                   // Acknowledge the mask operand, if needed
-                  if (vinsn_issue_q != VFU_MaskUnit)
-                    mask_ready_o = !vinsn_issue_q.vm;
+                  mask_ready_o = !vinsn_issue_q.vm;
 
                   // Bump pointers and counters of the result queue
                   result_queue_cnt_d += 1;


### PR DESCRIPTION
A bunch of fixes for the reduction engine and how the MASKU operations run on the VALU/VMFPU.

## Changelog

### Fixed 

- VALU cleans up the partial result of a reduction when no more needed
- VALU can step from normalOp->reduction and vice-versa without issues
- VALU's counters can now count bits when operating on mask vectors
- Fix the vector length for mask instructions that run on the VALU/VMFPU

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
