### PR TITLE
Hotfixes for main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix lane sequencer checks for floating-point comparisons
  - Fix synthesis error occuring due to the continuous assignmnet in the always block of mask unit
  - Fix wrong variable in `vmerge` and `vmv` `riscv-tests`
+ - Re-introduce WAIT_STATE to avoid hazards when changin LMUL
+ - Fix the PEs-ready signals related conditions in the main sequencer
 
 ### Added
 
@@ -52,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update LLVM to version `15.0.0` (RVV 1.0)
 - Update Spike to version `1.1.1-dev` (RVV 1.0)
 - Update `newlib` from commit 84d068 to 5192d5
+- Ara's dispatcher goes to WAIT_STATE only when the new LMUL is lower than the old one
 
 ## 2.2.0 - 2021-11-02
 

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -424,8 +424,8 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
         pe_req_d       = pe_req_o;
         pe_req_valid_d = pe_req_valid_o;
 
-        // Consume the request if acknowledged
-        if (pe_req_valid_o && pe_req_ready_i)
+        // Consume the request if acknowledged during a scalar move
+        if (pe_req_valid_o && &operand_requester_ready)
           pe_req_valid_d = 1'b0;
 
         // Wait for the address translation
@@ -502,7 +502,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     if (|pe_resp_i[NrLanes+OffsetMask].vinsn_done)
       running_mask_insn_d = 1'b0;
 
-    if (pe_req_valid_o && pe_req_ready_i && pe_req_o.vfu == VFU_MaskUnit)
+    if (pe_req_valid_o && &operand_requester_ready && pe_req_o.vfu == VFU_MaskUnit)
       running_mask_insn_d = 1'b1;
   end
 


### PR DESCRIPTION
The last PR introduced two bugs. The CI had problems this week, and the bugs remained unnoticed. 
They are solved with this PR.

## Changelog

### Fixed

 - Re-introduce `WAIT_STATE` to avoid hazards when changing `LMUL`
 - Fix the PEs-ready signals related conditions in the main sequencer

### Changed

- Ara's dispatcher goes to `WAIT_STATE` only when the new `LMUL` is lower than the old one

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
