### PR TITLE
VMFPU in-order execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - VALU's counters can now count bits when operating on mask vectors
  - Fix the vector length for mask instructions that run on the VALU/VMFPU
  - Don't let indexed memory operations interfere with the reductions in MASKU
+ - Enforce strict in-order execution of FPU operations in VMFPU
 
 ### Added
 

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -70,6 +70,8 @@ package ara_pkg;
   localparam int unsigned LatFDivSqrt     = 'd3;
   localparam int unsigned LatFNonComp     = 'd1;
   localparam int unsigned LatFConv        = 'd2;
+  // Define the maximum FPU latency
+  localparam int unsigned LatFMax = LatFCompEW64;
 
   // Define the maximum instruction queue depth
   localparam MaxVInsnQueueDepth = 4;
@@ -109,9 +111,9 @@ package ara_pkg;
     // Div
     VDIVU, VDIV, VREMU, VREM,
     // FPU
-    VFADD, VFSUB, VFRSUB, VFMUL, VFMACC, VFNMACC, VFMSAC, VFNMSAC, VFMADD, VFNMADD, VFMSUB, VFNMSUB,
-    VFMIN, VFMAX, VFSGNJ, VFSGNJN, VFSGNJX, VFCVTXUF, VFCVTXF, VFCVTFXU, VFCVTFX, VFCVTRTZXUF, VFCVTRTZXF,
-    VFCVTFF,
+    VFADD, VFSUB, VFRSUB, VFMUL, VFDIV, VFRDIV, VFMACC, VFNMACC, VFMSAC, VFNMSAC, VFMADD, VFNMADD, VFMSUB,
+    VFNMSUB, VFSQRT, VFMIN, VFMAX, VFCLASS, VFSGNJ, VFSGNJN, VFSGNJX, VFCVTXUF, VFCVTXF, VFCVTFXU, VFCVTFX,
+    VFCVTRTZXUF, VFCVTRTZXF, VFCVTFF,
     // Floating-point comparison instructions
     VMFEQ, VMFLE, VMFLT, VMFNE, VMFGT, VMFGE,
     // Integer comparison instructions


### PR DESCRIPTION
`fpnew` is composed of different unbalanced pipelined datapaths,
therefore it's possible that new instructions finish execution
before older ones.
In Ara, this should never happen. Therefore, if a potential latency
problem is detected, the issue instruction stalls.

Closes #33.

## Changelog

 - Enforce strict in-order execution of FPU operations in VMFPU

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
