### PR TITLE
Hotfix for misaligned memory ops with more than 255 beats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix wrong variable in `vmerge` and `vmv` `riscv-tests`
  - Re-introduce WAIT_STATE to avoid hazards when changin LMUL
  - Fix the PEs-ready signals related conditions in the main sequencer
+ - Fix misaligned memory operations with more than 255 beats (>= 256 beats)
 
 ### Added
 

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -486,10 +486,10 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
           // the memory interface.
           aligned_start_addr_d = aligned_addr(axi_addrgen_d.addr, $clog2(AxiDataWidth/8));
           // The final address can be found similarly...
-          if (axi_addrgen_d.len << int'(axi_addrgen_d.vew) > (256 << $clog2(AxiDataWidth/8))) begin
+          if (axi_addrgen_d.len << int'(axi_addrgen_d.vew) >= (256 << $clog2(AxiDataWidth/8))) begin
             aligned_end_addr_d =
-            aligned_addr(axi_addrgen_d.addr + (256 << $clog2(AxiDataWidth/8)) - 1,
-              $clog2(AxiDataWidth/8)) + AxiDataWidth/8 - 1;
+            aligned_addr(axi_addrgen_d.addr + (256 << $clog2(AxiDataWidth/8)),
+              $clog2(AxiDataWidth/8)) - 1;
           end else begin
             aligned_end_addr_d =
             aligned_addr(axi_addrgen_d.addr + (axi_addrgen_d.len << int'(axi_addrgen_d.vew)) - 1,
@@ -508,10 +508,9 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
         // the memory interface.
         aligned_start_addr_d = aligned_addr(axi_addrgen_q.addr, eff_axi_dw_log_q);
         // The final address can be found similarly...
-        if (axi_addrgen_q.len << int'(axi_addrgen_q.vew) > (256 << eff_axi_dw_log_q)) begin
+        if (axi_addrgen_q.len << int'(axi_addrgen_q.vew) >= (256 << eff_axi_dw_log_q)) begin
           aligned_end_addr_d =
-            aligned_addr(axi_addrgen_q.addr + (256 << eff_axi_dw_log_q) - 1, eff_axi_dw_log_q)
-            + eff_axi_dw_q - 1;
+            aligned_addr(axi_addrgen_q.addr + (256 << eff_axi_dw_log_q), eff_axi_dw_log_q) - 1;
         end else begin
           aligned_end_addr_d =
             aligned_addr(axi_addrgen_q.addr + (axi_addrgen_q.len << int'(axi_addrgen_q.vew)) - 1,
@@ -613,11 +612,11 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
               aligned_start_addr_d = axi_addrgen_d.addr;
               // The final address can be found similarly.
               // How many B we requested? No more than (256 << burst_size)
-              if (axi_addrgen_d.len << int'(axi_addrgen_q.vew) > (256 << eff_axi_dw_log_q))
+              if (axi_addrgen_d.len << int'(axi_addrgen_q.vew) >= (256 << eff_axi_dw_log_q))
               begin
                 aligned_end_addr_d =
-                  aligned_addr(aligned_start_addr_d + (256 << eff_axi_dw_log_q) - 1,
-                    eff_axi_dw_log_q) + eff_axi_dw_q - 1;
+                  aligned_addr(aligned_start_addr_d + (256 << eff_axi_dw_log_q),
+                    eff_axi_dw_log_q) - 1;
               end else begin
                 aligned_end_addr_d =
                   aligned_addr(aligned_start_addr_d + (axi_addrgen_d.len << int'(axi_addrgen_q.vew))


### PR DESCRIPTION
Hotfix for `addrgen.sv`.
The `aligned_end_addr` signal should consider the misalignment by adding `AxiDataWidth/8` only at the very last burst.

## Changelog

### Fixed

- Fix misaligned memory operations with more than 255 beats (>= 256 beats)
 
## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

