### PR TITLE
Removed the continuous assignment from the always block of mask unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Enforce strict in-order execution of FPU operations in VMFPU
  - Fixed AXI-inval-filter policy for D$ lines invalidation upon vector stores that are misaligned w.r.t. the D$ line width
  - Fix lane sequencer checks for floating-point comparisons
- - Fix synthesis error occuring due to the continuous assignmnet in the always block of mask unit 
+ - Fix synthesis error occuring due to the continuous assignmnet in the always block of mask unit
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Enforce strict in-order execution of FPU operations in VMFPU
  - Fixed AXI-inval-filter policy for D$ lines invalidation upon vector stores that are misaligned w.r.t. the D$ line width
  - Fix lane sequencer checks for floating-point comparisons
+ - Fix synthesis error occuring due to the continuous assignmnet in the always block of mask unit 
 
 ### Added
 
@@ -45,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Refactor `benchmark` app
 - Double the testbench memory size
 - Update the `python-requirements` list
+- Remove the assign keyword from the always block of masku.sv
 
 ## 2.2.0 - 2021-11-02
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -509,7 +509,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     //  Write results to the lanes  //
     //////////////////////////////////
 
-    assign unbalanced_a = (|commit_cnt_q[idx_width(NrLanes)-1:0] != 1'b0) ? 1'b1 : 1'b0;
+    unbalanced_a = (|commit_cnt_q[idx_width(NrLanes)-1:0] != 1'b0) ? 1'b1 : 1'b0;
     last_incoming_a = ((commit_cnt_q - vrf_pnt_q) < NrLanes) ? 1'b1 : 1'b0;
     for (int unsigned i = 1; i < NrLanes; i++)
       if (i >= {1'b0, commit_cnt_q[idx_width(NrLanes)-1:0]})


### PR DESCRIPTION
Continuous assignment in the always block of mask unit is non-synthesizable. Fixed the issue by removing assign statement from the always block 

## Changelog

### Fixed

- Synthesis error  

### Added

- NA

### Changed

- Removed the assign statement from the procedural block in the masku.sv

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
