### PR TITLE
Add support for scalar moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Vector indexed unordered/ordered stores (`vsuxei8`, `vsuxei16`, `vsuxei32`, `vsuxei64`, `vsoxei8`, `vsoxei16`, `vsoxei32`, `vsoxei64`)
  - Vector integer reductions (`vredsum`, `vredmaxu`, `vredmax`, `vredminu`, `vredmin`, `vredand`, `vredor`, `vredxor`, `vwredsumu`, `vwredsum`)
  - Introduce the global hazard table in the main sequencer, to provide up-to-date information to the operand requesters about the status of the different dependant instructions
+ - Integer and Floating-Point scalar move instructions (`vmv.x.s`, `vmv.s.x`, `vmv.f.s`, `vmv.s.f`)
 
 ### Changed
 

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -64,4 +64,6 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 
 ## Vector permutation instructions
 
+- Integer Scalar Move instructions: `vmv.x.s`, `vmv.s.x`
+- Floating-Point Scalar Move instructions: `vfmv.f.s`, `vfmv.s.f`
 - Vector slide instructions: `vslideup`, `vslidedown`, `vslide1up`, `vfslide1up`, `vslide1down`, `vfslide1down`

--- a/apps/riscv-tests/isa/macros/vector/vector_macros.h
+++ b/apps/riscv-tests/isa/macros/vector/vector_macros.h
@@ -82,8 +82,9 @@ int test_case;
 
 // Check the result against a scalar golden value
 #define XCMP(casenum,act,exp)                                           \
+  printf("Checking the results of the test case %d:\n", casenum);       \
   if (act != exp) {                                                     \
-    printf("FAILED. Got %d, expected %d.\n", casenum, act, exp);        \
+    printf("Index %d FAILED. Got %d, expected %d.\n", casenum, act, exp);\
     num_failed++;                                                       \
     return;                                                             \
   }                                                                     \
@@ -92,7 +93,7 @@ int test_case;
 // Check the result against a floating-point scalar golden value
 #define FCMP(casenum,act,exp)                                           \
   if(act != exp) {                                                      \
-    printf("FAILED. Got %lf, expected %lf.\n",casenum, act, exp);       \
+    printf("Index %d FAILED. Got %lf, expected %lf.\n",casenum, act, exp);       \
     num_failed++;                                                       \
     return;                                                             \
   }                                                                     \
@@ -126,9 +127,18 @@ int test_case;
   printf("PASSED.\n");
 
 // Macros to set vector length, type and multiplier
+// Don't use this to set VL == 0 since the compiler puts rs1 == x0
 #define VSET(VLEN,VTYPE,LMUL)                                                          \
   do {                                                                                 \
   asm volatile ("vsetvli t0, %[A]," #VTYPE "," #LMUL ", ta, ma \n" :: [A] "r" (VLEN)); \
+  } while(0)
+
+// Macros to set vector length equal to zero
+#define VSET_ZERO(VTYPE,LMUL)                                                              \
+  do {                                                                                     \
+    int vset_zero_buf;                                                                     \
+    asm volatile("li %0, 0" : "=r" (vset_zero_buf));                                       \
+    asm volatile("vsetvli x0, %0," #VTYPE "," #LMUL ", ta, ma \n" :: "r" (vset_zero_buf)); \
   } while(0)
 
 #define VSETMAX(VTYPE,LMUL)                                                            \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -59,6 +59,10 @@ rv64uv_sc_tests = vadd \
                   vwmaccus \
                   vmerge \
                   vmv \
+                  vmvxs \
+                  vmvsx \
+                  vfmvfs \
+                  vfmvsf \
                   vmvnrr \
                   vredsum \
                   vredmaxu \

--- a/apps/riscv-tests/isa/rv64uv/vfmvfs.c
+++ b/apps/riscv-tests/isa/rv64uv/vfmvfs.c
@@ -1,0 +1,90 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "float_macros.h"
+#include "vector_macros.h"
+
+double scalar_16b;
+float scalar_32b;
+double scalar_64b;
+
+void TEST_CASE1() {
+  BOX_HALF_IN_DOUBLE(scalar_16b, 0);
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 0xbb1e, 0xb573, 0x39dc, 0xb97a, 0xb4c0, 0xba31, 0x3897, 0x36ee,
+           0x3b27, 0xb7d7, 0x36c0, 0x376c, 0x395b, 0x3703, 0x3057, 0x0001);
+  asm volatile("vfmv.f.s %0, v1" : "=f"(scalar_16b));
+  XCMP(1, *((uint16_t *)&scalar_16b), 0xbb1e);
+
+  scalar_32b = 0;
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 0xbe9451b0, 0x3ece4bf7, 0x3eadc098, 0x3f09f4f0, 0x3ecc80cc,
+           0xbe8a42c5, 0x3f47fd31, 0xbe201365, 0xbeffeb17, 0xbf314e2e,
+           0xbd0a9c78, 0xbf1fb51f, 0x3b5e1209, 0x3eac9a73, 0xbeb187b6,
+           0x3dea828d);
+  asm volatile("vfmv.f.s %0, v1" : "=f"(scalar_32b));
+  XCMP(2, *((uint32_t *)&scalar_32b), 0xbe9451b0);
+
+  scalar_64b = 0;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 0xbfe8d9d3f67536d2, 0x3fdad9e3e9cdd5bc, 0xbfd90875fda29450,
+           0x3fe62686e0339faa, 0x3fe2208e74273f2c, 0xbfc21587add90b50,
+           0xbfc7a755744afe30, 0xbfdf67da0cc99808, 0xbfed4488f52c57bc,
+           0xbfe6d19a966debbe, 0xbfe1a7778d7c344c, 0xbfdae653f20dd9d4,
+           0x3fe4c26b0962c342, 0xbfe2053afd5a822c, 0xbfb9851b4a2e8ff0,
+           0xbfdc0cda147fbe5c);
+  asm volatile("vfmv.f.s %0, v1" : "=f"(scalar_64b));
+  XCMP(3, *((uint64_t *)&scalar_64b), 0xbfe8d9d3f67536d2);
+}
+
+// Check special cases
+void TEST_CASE2() {
+  scalar_64b = 0;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 0xbfe8d9d3f67536d2, 0x3fdad9e3e9cdd5bc, 0xbfd90875fda29450,
+           0x3fe62686e0339faa, 0x3fe2208e74273f2c, 0xbfc21587add90b50,
+           0xbfc7a755744afe30, 0xbfdf67da0cc99808, 0xbfed4488f52c57bc,
+           0xbfe6d19a966debbe, 0xbfe1a7778d7c344c, 0xbfdae653f20dd9d4,
+           0x3fe4c26b0962c342, 0xbfe2053afd5a822c, 0xbfb9851b4a2e8ff0,
+           0xbfdc0cda147fbe5c);
+  VSET(16, e64, m8);
+  asm volatile("vfmv.f.s %0, v1" : "=f"(scalar_64b));
+  XCMP(4, *((uint64_t *)&scalar_64b), 0xbfe8d9d3f67536d2);
+
+  scalar_64b = 0;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 0xbfe8d9d3f67536d2, 0x3fdad9e3e9cdd5bc, 0xbfd90875fda29450,
+           0x3fe62686e0339faa, 0x3fe2208e74273f2c, 0xbfc21587add90b50,
+           0xbfc7a755744afe30, 0xbfdf67da0cc99808, 0xbfed4488f52c57bc,
+           0xbfe6d19a966debbe, 0xbfe1a7778d7c344c, 0xbfdae653f20dd9d4,
+           0x3fe4c26b0962c342, 0xbfe2053afd5a822c, 0xbfb9851b4a2e8ff0,
+           0xbfdc0cda147fbe5c);
+  VSET_ZERO(e64, m1);
+  asm volatile("vfmv.f.s %0, v1" : "=f"(scalar_64b));
+  XCMP(5, *((uint64_t *)&scalar_64b), 0xbfe8d9d3f67536d2);
+
+  scalar_64b = 0;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 0xbfe8d9d3f67536d2, 0x3fdad9e3e9cdd5bc, 0xbfd90875fda29450,
+           0x3fe62686e0339faa, 0x3fe2208e74273f2c, 0xbfc21587add90b50,
+           0xbfc7a755744afe30, 0xbfdf67da0cc99808, 0xbfed4488f52c57bc,
+           0xbfe6d19a966debbe, 0xbfe1a7778d7c344c, 0xbfdae653f20dd9d4,
+           0x3fe4c26b0962c342, 0xbfe2053afd5a822c, 0xbfb9851b4a2e8ff0,
+           0xbfdc0cda147fbe5c);
+  VSET_ZERO(e64, m8);
+  asm volatile("vfmv.f.s %0, v1" : "=f"(scalar_64b));
+  XCMP(6, *((uint64_t *)&scalar_64b), 0xbfe8d9d3f67536d2);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vfmvsf.c
+++ b/apps/riscv-tests/isa/rv64uv/vfmvsf.c
@@ -1,0 +1,69 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "float_macros.h"
+#include "vector_macros.h"
+
+double scalar_16b;
+float scalar_32b;
+double scalar_64b;
+
+void TEST_CASE1() {
+  BOX_HALF_IN_DOUBLE(scalar_16b, 0xbb1e);
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vfmv.s.f v1, %0" ::"f"(scalar_16b));
+  VCMP_U16(1, v1, *((uint16_t *)&scalar_16b));
+
+  scalar_32b = 0xbe9451b0;
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vfmv.s.f v1, %0" ::"f"(scalar_32b));
+  VCMP_U32(2, v1, *((uint32_t *)&scalar_32b));
+
+  scalar_64b = 0xbfe8d9d3f67536d2;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vfmv.s.f v1, %0" ::"f"(scalar_64b));
+  VCMP_U64(3, v1, *((uint64_t *)&scalar_64b));
+}
+
+// Check special cases
+void TEST_CASE2() {
+  scalar_64b = 0xbfe8d9d3f67536d2;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET(16, e64, m8);
+  asm volatile("vfmv.s.f v1, %0" ::"f"(scalar_64b));
+  VSET(1, e64, m1);
+  VCMP_U64(4, v1, *((uint64_t *)&scalar_64b));
+
+  scalar_64b = 0xbfe8d9d3f67536d2;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET_ZERO(e64, m1);
+  asm volatile("vfmv.s.f v1, %0" ::"f"(scalar_64b));
+  VSET(1, e64, m1);
+  VCMP_U64(5, v1, 1);
+
+  scalar_64b = 0xbfe8d9d3f67536d2;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET_ZERO(e64, m8);
+  asm volatile("vfmv.s.f v1, %0" ::"f"(scalar_64b));
+  VSET(1, e64, m1);
+  VCMP_U64(6, v1, 1);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vmvsx.c
+++ b/apps/riscv-tests/isa/rv64uv/vmvsx.c
@@ -1,0 +1,75 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+int8_t scalar_8b;
+int16_t scalar_16b;
+int32_t scalar_32b;
+int64_t scalar_64b;
+
+void TEST_CASE1() {
+  scalar_8b = 55 << 0;
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.s.x v1, %0" ::"r"(scalar_8b));
+  VCMP_I8(1, v1, scalar_8b);
+
+  scalar_16b = 55 << 8;
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.s.x v1, %0" ::"r"(scalar_16b));
+  VCMP_I16(2, v1, scalar_16b);
+
+  scalar_32b = 55 << 16;
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.s.x v1, %0" ::"r"(scalar_32b));
+  VCMP_I32(3, v1, scalar_32b);
+
+  scalar_64b = 55 << 32;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.s.x v1, %0" ::"r"(scalar_64b));
+  VCMP_I64(4, v1, scalar_64b);
+}
+
+// Check special cases
+void TEST_CASE2() {
+  scalar_64b = 55 << 32;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET(16, e64, m8);
+  asm volatile("vmv.s.x v1, %0" ::"r"(scalar_64b));
+  VSET(1, e64, m1);
+  VCMP_I64(5, v1, scalar_64b);
+
+  scalar_64b = 55 << 32;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET_ZERO(e64, m1);
+  asm volatile("vmv.s.x v1, %0" ::"r"(scalar_64b));
+  VSET(1, e64, m1);
+  VCMP_I64(6, v1, 1);
+
+  scalar_64b = 55 << 32;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET_ZERO(e64, m8);
+  asm volatile("vmv.s.x v1, %0" ::"r"(scalar_64b));
+  VSET(1, e64, m1);
+  VCMP_I64(7, v1, 1);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vmvxs.c
+++ b/apps/riscv-tests/isa/rv64uv/vmvxs.c
@@ -1,0 +1,72 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+#include "vector_macros.h"
+
+int8_t scalar_8b;
+int16_t scalar_16b;
+int32_t scalar_32b;
+int64_t scalar_64b;
+
+void TEST_CASE1() {
+  scalar_8b = 0;
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 55 << 0, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.x.s %0, v1" : "=r"(scalar_8b));
+  XCMP(1, scalar_8b, 55 << 0);
+
+  scalar_16b = 0;
+  VSET(16, e16, m1);
+  VLOAD_16(v1, 55 << 8, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.x.s %0, v1" : "=r"(scalar_16b));
+  XCMP(2, scalar_16b, 55 << 8);
+
+  scalar_32b = 0;
+  VSET(16, e32, m1);
+  VLOAD_32(v1, 55 << 16, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.x.s %0, v1" : "=r"(scalar_32b));
+  XCMP(3, scalar_32b, 55 << 16);
+
+  scalar_64b = 0;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 55 << 30, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  asm volatile("vmv.x.s %0, v1" : "=r"(scalar_64b));
+  XCMP(4, scalar_64b, 55 << 30);
+}
+
+// Check special cases
+void TEST_CASE2() {
+  scalar_64b = 0;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 55 << 30, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET(16, e64, m8);
+  asm volatile("vmv.x.s %0, v1" : "=r"(scalar_64b));
+  XCMP(5, scalar_64b, 55 << 30);
+
+  scalar_64b = 0;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 55 << 30, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET_ZERO(e64, m1);
+  asm volatile("vmv.x.s %0, v1" : "=r"(scalar_64b));
+  XCMP(6, scalar_64b, 55 << 30);
+
+  scalar_64b = 0;
+  VSET(16, e64, m1);
+  VLOAD_64(v1, 55 << 30, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET_ZERO(e64, m8);
+  asm volatile("vmv.x.s %0, v1" : "=r"(scalar_64b));
+  XCMP(7, scalar_64b, 55 << 30);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+
+  TEST_CASE1();
+  TEST_CASE2();
+
+  EXIT_CHECK();
+}

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -81,6 +81,7 @@ package ara_pkg;
   localparam int unsigned VlduInsnQueueDepth = 4;
   localparam int unsigned VstuInsnQueueDepth = 4;
   localparam int unsigned SlduInsnQueueDepth = 2;
+  localparam int unsigned NoneInsnQueueDepth = 1;
   // Ara supports MaskuInsnQueueDepth = 1 only.
   localparam int unsigned MaskuInsnQueueDepth = 1;
 
@@ -104,6 +105,8 @@ package ara_pkg;
     VSLL, VSRL, VSRA, VNSRL, VNSRA,
     // Merge
     VMERGE,
+    // Scalar moves to VRF
+    VMVSX, VFMVSF,
     // Integer Reductions
     VREDSUM, VREDAND, VREDOR, VREDXOR, VREDMINU, VREDMIN, VREDMAXU, VREDMAX, VWREDSUMU, VWREDSUM,
     // Mul/Mul-Add
@@ -122,6 +125,8 @@ package ara_pkg;
     VMADC, VMSBC,
     // Mask operations
     VMANDNOT, VMAND, VMOR, VMXOR, VMORNOT, VMNAND, VMNOR, VMXNOR,
+    // Scalar moves from VRF
+    VMVXS, VFMVFS,
     // Slide instructions
     VSLIDEUP, VSLIDEDOWN,
     // Load instructions
@@ -298,9 +303,9 @@ package ara_pkg;
   // It is important that all the VFUs that can write back to the VRF
   // are grouped towards the beginning of the enumeration. The store unit
   // cannot do so, therefore it is at the end of the enumeration.
-  localparam int unsigned NrVFUs = 6;
+  localparam int unsigned NrVFUs = 7;
   typedef enum logic [$clog2(NrVFUs)-1:0] {
-    VFU_Alu, VFU_MFpu, VFU_SlideUnit, VFU_MaskUnit, VFU_LoadUnit, VFU_StoreUnit
+    VFU_Alu, VFU_MFpu, VFU_SlideUnit, VFU_MaskUnit, VFU_LoadUnit, VFU_StoreUnit, VFU_None
   } vfu_e;
 
   // Internally, each lane is treated as a processing element, between indexes

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -178,6 +178,9 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             operand_request_valid_o[MaskB] ||
             operand_request_valid_o[MaskM]);
         end
+        VFU_None : begin
+          pe_req_ready = !(operand_request_valid_o[MaskB]);
+        end
         default:;
       endcase
     end
@@ -204,7 +207,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
         vtype          : pe_req.vtype,
         default        : '0
       };
-      vfu_operation_valid_d = 1'b1;
+      vfu_operation_valid_d = (vfu_operation_d.vfu != VFU_None) ? 1'b1 : 1'b0;
 
       // Vector length calculation
       vfu_operation_d.vl = pe_req.vl / NrLanes;
@@ -226,7 +229,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
       if (lane_id_i < pe_req.vstart[idx_width(NrLanes)-1:0]) vfu_operation_d.vstart -= 1;
 
       // Mark the vector instruction as running
-      vinsn_running_d[pe_req.id] = 1'b1;
+      vinsn_running_d[pe_req.id] = (vfu_operation_d.vfu != VFU_None) ? 1'b1 : 1'b0;
 
       ////////////////////////
       //  Operand requests  //
@@ -666,6 +669,22 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             operand_request_i[MaskM].vl += 1;
           end
           operand_request_push[MaskM] = !pe_req.vm;
+        end
+        VFU_None: begin
+          operand_request_i[MaskB] = '{
+            id         : pe_req.id,
+            vs         : pe_req.vs2,
+            eew        : pe_req.eew_vs2,
+            conv       : pe_req.conversion_vs2,
+            scale_vl   : pe_req.scale_vl,
+            cvt_resize : pe_req.cvt_resize,
+            vtype      : pe_req.vtype,
+            vl         : vfu_operation_d.vl,
+            vstart     : vfu_operation_d.vstart,
+            hazard     : pe_req.hazard_vs2,
+            default    : '0
+          };
+          operand_request_push[MaskB] = 1'b1;
         end
         default:;
       endcase

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -219,6 +219,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   operand_queue #(
     .BufferDepth(1         ),
     .FPUSupport (FPUSupport),
+    .SupportIntExt2(1'b1),
+    .SupportIntExt4(1'b1),
+    .SupportIntExt8(1'b1),
     .NrLanes    (NrLanes   )
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),

--- a/hardware/src/lane/operand_requester.sv
+++ b/hardware/src/lane/operand_requester.sv
@@ -304,6 +304,9 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
               ntr_red  : operand_request_i[requester].cvt_resize,
               target_fu: operand_request_i[requester].target_fu
             };
+            // The length should be at least one after the rescaling
+            if (operand_queue_cmd_o[requester].vl == '0)
+              operand_queue_cmd_o[requester].vl = 1;
             operand_queue_cmd_valid_o[requester] = 1'b1;
 
             // Store the request
@@ -326,6 +329,9 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
               is_widening : operand_request_i[requester].cvt_resize == CVT_WIDE,
               default: '0
             };
+            // The length should be at least one after the rescaling
+            if (requester_d.len == '0)
+              requester_d.len = 1;
 
             // Mute the requisition if the vl is zero
             if (operand_request_i[requester].vl == '0) begin
@@ -387,6 +393,9 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
                   target_fu: operand_request_i[requester].target_fu
                 };
                 operand_queue_cmd_valid_o[requester] = 1'b1;
+                // The length should be at least one after the rescaling
+                if (operand_queue_cmd_o[requester].vl == '0)
+                  operand_queue_cmd_o[requester].vl = 1;
 
                 // Store the request
                 requester_d = '{
@@ -403,6 +412,9 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
                   hazard : operand_request_i[requester].hazard,
                   default: '0
                 };
+                // The length should be at least one after the rescaling
+                if (requester_d.len == '0)
+                  requester_d.len = 1;
               end
             end
           end

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -207,6 +207,9 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
             EW64: for (int b = 0; b < 1; b++) res.w64[b] = mask_i[8*b] ? opa.w64[b] : opb.w64[b];
           endcase
 
+        // Scalar move
+        VMVSX, VFMVSF: res = opa;
+
         // Comparison instructions
         VMIN, VMINU, VMAX, VMAXU,
         VREDMINU, VREDMIN, VREDMAXU, VREDMAX: unique case (vew_i)


### PR DESCRIPTION
# This PR depends on https://github.com/pulp-platform/ara/pull/129

Add support for Integer/Floating-Point scalar move instructions + related tests.

## Changelog

### Fixed

- Operand requesters should fetch at least one operand after rescaling

### Added

- Integer and Floating-Point scalar move instructions (`vmv.x.s`, `vmv.s.x`, `vmv.f.s`, `vmv.s.f`)

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [x] Code style guideline is observed