### PR TITLE
Fix lane sequencer checks for FP-comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Don't let indexed memory operations interfere with the reductions in MASKU
  - Enforce strict in-order execution of FPU operations in VMFPU
  - Fixed AXI-inval-filter policy for D$ lines invalidation upon vector stores that are misaligned w.r.t. the D$ line width
+ - Fix lane sequencer checks for floating-point comparisons
 
 ### Added
 

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -173,6 +173,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
         VFU_MaskUnit : begin
           pe_req_ready = !(operand_request_valid_o[AluA] ||
             operand_request_valid_o [AluB] ||
+            operand_request_valid_o [MulFPUA] ||
+            operand_request_valid_o [MulFPUB] ||
             operand_request_valid_o[MaskB] ||
             operand_request_valid_o[MaskM]);
         end


### PR DESCRIPTION
FP-comparisons are handled by the in-lane FPUs, and then are sent to the Mask Unit for commit. The `vfu` is officially the MaskUnit, but the operands are fetched by the FPU operand requesters. Thus, the FPU operand requesters should be ready to accept the new request.

## Changelog

### Fixed

- Fix lane sequencer checks for floating-point comparisons

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed