### PR TITLE
[SW] Add support for SPIKE simulations of the apps programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Vector integer reductions (`vredsum`, `vredmaxu`, `vredmax`, `vredminu`, `vredmin`, `vredand`, `vredor`, `vredxor`, `vwredsumu`, `vwredsum`)
  - Introduce the global hazard table in the main sequencer, to provide up-to-date information to the operand requesters about the status of the different dependant instructions
  - Integer and Floating-Point scalar move instructions (`vmv.x.s`, `vmv.s.x`, `vmv.f.s`, `vmv.s.f`)
+ - Add support for `apps` simulation with `spike`
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ cd apps
 make bin/hello_world
 ```
 
+### SPIKE Simulation
+
+All the applications can be simulated with SPIKE. Run the following command to build and run an application. E.g., `hello_world`:
+
+```bash
+cd apps
+make bin/hello_world.spike
+make spike-run-hello_world
+```
+
 ### RISC-V Tests
 
 The `apps` folder also contains the RISC-V tests repository, including a few unit tests for the vector instructions. Run the following command to build the unit tests:

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -49,6 +49,12 @@ linker_script: $(COMMON_DIR)/script/align_sections.sh $(ROOT_DIR)/../../config/$
 $(APPS): % : bin/% $(APPS_DIR)/Makefile $(shell find common -type f)
 .PHONY: $(BINARIES)
 
+# Patch spike crt0 to enable vector extension before execution
+.PHONY: patch-spike-crt0
+patch-spike-crt0: $(spike_env_dir)/benchmarks/common/crt.S
+	sed -i s/"li t0, MSTATUS_FS | MSTATUS_XS$$"/"li t0, MSTATUS_FS | MSTATUS_XS | MSTATUS_VS"/ $<
+	git update-index --assume-unchanged $<
+
 # Only some applications need to generate and then compile the data file
 # Generate a dummy data file for applications that do not need it
 define app_gen_data_template
@@ -57,6 +63,14 @@ $1/data.S:
 	cd $1 && if [ -d script ]; then source $$(COMMON_DIR)/script/datagen.sh $1 $$(OUT_MTX_SIZE) $$(F_SIZE); else touch data.S; fi
 endef
 $(foreach app,$(APPS),$(eval $(call app_gen_data_template,$(app))))
+
+define app_compile_template_spike
+bin/$1.spike: $1/data.S.o $(addsuffix .o.spike, $(shell find $(1) -name "*.c" -o -name "*.S")) $(RUNTIME_SPIKE) $(COMMON_SPIKE)
+	mkdir -p bin/
+	$$(RISCV_CC) -Iinclude $$(RISCV_CCFLAGS_SPIKE) -o $$@ $$(addsuffix .o.spike, $$(shell find $(1) -name "*.c" -o -name "*.S")) $(RUNTIME_SPIKE) $$(RISCV_LDFLAGS_SPIKE) -DSPIKE
+	$$(RISCV_OBJDUMP) $$(RISCV_OBJDUMP_FLAGS) -D $$@ > $$@.dump
+endef
+$(foreach app,$(APPS),$(eval $(call app_compile_template_spike,$(app))))
 
 define app_compile_template
 bin/$1: $1/data.S.o $(addsuffix .o, $(shell find $(1) -name "*.c" -o -name "*.S")) $(RUNTIME_LLVM) linker_script
@@ -107,6 +121,17 @@ riscv_tests_spike:
 format:
 	$(LLVM_INSTALL_DIR)/bin/clang-format -style=file -i $$(find . | grep -E "\.[h,c,cpp]$$" | grep -v riscv-tests)
 	$(LLVM_INSTALL_DIR)/bin/clang-format -style=file -i $$(find riscv-tests/isa/rv64uv | grep -E "\.[h,c,cpp]$$")
+
+# Run benchmarks on Spike
+define run_benchmark_spike
+spike-run-$1: bin/$1.spike
+	mkdir -p spike_runs
+	@echo
+	@echo "Simulating $1 with SPIKE:"
+	@echo
+	$(RISCV_SIM) $(RISCV_SIM_OPT) $$< | tee spike_runs/$$@
+endef
+$(foreach app,$(APPS),$(eval $(call run_benchmark_spike,$(app))))
 
 # Clean Spike simulation
 .PHONY: riscv_tests_spike_clean

--- a/apps/common/runtime.h
+++ b/apps/common/runtime.h
@@ -19,11 +19,26 @@ inline int64_t get_cycle_count() {
   return cycle_count;
 };
 
+#ifndef SPIKE
 // Start and stop the counter
 inline void start_timer() { timer = -get_cycle_count(); }
 inline void stop_timer() { timer += get_cycle_count(); }
 
 // Get the value of the timer
 inline int64_t get_timer() { return timer; }
+#else
+// Start and stop the counter
+inline void start_timer() {
+  while (0)
+    ;
+}
+inline void stop_timer() {
+  while (0)
+    ;
+}
+
+// Get the value of the timer
+inline int64_t get_timer() { return 0; }
+#endif
 
 #endif // _RUNTIME_H_

--- a/apps/dropout/main.c
+++ b/apps/dropout/main.c
@@ -27,10 +27,10 @@
 #undef INTRINSICS
 
 #include "dropout.h"
+#include "runtime.h"
 
 #ifndef SPIKE
 #include "printf.h"
-#include "runtime.h"
 #endif
 
 extern const unsigned int N;

--- a/apps/fconv2d/main.c
+++ b/apps/fconv2d/main.c
@@ -21,10 +21,10 @@
 #include <string.h>
 
 #include "fconv2d.h"
+#include "runtime.h"
 
 #ifndef SPIKE
 #include "printf.h"
-#include "runtime.h"
 #endif
 
 // Define Matrix dimensions:

--- a/apps/fconv3d/main.c
+++ b/apps/fconv3d/main.c
@@ -21,10 +21,10 @@
 #include <string.h>
 
 #include "fconv3d.h"
+#include "runtime.h"
 
 #ifndef SPIKE
 #include "printf.h"
-#include "runtime.h"
 #endif
 
 // Define Matrix dimensions:

--- a/apps/fmatmul/main.c
+++ b/apps/fmatmul/main.c
@@ -18,11 +18,15 @@
 //         Samuel Riedel, ETH Zurich
 
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "kernel/fmatmul.h"
-#include "printf.h"
 #include "runtime.h"
+
+#ifndef SPIKE
+#include "printf.h"
+#endif
 
 // Define Matrix dimensions:
 // C = AB with A=[MxN], B=[NxP], C=[MxP]

--- a/apps/hello_world/main.c
+++ b/apps/hello_world/main.c
@@ -19,7 +19,12 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifndef SPIKE
 #include "printf.h"
+#else
+#include "util.h"
+#include <stdio.h>
+#endif
 
 int main() {
   printf("Ariane says Hello!\n");

--- a/apps/iconv2d/main.c
+++ b/apps/iconv2d/main.c
@@ -21,10 +21,10 @@
 #include <string.h>
 
 #include "iconv2d.h"
+#include "runtime.h"
 
 #ifndef SPIKE
 #include "printf.h"
-#include "runtime.h"
 #endif
 
 // Define Matrix dimensions:

--- a/apps/imatmul/main.c
+++ b/apps/imatmul/main.c
@@ -18,11 +18,15 @@
 //         Samuel Riedel, ETH Zurich
 
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "kernel/imatmul.h"
-#include "printf.h"
 #include "runtime.h"
+
+#ifndef SPIKE
+#include "printf.h"
+#endif
 
 // Define Matrix dimensions:
 // C = AB with A=[MxN], B=[NxP], C=[MxP]

--- a/apps/jacobi2d/main.c
+++ b/apps/jacobi2d/main.c
@@ -76,9 +76,12 @@ WITH ACCESS OR USE OF THE SOFTWARE.
 #include <stdint.h>
 #include <string.h>
 
-#include "printf.h"
 #include "riscv_vector.h"
 #include "runtime.h"
+
+#ifndef SPIKE
+#include "printf.h"
+#endif
 
 // Define vector size
 #if defined(SIMTINY)


### PR DESCRIPTION
It is now possible to simulate the benchmarks in the `apps` folder using `spike`.

To compile `${program}` against the `spike` environment:
`cd apps`
`make bin/${program}.spike`

To run `${program}` on `spike`:
`cd apps`
`make spike-run-${program}`

For convenience, you can also just `spike-run-${program}` the target. It will be automatically compiled before execution.

If you want to copy-paste the previous commands, the variable `program` should be first initialized with the name of the program to run, e.g., `program=hello_world`.

## Changelog

### Added

 - Add support for `apps` simulation with `spike`

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
