### PR TITLE
[HW] :bug: Fix reductions + Rework the VALU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix whole-register-move destination register re-encoding
  - `vslide1up` always writes the scalar element in `vd`
  - Don't trim `vslide1up` counters since it always writes the scalar element
+ - Wait for the current reduction to be over to execute the next VALU instruction, also when reduction workload is unbalanced and some lanes are only a pass-through
 
 ### Added
 


### PR DESCRIPTION
# This PR depends on https://github.com/pulp-platform/ara/pull/100

The previous mechanism to handle the commit during a reduction was confusing and led to bugs. 
Now, the reduction triggers its commit only after the inter-lanes phase is over.
Also, some recurrent lines of code have been grouped into macros

## Changelog

### Fixed

- INT Reductions trigger their commit only after finishing the inter-lanes phase.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
- [x] No frequency degradation