### PR TITLE
Generic hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix stripmining condition in dispatcher
  - CVA6 tracks writes to floating-point scalar registers by the accelerator
  - Fixed de-synch bug in vector-FPU
+ - Fix masked VSLIDEUP. Use only the mask bits with index higher than the stride
+ - Fix SLDU issue_counter modification upon new VSLIDEUP incoming instruction
+ - Fix whole-register-move destination register re-encoding
 
 ### Added
 
@@ -61,6 +64,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ara's dispatcher goes to WAIT_STATE only when the new LMUL is lower than the old one
  - Halve CVA6's L1 caches to ease backend timing closure
  - Remove CVA6's cache patch from `hardware/patches` (CVA6 is now updated)
+ - Increase addrgen queue depth to four, to better hide memory latency
 
 ## 2.2.0 - 2021-11-02
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -854,8 +854,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     automatic int unsigned vlmax;
                     // Execute also if vl == 0
                     ignore_zero_vl_check = 1'b1;
-                    // Maximum vector length. VLMAX = simm[2:0] * VLEN / SEW.
-                    vlmax = VLENB;
+                    // The number of elements depends on the EEW we will consider
+                    vlmax = VLENB >> eew_q[insn.varith_type.rs2];
+                    // Rescale the maximum vector length depending on how many
+                    // registers we should copy (VLMAX = simm[2:0] * VLEN / SEW).
                     unique case (insn.varith_type.rs1[17:15])
                       3'd0 : begin
                         vlmax <<= 0;
@@ -885,8 +887,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.use_vs1       = 1'b1;
                     ara_req_d.use_vs2       = 1'b0;
                     ara_req_d.vs1           = insn.varith_type.rs2;
-                    ara_req_d.vtype.vsew    = EW8;
-                    ara_req_d.scale_vl      = 1'b1;
+                    ara_req_d.eew_vs1       = eew_q[insn.varith_type.rs2];
+                    // Copy the encoding information to the new register
+                    ara_req_d.vtype.vsew    = eew_q[insn.varith_type.rs2];
                     ara_req_d.vl            = vlmax; // whole register move
                   end
                   6'b101000: ara_req_d.op = ara_pkg::VSRL;

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -537,6 +537,11 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
               if (((operand_request_i[MaskM].vl + pe_req.stride) <<
                     int'(pe_req.vtype.vsew) * NrLanes * 8 != pe_req.vl))
                 operand_request_i[MaskM].vl += 1;
+
+              // SLIDEUP only uses mask bits whose indices are > stride
+              // Don't send the previous (unused) ones to the MASKU
+              if (pe_req.stride >= NrLanes * 64)
+                operand_request_i[MaskM].vstart += ((pe_req.stride >> NrLanes * 64) << NrLanes * 64) / 8;
             end
             VSLIDEDOWN: begin
               // Since this request goes outside of the lane, we might need to request an

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -380,9 +380,6 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
             // wide signal to please the tool
             red_stride_cnt_d_wide = {red_stride_cnt_q, red_stride_cnt_q[idx_width(NrLanes)-1]};
             red_stride_cnt_d      = red_stride_cnt_d_wide[idx_width(NrLanes)-1:0];
-            // We used all the bits of the mask
-            if (vinsn_issue_q.op == VSLIDEUP)
-              mask_ready_o = !vinsn_issue_q.vm;
           end
 
           // Filled up a word to the VRF or finished the instruction
@@ -390,7 +387,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
             // Reset the pointer
             out_pnt_d = vinsn_issue_q.vfu == VFU_Alu ? {'0, red_stride_cnt_d, 3'b0} : '0;
             // We used all the bits of the mask
-            if (vinsn_issue_q.op == VSLIDEDOWN)
+            if (vinsn_issue_q.op inside {VSLIDEUP, VSLIDEDOWN})
               mask_ready_o = !vinsn_issue_q.vm;
 
             // Increment VRF address

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -89,7 +89,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
   logic             axi_addrgen_queue_empty;
 
   fifo_v3 #(
-    .DEPTH(2                ),
+    .DEPTH(4                ),
     .dtype(addrgen_axi_req_t)
   ) i_addrgen_req_queue (
     .clk_i     (clk_i                                                    ),


### PR DESCRIPTION
Round of hotfixes for bugs noticed while implementing new kernels.

## Changelog

### Fixed

- Fix masked `VSLIDEUP`. Use only the mask bits with index higher than the stride.
- Fix `SLDU` `issue_counter` modification upon new `VSLIDEUP` incoming instruction.
- Fix whole-register-move destination re-encoding.

### Changed

- Increase addrgen queue depth to four, to better hide the memory latency.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
