### PR TITLE
[hardware] :bug: Fix Stripmining Condition in Dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Re-introduce WAIT_STATE to avoid hazards when changin LMUL
  - Fix the PEs-ready signals related conditions in the main sequencer
  - Fix misaligned memory operations with more than 255 beats (>= 256 beats)
+ - Fix stripmining condition in dispatcher
 
 ### Added
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -356,7 +356,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       vl_d = vlmax;
                     end else begin
                       // Normal stripmining
-                      vl_d = (vlen_t'(acc_req_i.rs1) > vlmax) ? vlmax : vlen_t'(acc_req_i.rs1);
+                      vl_d = ((|acc_req_i.rs1[$bits(acc_req_i.rs1)-1:$bits(vl_d)]) ||
+                        (vlen_t'(acc_req_i.rs1) > vlmax)) ? vlmax : vlen_t'(acc_req_i.rs1);
                     end
                   end
                 end


### PR DESCRIPTION
Hardware should compare the full length of the input avl wrt MAXVL. 
Do not deploy a 64-bit comparator for this, use OR gates for upper bits since quantities are unsigned.

## Changelog

### Fixed

- Fix stripmining condition in dispatcher

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
