### PR TITLE
Fix D$ lines invalidation policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix the vector length for mask instructions that run on the VALU/VMFPU
  - Don't let indexed memory operations interfere with the reductions in MASKU
  - Enforce strict in-order execution of FPU operations in VMFPU
+ - Fixed AXI-inval-filter policy for D$ lines invalidation upon vector stores that are misaligned w.r.t. the D$ line width
 
 ### Added
 

--- a/hardware/src/axi_inval_filter.sv
+++ b/hardware/src/axi_inval_filter.sv
@@ -35,6 +35,8 @@ module axi_inval_filter #(
     input  logic                 inval_ready_i
   );
 
+  import cf_math_pkg::idx_width;
+
   // Includes
   `include "axi/typedef.svh"
   `include "common_cells/registers.svh"
@@ -51,10 +53,6 @@ module axi_inval_filter #(
 
   assign inval_addr_o  = aw_fifo_data.addr + inval_offset_q;
   assign inval_valid_o = ~aw_fifo_empty;
-
-  // Misaligned-address flag
-  logic addr_misaligned;
-  assign addr_misaligned = |aw_fifo_data.addr[$clog2(L1LineWidth)-1:0];
 
   //////////////////
   // AXI Handling //
@@ -92,10 +90,10 @@ module axi_inval_filter #(
           // Wait for the L1 to accept a new invalidation request
           if (inval_ready_i) begin
             // Continue if we are not done yet
-            // If the address is misaligned, invalidate one additional cache line
-            if (L1LineWidth < ((aw_fifo_data.len + 1 + addr_misaligned) << aw_fifo_data.size)) begin
+            // If the addr is misaligned wrt the cache line, we should invalidate one line more
+            if ((L1LineWidth - aw_fifo_data.addr[idx_width(L1LineWidth)-1:0]) < ((aw_fifo_data.len + 1) << aw_fifo_data.size)) begin
               state_d        = Invalidating;
-              inval_offset_d = L1LineWidth;
+              inval_offset_d = L1LineWidth - aw_fifo_data.addr[idx_width(L1LineWidth)-1:0];
             end else begin
               aw_fifo_pop = 1'b1;
             end
@@ -109,8 +107,7 @@ module axi_inval_filter #(
         if (inval_ready_i) begin
           inval_offset_d = inval_offset_q + L1LineWidth;
           // Are we done?
-          // If the address is misaligned, invalidate one additional cache line
-          if (inval_offset_d >= ((aw_fifo_data.len + 1 + addr_misaligned) << aw_fifo_data.size)) begin
+          if (inval_offset_d >= ((aw_fifo_data.len + 1) << aw_fifo_data.size)) begin
             state_d        = Idle;
             inval_offset_d = '0;
             aw_fifo_pop    = 1'b1;


### PR DESCRIPTION
Fix invalidation policy upon vector stores to misaligned addresses (misaligned wrt the D$ line width).
The previous HW was simpler but wrong. We introduced a simple adder (with 512 bit of cache line width, the adder is a 7-bit one) to quantify the misalignment w.r.t. the cache line.

## Changelog

### Fixed

 - Fixed AXI-inval-filter policy for D$ lines invalidation upon vector stores that are misaligned w.r.t. the D$ line width

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
