### PR TITLE
[SW, HW] Add support for ideal-dispatcher simulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,7 +474,7 @@ jobs:
     - name: Untar Verilated model of Ara
       run: tar xvf ara.tar
     - name: Benchmark Ara
-      run: config=${{ matrix.ara_config }} ./scripts/benchmark.sh
+      run: config=${{ matrix.ara_config }} ./scripts/benchmark.sh ci
     - name: Tar runtime results
       run: |
         tar -cvf benchmarks-${{ matrix.ara_config }}.tar *.benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,9 +434,13 @@ jobs:
         else
           echo "base=HEAD~1" >> $GITHUB_ENV
         fi
-
+    # Don't check the `patches` directory! Trailing whitespaces
+    # are mandatory there if they exist.
     - name: Check for trailing whitespaces and tabs
-      run: git diff --check $base HEAD --
+      run: |
+        git diff --check $base HEAD -- \
+        apps config hardware .github   \
+        *.md Bender.* Makefile
 
 #####################
 #  Benchmark stage  #

--- a/Bender.yml
+++ b/Bender.yml
@@ -67,6 +67,8 @@ sources:
         - hardware/tb/ara_testharness.sv
         # Level 2
         - hardware/tb/ara_tb.sv
+        # Level 3
+        - hardware/src/accel_dispatcher_ideal.sv
 
         - target: verilator
           files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Don't trim `vslide1up` counters since it always writes the scalar element
  - Wait for the current reduction to be over to execute the next VALU instruction, also when reduction workload is unbalanced and some lanes are only a pass-through
  - Reshuffle the source registers vs when an in-lane operation operates on element with vsew != eew_q[vs]
+ - Fix the data target for `.spike` app compilations
+ - `make -C apps clean` performs a deeper clean of the temporary object files
 
 ### Added
 
@@ -61,6 +63,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Vector floating-point divide instructions (`vfdiv`, `vfrdiv`)
  - Vector floating-point square-root instruction (`vfsqrt`)
  - Add simple test for source registers reshuffle, when VSEW != EEW_vs
+ - Add support for ideal-dispatcher simulation
+ - Add compile-time garbage-collection to strip unused functions out and decrease the memory footprint of the binary
+ - Add benchmarking capability with the ideal-dispatcher system + performance plotting. The support is limited to simluation with QuestaSim only
 
 ### Changed
 
@@ -81,6 +86,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Remove CVA6's cache patch from `hardware/patches` (CVA6 is now updated)
  - Increase addrgen queue depth to four, to better hide memory latency
  - The RESHUFFLE state is now iterative and reshuffles all the vector registers that need this operation
+ - Performance metrics are now calculated by an external performance.py script, instead of during the program simulation, which just prints out the cycle count
 
 ## 2.2.0 - 2021-11-02
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LLVM_INSTALL_DIR        ?= ${INSTALL_DIR}/riscv-llvm
 ISA_SIM_INSTALL_DIR     ?= ${INSTALL_DIR}/riscv-isa-sim
 ISA_SIM_MOD_INSTALL_DIR ?= ${INSTALL_DIR}/riscv-isa-sim-mod
 VERIL_INSTALL_DIR       ?= ${INSTALL_DIR}/verilator
-VERIL_VERSION           ?= v4.214
+VERIL_VERSION           ?= v4.226
 
 CMAKE ?= cmake
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,30 @@ Alternatively, you can also use the `riscv_tests` target at Ara's top-level Make
 Add `trace=1` to the `verilate`, `simv`, and `riscv_tests_simv` commands to generate waveform traces in the `fst` format.
 You can use `gtkwave` to open such waveforms.
 
+### Ideal Dispatcher mode
+
+CVA6 can be replaced by an ideal FIFO that dispatches the vector instructions to Ara with the maximum issue-rate possible.
+In this mode, only Ara and its memory system affect performance.
+This mode has some limitations:
+ - The dispatcher is a simple FIFO. Ara and the dispatcher cannot have complex interactions.
+ - Therefore, the vector program should be fire-and-forget. There cannot be runtime dependencies from the vector to the scalar code.
+ - Not all the vector instructions are supported, e.g., the ones that use the `rs2` register.
+
+To compile a program and generate its vector trace:
+
+```bash
+cd apps
+make bin/${program}.ideal
+```
+
+This command will generate the `ideal` binary to be loaded in the L2 memory for the simulation (data accessed by the vector code).
+To run the system in Ideal Dispatcher mode:
+
+```bash
+cd hardware
+make sim app=${program} ideal_dispatcher=1
+```
+
 ## Publication
 
 If you want to use Ara, you can cite us:

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -64,6 +64,21 @@ $1/data.S:
 endef
 $(foreach app,$(APPS),$(eval $(call app_gen_data_template,$(app))))
 
+define vector_trace_template
+ideal_dispatcher/vtrace/$1.vtrace: bin/$1.spike $(VTRACE_SCRIPTS)
+	mkdir -p ideal_dispatcher/vtrace ideal_dispatcher/log ideal_dispatcher/temp
+	echo "run" | $(RISCV_SIM_MOD) $(RISCV_SIM_MOD_OPT) $$< 2> ideal_dispatcher/temp/$1.temp 1> ideal_dispatcher/log/$1.log
+	cd ideal_dispatcher && scripts/vtrace.sh temp/$1.temp vtrace/$1.vtrace
+endef
+$(foreach app,$(APPS),$(eval $(call vector_trace_template,$(app))))
+
+define app_compile_template_ideal
+bin/$1.ideal: bin/$1.spike ideal_dispatcher/vtrace/$1.vtrace
+	mkdir -p bin/
+	cp bin/$1.spike bin/$1.ideal
+endef
+$(foreach app,$(APPS),$(eval $(call app_compile_template_ideal,$(app))))
+
 define app_compile_template_spike
 bin/$1.spike: $1/data.S.o $(addsuffix .o.spike, $(shell find $(1) -name "*.c" -o -name "*.S")) $(RUNTIME_SPIKE) $(COMMON_SPIKE)
 	mkdir -p bin/

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -80,7 +80,7 @@ endef
 $(foreach app,$(APPS),$(eval $(call app_compile_template_ideal,$(app))))
 
 define app_compile_template_spike
-bin/$1.spike: $1/data.S.o $(addsuffix .o.spike, $(shell find $(1) -name "*.c" -o -name "*.S")) $(RUNTIME_SPIKE) $(COMMON_SPIKE)
+bin/$1.spike: $1/data.S.o.spike $(addsuffix .o.spike, $(shell find $(1) -name "*.c" -o -name "*.S")) $(RUNTIME_SPIKE) $(COMMON_SPIKE)
 	mkdir -p bin/
 	$$(RISCV_CC) -Iinclude $$(RISCV_CCFLAGS_SPIKE) -o $$@ $$(addsuffix .o.spike, $$(shell find $(1) -name "*.c" -o -name "*.S")) $(RUNTIME_SPIKE) $$(RISCV_LDFLAGS_SPIKE) -DSPIKE
 	$$(RISCV_OBJDUMP) $$(RISCV_OBJDUMP_FLAGS) -D $$@ > $$@.dump
@@ -153,8 +153,15 @@ $(foreach app,$(APPS),$(eval $(call run_benchmark_spike,$(app))))
 riscv_tests_spike_clean:
 	make -C riscv-tests/isa clean
 
+.PHONY: benchmarks_clean
+benchmarks_clean:
+	cd $(APPS_DIR)/benchmarks && \
+	rm -vf *.S.* *.c.*        && \
+	rm -vf data/*.S.*         && \
+	rm -vf kernel/*.c.*
+
 .PHONY: clean
-clean: riscv_tests_spike_clean
+clean: riscv_tests_spike_clean benchmarks_clean
 	rm -vf $(BINARIES)
 	rm -vf $(CVA6_BINARIES)
 	rm -vf $(ARA_BINARIES)
@@ -164,6 +171,7 @@ clean: riscv_tests_spike_clean
 	rm -vf $(addsuffix /main.c.o,$(APPS))
 	rm -vf $(RUNTIME_GCC)
 	rm -vf $(RUNTIME_LLVM)
-	for app in $(APPS); do cd $${app} && rm -f ./*.c.o && rm -f ./*.S* && cd .. ; done
+	rm -vf $(RUNTIME_SPIKE)
+	for app in $(APPS); do cd $(APPS_DIR)/$${app} && rm -f ./*.c.o* && rm -f ./*.S* && cd .. ; done
 
 .INTERMEDIATE: $(addsuffix /main.c.o,$(APPS))

--- a/apps/benchmarks/benchmark/fconv2d.bmark
+++ b/apps/benchmarks/benchmark/fconv2d.bmark
@@ -49,7 +49,7 @@ int main() {
 
   int64_t runtime = get_timer();
   float performance = 2.0 * F * F * M * N / (runtime);
-  printf("[performance]: %d %f\n", M, performance);
+  printf("[cycles]: %ld\n", runtime);
 
   return 0;
 }

--- a/apps/benchmarks/benchmark/fconv3d.bmark
+++ b/apps/benchmarks/benchmark/fconv3d.bmark
@@ -48,7 +48,7 @@ int main() {
 
   int64_t runtime = get_timer();
   float performance = 2.0 * 3.0 * F * F * M * N / (runtime);
-  printf("[performance]: %ld %f\n", M, performance);
+  printf("[cycles]: %ld\n", runtime);
 
   return 0;
 }

--- a/apps/benchmarks/benchmark/fmatmul.bmark
+++ b/apps/benchmarks/benchmark/fmatmul.bmark
@@ -43,7 +43,7 @@ int main() {
 
   int64_t runtime = get_timer();
   float performance = 2.0 * SIZE * SIZE * SIZE / runtime;
-  printf("[performance]: %d %f\n", SIZE, performance);
+  printf("[cycles]: %ld\n", runtime);
 
   return 0;
 }

--- a/apps/benchmarks/benchmark/iconv2d.bmark
+++ b/apps/benchmarks/benchmark/iconv2d.bmark
@@ -51,7 +51,7 @@ int main() {
 
   int64_t runtime = get_timer();
   float performance = 2.0 * F * F * M * N / (runtime);
-  printf("[performance]: %d %f\n", M, performance);
+  printf("[cycles]: %ld\n", runtime);
 
   return 0;
 }

--- a/apps/benchmarks/benchmark/imatmul.bmark
+++ b/apps/benchmarks/benchmark/imatmul.bmark
@@ -43,7 +43,7 @@ int main() {
 
   int64_t runtime = get_timer();
   float performance = 2.0 * SIZE * SIZE * SIZE / runtime;
-  printf("[performance]: %d %f\n", SIZE, performance);
+  printf("[cycles]: %ld\n", runtime);
 
   return 0;
 }

--- a/apps/benchmarks/main.c
+++ b/apps/benchmarks/main.c
@@ -21,8 +21,11 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "printf.h"
 #include "runtime.h"
+
+#ifndef SPIKE
+#include "printf.h"
+#endif
 
 #if defined(IMATMUL)
 #include "benchmark/imatmul.bmark"

--- a/apps/benchmarks/main.c
+++ b/apps/benchmarks/main.c
@@ -19,6 +19,7 @@
 //         Matteo Perotti, ETH Zurich
 
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "runtime.h"

--- a/apps/common/runtime.mk
+++ b/apps/common/runtime.mk
@@ -33,10 +33,11 @@ endif
 # Include configuration
 include $(ARA_DIR)/config/$(config).mk
 
-INSTALL_DIR         ?= $(ARA_DIR)/install
-GCC_INSTALL_DIR     ?= $(INSTALL_DIR)/riscv-gcc
-LLVM_INSTALL_DIR    ?= $(INSTALL_DIR)/riscv-llvm
-ISA_SIM_INSTALL_DIR ?= $(INSTALL_DIR)/riscv-isa-sim
+INSTALL_DIR             ?= $(ARA_DIR)/install
+GCC_INSTALL_DIR         ?= $(INSTALL_DIR)/riscv-gcc
+LLVM_INSTALL_DIR        ?= $(INSTALL_DIR)/riscv-llvm
+ISA_SIM_INSTALL_DIR     ?= $(INSTALL_DIR)/riscv-isa-sim
+ISA_SIM_MOD_INSTALL_DIR ?= $(INSTALL_DIR)/riscv-isa-sim-mod
 
 RISCV_XLEN    ?= 64
 RISCV_ARCH    ?= rv$(RISCV_XLEN)gcv
@@ -63,7 +64,9 @@ SPIKE_INC     ?= -I$(spike_env_dir)/env -I$(spike_env_dir)/benchmarks/common
 SPIKE_CCFLAGS ?= -DPREALLOCATE=1 -DSPIKE=1 $(SPIKE_INC)
 SPIKE_LDFLAGS ?= -nostdlib -T$(spike_env_dir)/benchmarks/common/test.ld
 RISCV_SIM     ?= $(ISA_SIM_INSTALL_DIR)/bin/spike
+RISCV_SIM_MOD ?= $(ISA_SIM_MOD_INSTALL_DIR)/bin/spike
 RISCV_SIM_OPT ?= --isa=rv64gcv_zfh --varch="vlen:4096,elen:64"
+RISCV_SIM_MOD_OPT ?= --isa=rv64gcv_zfh --varch="vlen:4096,elen:64" -d
 
 # Defines
 ENV_DEFINES ?=

--- a/apps/common/runtime.mk
+++ b/apps/common/runtime.mk
@@ -79,11 +79,11 @@ RISCV_WARNINGS += -Wunused-variable -Wall -Wextra -Wno-unused-command-line-argum
 # LLVM Flags
 LLVM_FLAGS     ?= -march=rv64gcv_zfh_zvfh0p1 -menable-experimental-extensions -mabi=$(RISCV_ABI) -mno-relax -fuse-ld=lld
 RISCV_FLAGS    ?= $(LLVM_FLAGS) -mcmodel=medany -I$(CURDIR)/common -std=gnu99 -O3 -ffast-math -fno-common -fno-builtin-printf $(DEFINES) $(RISCV_WARNINGS)
-RISCV_CCFLAGS  ?= $(RISCV_FLAGS)
-RISCV_CCFLAGS_SPIKE  ?= $(RISCV_FLAGS) $(SPIKE_CCFLAGS)
-RISCV_CXXFLAGS ?= $(RISCV_FLAGS)
-RISCV_LDFLAGS  ?= -static -nostartfiles -lm
-RISCV_LDFLAGS_SPIKE  ?= $(RISCV_LDFLAGS) $(SPIKE_LDFLAGS)
+RISCV_CCFLAGS  ?= $(RISCV_FLAGS) -ffunction-sections -fdata-sections
+RISCV_CCFLAGS_SPIKE  ?= $(RISCV_FLAGS) $(SPIKE_CCFLAGS) -ffunction-sections -fdata-sections
+RISCV_CXXFLAGS ?= $(RISCV_FLAGS) -ffunction-sections -fdata-sections
+RISCV_LDFLAGS  ?= -static -nostartfiles -lm -Wl,--gc-sections
+RISCV_LDFLAGS_SPIKE  ?= $(RISCV_LDFLAGS) $(SPIKE_LDFLAGS) -Wl,--gc-sections
 
 # GCC Flags
 RISCV_FLAGS_GCC    ?= -mcmodel=medany -march=$(RISCV_ARCH) -mabi=$(RISCV_ABI) -I$(CURDIR)/common -static -std=gnu99 -O3 -ffast-math -fno-common -fno-builtin-printf $(DEFINES) $(RISCV_WARNINGS)

--- a/apps/ideal_dispatcher/scripts/dump_vtrace.py
+++ b/apps/ideal_dispatcher/scripts/dump_vtrace.py
@@ -157,5 +157,5 @@ with open(infile, "r") as fin, open(outfile, "w") as fout:
       for reg in frf:
         if (reg in insn['regs']):
           insn['vals'] = "{}".format(frf[reg])
-    insn_out = ' '
+    insn_out = ''
     fout.write(insn_out.join([insn['asm'], insn['vals'], addRs2(insn['name'], insn['regs'])]) + '\n')

--- a/apps/ideal_dispatcher/scripts/dump_vtrace.py
+++ b/apps/ideal_dispatcher/scripts/dump_vtrace.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright 2020 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+# Decode the vector instructions replacing the register names with their actual values
+
+import sys
+
+infile  = sys.argv[1]
+outfile = sys.argv[2]
+
+# 32 registers, with 4 registers per row
+RegRows  = 8
+# String width of a single register in the rf, "label: value"
+RegWidth = 26
+
+xrf = {
+  'zero' : '0',
+  'ra'   : '0',
+  'sp'   : '0',
+  'gp'   : '0',
+  'tp'   : '0',
+  't0'   : '0',
+  't1'   : '0',
+  't2'   : '0',
+  's0'   : '0',
+  's1'   : '0',
+  'a0'   : '0',
+  'a1'   : '0',
+  'a2'   : '0',
+  'a3'   : '0',
+  'a4'   : '0',
+  'a5'   : '0',
+  'a6'   : '0',
+  'a7'   : '0',
+  's2'   : '0',
+  's3'   : '0',
+  's4'   : '0',
+  's5'   : '0',
+  's6'   : '0',
+  's7'   : '0',
+  's8'   : '0',
+  's9'   : '0',
+  's10'  : '0',
+  's11'  : '0',
+  't3'   : '0',
+  't4'   : '0',
+  't5'   : '0',
+  't6'   : '0'
+}
+
+frf = {
+  'ft0'  : '0',
+  'ft1'  : '0',
+  'ft2'  : '0',
+  'ft3'  : '0',
+  'ft4'  : '0',
+  'ft5'  : '0',
+  'ft6'  : '0',
+  'ft7'  : '0',
+  'fs0'  : '0',
+  'fs1'  : '0',
+  'fa0'  : '0',
+  'fa1'  : '0',
+  'fa2'  : '0',
+  'fa3'  : '0',
+  'fa4'  : '0',
+  'fa5'  : '0',
+  'fa6'  : '0',
+  'fa7'  : '0',
+  'fs2'  : '0',
+  'fs3'  : '0',
+  'fs4'  : '0',
+  'fs5'  : '0',
+  'fs6'  : '0',
+  'fs7'  : '0',
+  'fs8'  : '0',
+  'fs9'  : '0',
+  'fs10' : '0',
+  'fs11' : '0',
+  'ft8'  : '0',
+  'ft9'  : '0',
+  'ft10' : '0',
+  'ft11' : '0'
+}
+
+insn_pattern = "core"
+
+insn = {
+  'asm'  : '',
+  'name' : '',
+  'regs' : '',
+  'vals' : ''
+}
+
+def updateRf(regline, reg_width, rf):
+  # Divide the four registers in list elements
+  reg_list = [regline[idx : idx + reg_width] for idx in range(0, len(regline), reg_width)]
+  # Divide each label from the reg value
+  reg_list = [string.replace('0x', '').replace(':', '').split() for string in reg_list[:-1]]
+  # Update the regstate and return
+  for reg in reg_list:
+    rf[reg[0]] = reg[1]
+  return rf
+
+# Some vector instructions require an rs2 value to be passed along
+# vsetvl, strided mem ops (vtype, stride)
+def addRs2(disasm, args):
+  rs2 = ''
+  if (disasm == 'vsetvl'):
+    #rs2 =
+    print('ERROR: vsetvl found, implement addRs2 function!')
+  if ('vlse' in disasm or 'vsse' in disasm):
+    #rs2 =
+    print('ERROR: vlse or vsse found, implement addRs2 function!')
+  return rs2
+
+# If an instruction needs a register value, fetch it from the next XRF/FRF state
+with open(infile, "r") as fin, open(outfile, "w") as fout:
+  # Read all the lines
+  for line in fin:
+    # Look for instructions
+    if (insn_pattern in line):
+      # Remove brackets
+      insn['asm']  = line.split()[3][3:-1]
+      insn['name'] = line.split()[4]
+      insn['regs'] = [elm.replace(',', '').replace('(', '').replace(')', '') for elm in line.split()[5:]]
+      # Update the internal state
+      stateline = ''
+      # Upadte xrf
+      for row in range(RegRows):
+        regline = fin.readline()
+        xrf = updateRf(regline, RegWidth, xrf)
+      # Update frf
+      for row in range(RegRows):
+        regline = fin.readline()
+        frf = updateRf(regline, RegWidth, frf)
+      # Fetch the values to be forwarded to Ara
+      for reg in xrf:
+        if (reg in insn['regs']):
+          insn['vals'] = "{}".format(xrf[reg])
+      for reg in frf:
+        if (reg in insn['regs']):
+          insn['vals'] = "{}".format(frf[reg])
+    insn_out = ' '
+    fout.write(insn_out.join([insn['asm'], insn['vals'], addRs2(insn['name'], insn['regs'])]) + '\n')

--- a/apps/ideal_dispatcher/scripts/filter_vtrace.sh
+++ b/apps/ideal_dispatcher/scripts/filter_vtrace.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright 2020 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+# Check if the SPIKE log contains only expected strings
+check_log() {
+  # Super simple check. It can give false negatives
+  if grep -v "0x" $1 >/dev/null; then echo "The SPIKE log was not clean."; fi
+}
+
+# Filter out scalar instructions and simple trash from SPIKE log with intermixed scalar and vector instructions
+filter_vec() {
+  grep "0x" $1 | grep -v ";" | grep -v "core\s\+0.*) [^v]" > $2
+}
+
+# Main function
+main() {
+  # Check if the log is clean
+  check_log $1
+  # Filter out scalar instructions
+  filter_vec $1 $2
+}
+
+# Call main
+main $1 $2

--- a/apps/ideal_dispatcher/scripts/vtrace.sh
+++ b/apps/ideal_dispatcher/scripts/vtrace.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2020 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+# This script should be executed from the output directory
+temp=$1
+vtrace=$2
+
+# Filter trash and scalar insn
+./scripts/filter_vtrace.sh $temp $temp.filtered
+# Create the content for the perfect dispatcher
+python3 ./scripts/dump_vtrace.py $temp.filtered $vtrace

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -61,7 +61,7 @@ vtrace_path    ?= $(abspath $(ROOT_DIR)/../apps/ideal_dispatcher/vtrace)
 ideal          ?=
 ifeq ($(ideal_dispatcher), 1)
   vtrace       = $(vtrace_path)/$(app).vtrace
-  bender_defs += --define IDEAL_DISPATCHER=1 --define VTRACE="$(vtrace)"
+  bender_defs += --define IDEAL_DISPATCHER=1 --define VTRACE="$(vtrace)" --define N_VINSN=$(shell wc -l $(vtrace) | cut -d " " -f 1)
   ideal        = "_ideal"
 endif
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -55,6 +55,15 @@ questa_cmd     ?= questa-$(questa_version)
 questa_args    ?=
 # Path to the binaries
 app_path       ?= $(abspath $(ROOT_DIR)/../apps/bin)
+# Path to ideal dispatcher vtraces
+vtrace_path    ?= $(abspath $(ROOT_DIR)/../apps/ideal_dispatcher/vtrace)
+
+ideal          ?=
+ifeq ($(ideal_dispatcher), 1)
+  vtrace       = $(vtrace_path)/$(app).vtrace
+  bender_defs += --define IDEAL_DISPATCHER=1 --define VTRACE="$(vtrace)"
+  ideal        = "_ideal"
+endif
 
 # Check if the specified QuestaSim version exists
 ifeq (, $(shell which $(questa_cmd)))
@@ -65,7 +74,11 @@ endif
 
 questa_args += +UVM_NO_RELNOTES
 ifdef app
+ifeq ($(ideal_dispatcher), 1)
+	preload ?= "$(app_path)/$(app).ideal"
+else
 	preload ?= "$(app_path)/$(app)"
+endif
 endif
 ifdef preload
 	questa_args += +PRELOAD=$(preload)
@@ -120,7 +133,7 @@ $(buildpath)/compile_$(config).tcl: $(config_file) Makefile ../Bender.yml $(shel
 .PHONY: sim
 sim: compile
 	cd $(buildpath) && \
-	$(questa_cmd) vsim $(questa_args) $(library).$(top_level) -do ../scripts/run.tcl
+	$(questa_cmd) vsim $(questa_args) $(library).$(top_level) -do ../scripts/run$(ideal).tcl
 	./scripts/return_status.sh $(buildpath)/transcript
 
 .PHONY: simc

--- a/hardware/scripts/run_ideal.tcl
+++ b/hardware/scripts/run_ideal.tcl
@@ -1,0 +1,9 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+
+do ../scripts/wave_ideal.tcl
+log -r /*
+run -a

--- a/hardware/scripts/wave_ara_ideal.tcl
+++ b/hardware/scripts/wave_ara_ideal.tcl
@@ -1,0 +1,24 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+
+add wave -noupdate -group Ara -group core /ara_tb/dut/i_ara_soc/i_system/i_ara/*
+
+add wave -noupdate -group Ara -group dispatcher /ara_tb/dut/i_ara_soc/i_system/i_ara/i_dispatcher/*
+add wave -noupdate -group Ara -group sequencer /ara_tb/dut/i_ara_soc/i_system/i_ara/i_sequencer/*
+
+# Add waves from all the lanes
+for {set lane 0}  {$lane < [examine -radix dec ara_tb.NrLanes]} {incr lane} {
+    do ../scripts/wave_lane_ideal.tcl $lane
+}
+
+add wave -noupdate -group Ara -group masku /ara_tb/dut/i_ara_soc/i_system/i_ara/i_masku/*
+
+add wave -noupdate -group Ara -group sldu /ara_tb/dut/i_ara_soc/i_system/i_ara/i_sldu/*
+
+add wave -noupdate -group Ara -group vlsu -group addrgen /ara_tb/dut/i_ara_soc/i_system/i_ara/i_vlsu/i_addrgen/*
+add wave -noupdate -group Ara -group vlsu -group vldu /ara_tb/dut/i_ara_soc/i_system/i_ara/i_vlsu/i_vldu/*
+add wave -noupdate -group Ara -group vlsu -group vstu /ara_tb/dut/i_ara_soc/i_system/i_ara/i_vlsu/i_vstu/*
+add wave -noupdate -group Ara -group vlsu /ara_tb/dut/i_ara_soc/i_system/i_ara/i_vlsu/*

--- a/hardware/scripts/wave_ideal.tcl
+++ b/hardware/scripts/wave_ideal.tcl
@@ -1,0 +1,11 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+
+onerror {resume}
+quietly WaveActivateNextPane {} 0
+
+# Add Ara's waveforms
+do ../scripts/wave_ara_ideal.tcl

--- a/hardware/scripts/wave_lane_ideal.tcl
+++ b/hardware/scripts/wave_lane_ideal.tcl
@@ -1,0 +1,40 @@
+# Copyright 2021 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+
+add wave -noupdate -group Ara -group Lane[$1] -group sequencer /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_lane_sequencer/*
+
+add wave -noupdate -group Ara -group Lane[$1] -group operand_requester /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_requester/*
+for {set requester 0}  {$requester < [examine -radix dec ara_pkg::NrOperandQueues]} {incr requester} {
+    add wave -noupdate -group Ara -group Lane[$1] -group operand_requester -group requester[$requester] /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_requester/gen_operand_requester[$requester]/*
+}
+
+add wave -noupdate -group Ara -group Lane[$1] -group vector_regfile /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vrf/*
+
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group alu_a /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_alu_a/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group alu_b /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_alu_b/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_a /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_a/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_b /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_b/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_c /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_c/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mfpu_c /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mfpu_c/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group st_mask_a /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_st_mask_a/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group slide_addrgen_a /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_slide_addrgen_a/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mask_b /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mask_b/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues -group mask_m /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/i_operand_queue_mask_m/*
+add wave -noupdate -group Ara -group Lane[$1] -group operand_queues /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_operand_queues/*
+
+add wave -noupdate -group Ara -group Lane[$1] -group valu -group simd_alu /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_valu/i_simd_alu/*
+add wave -noupdate -group Ara -group Lane[$1] -group valu /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_valu/*
+
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew64 /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew64/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew32 /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew32/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew16 /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew16/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vmul_ew8 /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_mul_ew8/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vdiv /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_div/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group simd_vdiv -group serdiv /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/i_simd_div/i_serdiv/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu -group fpnew /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/fpu_gen/i_fpnew_bulk/*
+add wave -noupdate -group Ara -group Lane[$1] -group vmfpu /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/i_vfus/i_vmfpu/*
+
+add wave -noupdate -group Ara -group Lane[$1] /ara_tb/dut/i_ara_soc/i_system/i_ara/gen_lanes[$1]/i_lane/*

--- a/hardware/src/accel_dispatcher_ideal.sv
+++ b/hardware/src/accel_dispatcher_ideal.sv
@@ -1,0 +1,72 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+// Description:
+// Perfect dispatcher to Ara: load instructions from an external file
+//
+// Note: the module does not support answers from Ara,
+// it is just a blind dispatcher
+
+`define STRINGIFY(x) `"x`"
+`ifndef VTRACE
+`define VTRACE ./
+`endif
+
+module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; (
+  input logic                     clk_i,
+  inout logic                     rst_ni,
+  // Accelerator interaface
+  output accelerator_req_t  acc_req_o,
+  output logic              acc_req_valid_o,
+  input  logic              acc_req_ready_i,
+  input  accelerator_resp_t acc_resp_i,
+  input  logic              acc_resp_valid_i,
+  output logic              acc_resp_ready_o
+);
+
+  localparam string vtrace = `STRINGIFY(`VTRACE);
+
+  // Reading process
+  initial begin
+    int fd;
+    int status;
+
+    riscv::instruction_t insn;
+    riscv::xlen_t        rs1, rs2;
+
+    acc_req_o = '0;
+    acc_req_valid_o = 1'b0;
+
+    // Flush the answer
+	acc_resp_ready_o = 1'b1;
+
+    acc_req_o     = '0;
+    acc_req_o.frm = fpnew_pkg::RNE;
+
+    fd = $fopen(vtrace, "r");
+    if (!fd) $display("Error: vector instructions list did not open correctly.");
+
+    @(posedge rst_ni);
+    @(negedge clk_i);
+
+    while ($fscanf(fd, "%h %h", insn, rs1) == 2) begin
+      // Always valid
+      acc_req_valid_o = 1'b1;
+      acc_req_o.insn  = insn;
+      acc_req_o.rs1   = rs1;
+      //acc_req_o.rs2   = rs2;
+      // Wait for the handshake
+      wait(acc_req_ready_i);
+      @(posedge clk_i);
+      @(negedge clk_i);
+    end
+
+    // Stop dispatching
+    acc_req_valid_o = 1'b0;
+
+    $fclose(fd);
+  end
+
+endmodule

--- a/hardware/src/accel_dispatcher_ideal.sv
+++ b/hardware/src/accel_dispatcher_ideal.sv
@@ -14,9 +14,15 @@
 `define VTRACE ./
 `endif
 
+// Dummy definition not to throw errors during compilation
+// If N_VINSN is not defined, this file will not be used anyway
+`ifndef N_VINSN
+`define N_VINSN 1
+`endif
+
 module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; (
   input logic                     clk_i,
-  inout logic                     rst_ni,
+  input logic                     rst_ni,
   // Accelerator interaface
   output accelerator_req_t  acc_req_o,
   output logic              acc_req_valid_o,
@@ -28,13 +34,128 @@ module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; (
 
   localparam string vtrace = `STRINGIFY(`VTRACE);
 
-  // Reading process
-  initial begin
+  //////////
+  // Data //
+  //////////
+
+  // Width and number of vector instructions in the ideal dispatcher
+  localparam integer unsigned DATA_WIDTH  = 32 + 64; // vinsn + scalar reg
+  localparam integer unsigned N_VINSN   = `N_VINSN;
+
+  typedef struct packed {
+    riscv::instruction_t insn;
+    riscv::xlen_t rs1;
+  } fifo_payload_t;
+
+  logic [DATA_WIDTH-1:0] fifo_data_raw;
+  fifo_payload_t fifo_data;
+
+  // FIFO-like structure with no reset
+  // Instantiated here without hierarchy to please questasim
+
+  // FIFO read pointer
+  logic [$clog2(N_VINSN):0] read_pointer_n, read_pointer_q;
+  // FIFO counter
+  logic [$clog2(N_VINSN):0] status_cnt_n, status_cnt_q;
+  // FIFO
+  logic [DATA_WIDTH-1:0] fifo_q [N_VINSN];
+  logic fifo_empty;
+
+  // read and write queue logic
+  always_comb begin : read_write_comb
+    // Default assignment
+    read_pointer_n = read_pointer_q;
+    status_cnt_n   = status_cnt_q;
+    fifo_data_raw  = fifo_q[read_pointer_q];
+
+    if (acc_req_ready_i && ~fifo_empty) begin
+      // read from the queue is a default assignment
+      // but increment the read pointer...
+      if (read_pointer_n == N_VINSN - 1)
+        read_pointer_n = '0;
+      else
+        read_pointer_n = read_pointer_q + 1;
+      // ... and decrement the overall count
+      status_cnt_n = status_cnt_q - 1;
+    end
+  end
+
+  // sequential process
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      read_pointer_q  <= '0;
+      status_cnt_q    <= N_VINSN;
+    end else begin
+      read_pointer_q  <= read_pointer_n;
+      status_cnt_q    <= status_cnt_n;
+    end
+  end
+
+  assign fifo_empty = (status_cnt_q == 0);
+
+  // Always valid until empty
+  assign acc_req_valid_o = ~fifo_empty;
+  // Flush the answer
+  assign acc_resp_ready_o = 1'b1;
+  // Output assignment
+  assign fifo_data = fifo_payload_t'(fifo_data_raw);
+  assign acc_req_o = '{
+    insn    : fifo_data.insn,
+    rs1     : fifo_data.rs1,
+    default : '0
+  };
+
+  // Initialize the perfect dispatcher
+  initial $readmemh(vtrace, fifo_q);
+
+  /////////////
+  // Control //
+  /////////////
+
+  // Ideal performance counter
+  logic [63:0] perf_cnt_d, perf_cnt_q;
+  // Useful if the reset is not asserted exactly when the simulation starts
+  logic was_reset = 0;
+
+  // Reset the counter and then always count-up until the end
+  assign perf_cnt_d = rst_ni ? perf_cnt_q + 1 : '0;
+  always_ff @(posedge clk_i, negedge rst_ni) begin : p_perf_cnt_ideal
+    if (!rst_ni) begin
+      perf_cnt_q  <= '0;
+      was_reset   <= 1'b1;
+	end else begin
+      perf_cnt_q  <= perf_cnt_d;
+    end
+  end
+
+  // Stop the computation when the instructions are over and ara has returned idle
+  // Just check that we are after reset
+  always_ff @(posedge clk_i) begin
+    if (rst_ni && was_reset && !acc_req_valid_o && i_system.i_ara.ara_idle) begin
+      $display("[cycles]: %d", int'(perf_cnt_q));
+      $info("Core Test ", $sformatf("*** SUCCESS *** (tohost = %0d)", 0));
+      $finish(0);
+    end
+  end
+endmodule
+
+// The following is another definition of the module, possibly more flexible
+// but not compatible with Verilator
+/*
+  //////////
+  // Data //
+  //////////
+
+    // Reading process
+    initial begin
     int fd;
     int status;
 
-    riscv::instruction_t insn;
-    riscv::xlen_t        rs1, rs2;
+    typedef struct packed {
+      riscv::instruction_t insn;
+      riscv::xlen_t rs1;
+    } fifo_payload_t;
+    fifo_payload_t payload;
 
     acc_req_o = '0;
     acc_req_valid_o = 1'b0;
@@ -51,12 +172,11 @@ module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; (
     @(posedge rst_ni);
     @(negedge clk_i);
 
-    while ($fscanf(fd, "%h %h", insn, rs1) == 2) begin
+    while ($fscanf(fd, "%h", payload) == 1) begin
       // Always valid
       acc_req_valid_o = 1'b1;
-      acc_req_o.insn  = insn;
-      acc_req_o.rs1   = rs1;
-      //acc_req_o.rs2   = rs2;
+      acc_req_o.insn  = payload.insn;
+      acc_req_o.rs1   = payload.rs1;
       // Wait for the handshake
       wait(acc_req_ready_i);
       @(posedge clk_i);
@@ -69,4 +189,36 @@ module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; (
     $fclose(fd);
   end
 
-endmodule
+  /////////////
+  // Control //
+  /////////////
+
+  // Ideal performance counter
+  logic [63:0] perf_cnt_d, perf_cnt_q;
+
+  initial begin
+    $display("Ideal performance counter is initialized.");
+    perf_cnt_d = '0;
+    // Start the counter when the first instruction is dispatched
+    @(posedge i_system.acc_req_valid);
+    $display("Start counting...");
+    // Loop until the last instruction is dispatched and until ara is idle again
+    while (i_system.acc_req_valid || !i_system.i_ara.ara_idle) begin
+	  perf_cnt_d = perf_cnt_q + 1;
+      @(negedge clk_i);
+	end
+    $display("Stop counting.");
+    perf_cnt_d = perf_cnt_q;
+    $display("[cycles]: %d", int'(perf_cnt_q));
+    $info("Core Test ", $sformatf("*** SUCCESS *** (tohost = %0d)", 0));
+    $finish(0);
+  end
+
+  always_ff @(posedge clk_i, negedge rst_ni) begin : p_perf_cnt_ideal
+    if (!rst_ni) begin
+      perf_cnt_q <= '0;
+	end else begin
+      perf_cnt_q <= perf_cnt_d;
+    end
+  end
+ */

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -497,7 +497,7 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     @(i_system.i_ara.ara_idle);
     $display("Stop counting.");
     perf_cnt_d = perf_cnt_q;
-    $display("The cycle count is: %d", int'(perf_cnt_q));
+    $display("[cycles]: %d", int'(perf_cnt_q));
 
     $finish;
   end

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -478,39 +478,6 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     .axi_resp_i   (system_axi_resp  )
   );
 
-`ifdef IDEAL_DISPATCHER
-  // Ideal performance counter
-  logic [63:0] perf_cnt_d, perf_cnt_q;
-
-  initial begin
-    $display("Ideal performance counter is initialized.");
-    perf_cnt_d = '0;
-    // Start the counter when the first instruction is dispatched
-    @(posedge i_system.acc_req_valid);
-    $display("Start counting...");
-    // Loop until the last instruction is dispatched
-    while (i_system.acc_req_valid) begin
-	  perf_cnt_d = perf_cnt_q + 1;
-      @(negedge clk_i);
-	end
-    // Stop the timer when the last instruction is executed
-    @(i_system.i_ara.ara_idle);
-    $display("Stop counting.");
-    perf_cnt_d = perf_cnt_q;
-    $display("[cycles]: %d", int'(perf_cnt_q));
-
-    $finish;
-  end
-
-  always_ff @(posedge clk_i, negedge rst_ni) begin : p_perf_cnt_ideal
-    if (!rst_ni) begin
-      perf_cnt_q <= '0;
-	end else begin
-      perf_cnt_q <= perf_cnt_d;
-    end
-  end
-`endif
-
   //////////////////
   //  Assertions  //
   //////////////////

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -478,6 +478,39 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     .axi_resp_i   (system_axi_resp  )
   );
 
+`ifdef IDEAL_DISPATCHER
+  // Ideal performance counter
+  logic [63:0] perf_cnt_d, perf_cnt_q;
+
+  initial begin
+    $display("Ideal performance counter is initialized.");
+    perf_cnt_d = '0;
+    // Start the counter when the first instruction is dispatched
+    @(posedge i_system.acc_req_valid);
+    $display("Start counting...");
+    // Loop until the last instruction is dispatched
+    while (i_system.acc_req_valid) begin
+	  perf_cnt_d = perf_cnt_q + 1;
+      @(negedge clk_i);
+	end
+    // Stop the timer when the last instruction is executed
+    @(i_system.i_ara.ara_idle);
+    $display("Stop counting.");
+    perf_cnt_d = perf_cnt_q;
+    $display("The cycle count is: %d", int'(perf_cnt_q));
+
+    $finish;
+  end
+
+  always_ff @(posedge clk_i, negedge rst_ni) begin : p_perf_cnt_ideal
+    if (!rst_ni) begin
+      perf_cnt_q <= '0;
+	end else begin
+      perf_cnt_q <= perf_cnt_d;
+    end
+  end
+`endif
+
   //////////////////
   //  Assertions  //
   //////////////////

--- a/patches/0003-riscv-isa-sim-patch
+++ b/patches/0003-riscv-isa-sim-patch
@@ -1,0 +1,134 @@
+diff --git a/riscv/execute.cc b/riscv/execute.cc
+index ee8257f9..a9459a26 100644
+--- a/riscv/execute.cc
++++ b/riscv/execute.cc
+@@ -273,6 +273,10 @@ void processor_t::step(size_t n)
+ 
+           insn_fetch_t fetch = mmu->load_insn(pc);
+           if (debug && !state.serialized)
++            // mp-17: check if the instruction is a vector one
++            if ((disassembler->disassemble(fetch.insn))[0] == 'v') {
++              is_vec_insn = 1;
++            }
+             disasm(fetch.insn);
+           pc = execute_insn(this, pc, fetch);
+           advance_pc();
+diff --git a/riscv/interactive.cc b/riscv/interactive.cc
+index 22929d43..5406e3ee 100644
+--- a/riscv/interactive.cc
++++ b/riscv/interactive.cc
+@@ -86,7 +86,7 @@ void sim_t::interactive()
+   while (!done())
+   {
+     std::cerr << ": " << std::flush;
+-    std::string s = readline(2);
++    std::string s = readline(0);
+ 
+     std::stringstream ss(s);
+     std::string cmd, tmp;
+@@ -154,13 +154,29 @@ void sim_t::interactive_run_silent(const std::string& cmd, const std::vector<std
+   interactive_run(cmd,args,false);
+ }
+ 
++// mp-17: modify this function to print the whole internal scalar RF state upon a vector instruction
+ void sim_t::interactive_run(const std::string& cmd, const std::vector<std::string>& args, bool noisy)
+ {
+   size_t steps = args.size() ? atoll(args[0].c_str()) : -1;
+   ctrlc_pressed = false;
+   set_procs_debug(noisy);
+-  for (size_t i = 0; i < steps && !ctrlc_pressed && !done(); i++)
++
++  // This is a hack, but we are always using core 0
++  processor_t *p = get_core("0");
++
++  for (size_t i = 0; i < steps && !ctrlc_pressed && !done(); i++) {
++    // Step forward
+     step(1);
++    // Check if the fetched instruction was a vector one
++    if (p->is_vec_insn) {
++      // Print the whole F regfile
++      interactive_reg(cmd, {"0"});
++      // Print the whole F regfile
++      interactive_fregd_all(cmd, {"0"});
++      // Clear the flag
++      p->is_vec_insn = 0;
++    }
++  }
+ }
+ 
+ void sim_t::interactive_quit(const std::string& cmd, const std::vector<std::string>& args)
+@@ -311,6 +327,30 @@ void sim_t::interactive_freg(const std::string& cmd, const std::vector<std::stri
+   fprintf(stderr, "0x%016" PRIx64 "%016" PRIx64 "\n", r.v[1], r.v[0]);
+ }
+ 
++// mp-17: modified function to print all the scalar registers
++void sim_t::interactive_fregd_all(const std::string& cmd, const std::vector<std::string>& args)
++{
++  if (args.size() < 1)
++    throw trap_interactive();
++
++  processor_t *p = get_core(args[0]);
++  int max_xlen = p->get_max_xlen();
++
++  std::ostream out(sout_.rdbuf());
++  out << std::hex;
++
++  if (args.size() == 1) {
++    // Show all the fregs!
++    for (int r = 0; r < NFPR; ++r) {
++      out << std::setfill(' ') << std::setw(4) << fpr_name[r]
++          << ": 0x" << std::setfill('0') << std::setw(max_xlen/4)
++          << (p->get_state()->FPR[r]).v[0];
++      if ((r + 1) % 4 == 0)
++        out << std::endl;
++    }
++  }
++}
++
+ void sim_t::interactive_fregh(const std::string& cmd, const std::vector<std::string>& args)
+ {
+   fpr f;
+@@ -424,7 +464,7 @@ void sim_t::interactive_until(const std::string& cmd, const std::vector<std::str
+   // mask bits above max_xlen
+   int max_xlen = procs[strtol(args[1].c_str(),NULL,10)]->get_max_xlen();
+   if (max_xlen == 32) val &= 0xFFFFFFFF;
+-  
++
+   std::vector<std::string> args2;
+   args2 = std::vector<std::string>(args.begin()+1,args.end()-1);
+ 
+diff --git a/riscv/processor.h b/riscv/processor.h
+index ad6e8929..03ea4cf7 100644
+--- a/riscv/processor.h
++++ b/riscv/processor.h
+@@ -272,6 +272,8 @@ public:
+               FILE *log_file);
+   ~processor_t();
+ 
++  // mp-17: register a vector instruction
++  int is_vec_insn = 0;
+   void set_debug(bool value);
+   void set_histogram(bool value);
+ #ifdef RISCV_ENABLE_COMMITLOG
+@@ -444,7 +446,7 @@ private:
+   bool halt_on_reset;
+   std::vector<bool> extension_table;
+   std::vector<bool> impl_table;
+-  
++
+   entropy_source es; // Crypto ISE Entropy source.
+ 
+   std::vector<insn_desc_t> instructions;
+diff --git a/riscv/sim.h b/riscv/sim.h
+index 1c47ce75..201c3917 100644
+--- a/riscv/sim.h
++++ b/riscv/sim.h
+@@ -108,6 +108,8 @@ private:
+   void interactive_vreg(const std::string& cmd, const std::vector<std::string>& args);
+   void interactive_reg(const std::string& cmd, const std::vector<std::string>& args);
+   void interactive_freg(const std::string& cmd, const std::vector<std::string>& args);
++  // mp-17: print all the scalar registers
++  void interactive_fregd_all(const std::string& cmd, const std::vector<std::string>& args);
+   void interactive_fregh(const std::string& cmd, const std::vector<std::string>& args);
+   void interactive_fregs(const std::string& cmd, const std::vector<std::string>& args);
+   void interactive_fregd(const std::string& cmd, const std::vector<std::string>& args);

--- a/scripts/benchmark.gnuplot
+++ b/scripts/benchmark.gnuplot
@@ -36,13 +36,18 @@ set out "imatmul.png"
 
 # Plot the rooflines
 plot roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
-     'imatmul_2.benchmark' w p lw 2 lc 1 pt 2 notitle,                                        \
+     'imatmul_2.benchmark'       w p lw 2 lc 1 pt 5 notitle,                                  \
+     'imatmul_2_ideal.benchmark' w p lw 2 lc 1 pt 4 notitle,                                  \
      roof_mem(x, 2,  8) w l lw 2 lc 2 notitle, roof_cpu(x, 2,  8) w l lw 2 lc 2 t  '4 Lanes', \
-     'imatmul_4.benchmark' w p lw 2 lc 2 pt 2 notitle,                                        \
+     'imatmul_4.benchmark'       w p lw 2 lc 2 pt 5 notitle,                                  \
+     'imatmul_4_ideal.benchmark' w p lw 2 lc 2 pt 4 notitle,                                  \
      roof_mem(x, 4, 16) w l lw 2 lc 3 notitle, roof_cpu(x, 4, 16) w l lw 2 lc 3 t  '8 Lanes', \
-     'imatmul_8.benchmark' w p lw 2 lc 3 pt 2 notitle,                                        \
+     'imatmul_8.benchmark'       w p lw 2 lc 3 pt 5 notitle,                                  \
+     'imatmul_8_ideal.benchmark' w p lw 2 lc 3 pt 4 notitle,                                  \
      roof_mem(x, 8, 32) w l lw 2 lc 7 notitle, roof_cpu(x, 8, 32) w l lw 2 lc 7 t '16 Lanes', \
-     'imatmul_16.benchmark' w p lw 2 lc 7 pt 2 notitle
+     'imatmul_16.benchmark'       w p lw 2 lc 7 pt 5 notitle,                                 \
+     'imatmul_16_ideal.benchmark' w p lw 2 lc 7 pt 4 notitle
+
 unset out
 
 #############
@@ -62,13 +67,17 @@ set out "fmatmul.png"
 
 # Plot the rooflines
 plot roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
-     'fmatmul_2.benchmark' w p lw 2 lc 1 pt 2 notitle,                                        \
+     'fmatmul_2.benchmark'       w p lw 2 lc 1 pt 5 notitle,                                  \
+     'fmatmul_2_ideal.benchmark' w p lw 2 lc 1 pt 4 notitle,                                  \
      roof_mem(x, 2,  8) w l lw 2 lc 2 notitle, roof_cpu(x, 2,  8) w l lw 2 lc 2 t  '4 Lanes', \
-     'fmatmul_4.benchmark' w p lw 2 lc 2 pt 2 notitle,                                        \
+     'fmatmul_4.benchmark'       w p lw 2 lc 2 pt 5 notitle,                                  \
+     'fmatmul_4_ideal.benchmark' w p lw 2 lc 2 pt 4 notitle,                                  \
      roof_mem(x, 4, 16) w l lw 2 lc 3 notitle, roof_cpu(x, 4, 16) w l lw 2 lc 3 t  '8 Lanes', \
-     'fmatmul_8.benchmark' w p lw 2 lc 3 pt 2 notitle,                                        \
+     'fmatmul_8.benchmark'       w p lw 2 lc 3 pt 5 notitle,                                  \
+     'fmatmul_8_ideal.benchmark' w p lw 2 lc 3 pt 4 notitle,                                  \
      roof_mem(x, 8, 32) w l lw 2 lc 7 notitle, roof_cpu(x, 8, 32) w l lw 2 lc 7 t '16 Lanes', \
-     'fmatmul_16.benchmark' w p lw 2 lc 7 pt 2 notitle
+     'fmatmul_16.benchmark'       w p lw 2 lc 7 pt 5 notitle,                                 \
+     'fmatmul_16_ideal.benchmark' w p lw 2 lc 7 pt 4 notitle
 
 #############
 ## ICONV2D ##
@@ -87,13 +96,17 @@ set out "iconv2d.png"
 
 # Plot the rooflines
 plot roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
-     'iconv2d_2.benchmark' w p lw 2 lc 1 pt 2 notitle,                                        \
+     'iconv2d_2.benchmark'       w p lw 2 lc 1 pt 5 notitle,                                  \
+     'iconv2d_2_ideal.benchmark' w p lw 2 lc 1 pt 4 notitle,                                  \
      roof_mem(x, 2,  8) w l lw 2 lc 2 notitle, roof_cpu(x, 2,  8) w l lw 2 lc 2 t  '4 Lanes', \
-     'iconv2d_4.benchmark' w p lw 2 lc 2 pt 2 notitle,                                        \
+     'iconv2d_4.benchmark'       w p lw 2 lc 2 pt 5 notitle,                                  \
+     'iconv2d_4_ideal.benchmark' w p lw 2 lc 2 pt 4 notitle,                                  \
      roof_mem(x, 4, 16) w l lw 2 lc 3 notitle, roof_cpu(x, 4, 16) w l lw 2 lc 3 t  '8 Lanes', \
-     'iconv2d_8.benchmark' w p lw 2 lc 3 pt 2 notitle,                                        \
+     'iconv2d_8.benchmark'       w p lw 2 lc 3 pt 5 notitle,                                  \
+     'iconv2d_8_ideal.benchmark' w p lw 2 lc 3 pt 4 notitle,                                  \
      roof_mem(x, 8, 32) w l lw 2 lc 7 notitle, roof_cpu(x, 8, 32) w l lw 2 lc 7 t '16 Lanes', \
-     'iconv2d_16.benchmark' w p lw 2 lc 7 pt 2 notitle
+     'iconv2d_16.benchmark'       w p lw 2 lc 7 pt 5 notitle,                                 \
+     'iconv2d_16_ideal.benchmark' w p lw 2 lc 7 pt 4 notitle
 
 #############
 ## FCONV2D ##
@@ -112,13 +125,17 @@ set out "fconv2d.png"
 
 # Plot the rooflines
 plot roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
-     'fconv2d_2.benchmark' w p lw 2 lc 1 pt 2 notitle,                                        \
+     'fconv2d_2.benchmark'       w p lw 2 lc 1 pt 5 notitle,                                  \
+     'fconv2d_2_ideal.benchmark' w p lw 2 lc 1 pt 4 notitle,                                  \
      roof_mem(x, 2,  8) w l lw 2 lc 2 notitle, roof_cpu(x, 2,  8) w l lw 2 lc 2 t  '4 Lanes', \
-     'fconv2d_4.benchmark' w p lw 2 lc 2 pt 2 notitle,                                        \
+     'fconv2d_4.benchmark'       w p lw 2 lc 2 pt 5 notitle,                                  \
+     'fconv2d_4_ideal.benchmark' w p lw 2 lc 2 pt 4 notitle,                                  \
      roof_mem(x, 4, 16) w l lw 2 lc 3 notitle, roof_cpu(x, 4, 16) w l lw 2 lc 3 t  '8 Lanes', \
-     'fconv2d_8.benchmark' w p lw 2 lc 3 pt 2 notitle,                                        \
+     'fconv2d_8.benchmark'       w p lw 2 lc 3 pt 5 notitle,                                  \
+     'fconv2d_8_ideal.benchmark' w p lw 2 lc 3 pt 4 notitle,                                  \
      roof_mem(x, 8, 32) w l lw 2 lc 7 notitle, roof_cpu(x, 8, 32) w l lw 2 lc 7 t '16 Lanes', \
-     'fconv2d_16.benchmark' w p lw 2 lc 7 pt 2 notitle
+     'fconv2d_16.benchmark'       w p lw 2 lc 7 pt 5 notitle,                                 \
+     'fconv2d_16_ideal.benchmark' w p lw 2 lc 7 pt 4 notitle
 
 #############
 ## FCONV3D ##
@@ -137,10 +154,14 @@ set out "fconv3d.png"
 
 # Plot the rooflines
 plot roof_mem(x, 1,  4) w l lw 2 lc 1 notitle, roof_cpu(x, 1,  4) w l lw 2 lc 1 t  '2 Lanes', \
-     'fconv3d_2.benchmark' w p lw 2 lc 1 pt 2 notitle,                                        \
+     'fconv3d_2.benchmark'       w p lw 2 lc 1 pt 5 notitle,                                  \
+     'fconv3d_2_ideal.benchmark' w p lw 2 lc 1 pt 4 notitle,                                  \
      roof_mem(x, 2,  8) w l lw 2 lc 2 notitle, roof_cpu(x, 2,  8) w l lw 2 lc 2 t  '4 Lanes', \
-     'fconv3d_4.benchmark' w p lw 2 lc 2 pt 2 notitle,                                        \
+     'fconv3d_4.benchmark'       w p lw 2 lc 2 pt 5 notitle,                                  \
+     'fconv3d_4_ideal.benchmark' w p lw 2 lc 2 pt 4 notitle,                                  \
      roof_mem(x, 4, 16) w l lw 2 lc 3 notitle, roof_cpu(x, 4, 16) w l lw 2 lc 3 t  '8 Lanes', \
-     'fconv3d_8.benchmark' w p lw 2 lc 3 pt 2 notitle,                                        \
+     'fconv3d_8.benchmark'       w p lw 2 lc 3 pt 5 notitle,                                  \
+     'fconv3d_8_ideal.benchmark' w p lw 2 lc 3 pt 4 notitle,                                  \
      roof_mem(x, 8, 32) w l lw 2 lc 7 notitle, roof_cpu(x, 8, 32) w l lw 2 lc 7 t '16 Lanes', \
-     'fconv3d_16.benchmark' w p lw 2 lc 7 pt 2 notitle
+     'fconv3d_16.benchmark'       w p lw 2 lc 7 pt 5 notitle,                                 \
+     'fconv3d_16_ideal.benchmark' w p lw 2 lc 7 pt 4 notitle

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -3,14 +3,12 @@
 # Python in use
 PYTHON=python3
 
-# Command to compile ideal dispatcher system
-# If questa is not installed, the ideal dispatcher
-# metrics will be the copy of the default system
-if [ "$1" == "questa" ]
+# Is this exectued by the CI?
+if [ "$1" == "ci" ]
 then
-    ID_SIMULATOR=simc
+    ci=1
 else
-    ID_SIMULATOR=simv
+    ci=0
 fi
 
 # Include Ara's configuration
@@ -53,14 +51,16 @@ for kernel in imatmul fmatmul; do
 	    cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
         ./scripts/performance.py $kernel "$size" $cycles >> ${kernel}_${nr_lanes}.benchmark
 
-        # System with ideal dispatcher
-        ENV_DEFINES="-DSIZE=$size -D${kernel^^}=1" \
-               make -C apps/ bin/benchmarks.ideal
-        touch -a hardware/build
-        make -C hardware/ -B $ID_SIMULATOR app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-        # Extract the cycle count and calculate performance
-	    cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-        ./scripts/performance.py $kernel "$size" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+        if [ "$ci" == 0 ]; then
+          # System with ideal dispatcher
+          ENV_DEFINES="-DSIZE=$size -D${kernel^^}=1" \
+                 make -C apps/ bin/benchmarks.ideal
+          touch -a hardware/build
+          make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
+          # Extract the cycle count and calculate performance
+	      cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+          ./scripts/performance.py $kernel "$size" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+        fi
     done
 done
 
@@ -97,14 +97,16 @@ for kernel in iconv2d fconv2d; do
 	        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
             ./scripts/performance.py $kernel "$size $filter" $cycles >> ${kernel}_${nr_lanes}.benchmark
 
-            # System with ideal dispatcher
-            ENV_DEFINES="-D${kernel^^}=1" \
-                   make -C apps/ bin/benchmarks.ideal
-            touch -a hardware/build
-            make -C hardware/ -B $ID_SIMULATOR app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-            # Extract the performance
-	        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-            ./scripts/performance.py $kernel "$size $filter" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+            if [ "$ci" == 0 ]; then
+              # System with ideal dispatcher
+              ENV_DEFINES="-D${kernel^^}=1" \
+                     make -C apps/ bin/benchmarks.ideal
+              touch -a hardware/build
+              make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
+              # Extract the performance
+	          cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+              ./scripts/performance.py $kernel "$size $filter" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+            fi
         done
     done
 done
@@ -142,14 +144,16 @@ for kernel in fconv3d; do
 	        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
             ./scripts/performance.py $kernel "$size $filter" $cycles >> ${kernel}_${nr_lanes}.benchmark
 
-            # System with ideal dispatcher
-            ENV_DEFINES="-D${kernel^^}=1" \
-                   make -C apps/ bin/benchmarks.ideal
-            touch -a hardware/build
-            make -C hardware/ -B $ID_SIMULATOR app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-            # Extract the performance
-	        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-            ./scripts/performance.py $kernel "$size $filter" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+            if [ "$ci" == 0 ]; then
+              # System with ideal dispatcher
+              ENV_DEFINES="-D${kernel^^}=1" \
+                     make -C apps/ bin/benchmarks.ideal
+              touch -a hardware/build
+              make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
+              # Extract the performance
+	          cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+              ./scripts/performance.py $kernel "$size $filter" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+            fi
         done
     done
 done

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# Copyright 2022 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Matteo Perotti, ETH Zurich
+#
+# Calculate throughput performance metric for a particular kernel, cycle count,
+# and environment conditions
+
+import sys
+
+# Performance extractors: returns problem size and performance (throughput)
+def imatmul(args, cycles):
+  size        = int(args[0])
+  performance = 2 * size * size * size / cycles
+  return [size, performance]
+def fmatmul(args, cycles):
+  size        = int(args[0])
+  performance = 2 * size * size * size / cycles
+  return [size, performance]
+def iconv2d(args, cycles):
+  size        = int(args[0])
+  filter      = int(args[1])
+  performance = 2 * filter * filter * size * size / cycles
+  return [size, performance]
+def fconv2d(args, cycles):
+  size        = int(args[0])
+  filter      = int(args[1])
+  performance = 2 * filter * filter * size * size / cycles
+  return [size, performance]
+def fconv3d(args, cycles):
+  size        = int(args[0])
+  filter      = int(args[1])
+  performance = 2 * 3 * filter * filter * size * size / cycles
+  return [size, performance]
+
+perfExtr = {
+  'imatmul' : imatmul,
+  'fmatmul' : fmatmul,
+  'iconv2d' : iconv2d,
+  'fconv2d' : fconv2d,
+  'fconv3d' : fconv3d,
+}
+
+def main():
+  kernel   = str(sys.argv[1])
+  args     = str(sys.argv[2]).split()
+  cycles   = int(sys.argv[3])
+  # Extract performance information
+  try:
+    result = perfExtr[kernel](args, cycles)
+  except KeyError:
+    sys.exit('Error: the kernel "' + kernel + '" is not valid')
+
+  # Print performance information on file
+  print(result[0], result[1])
+
+if __name__ == '__main__':
+  main()

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -40,7 +40,7 @@ def fconv2d(args, cycles):
   size        = int(args[0])
   filter      = int(args[1])
   performance = 2 * filter * filter * size * size / cycles
-  return [size, performance]
+  return [args, performance]
 def fconv3d(args, cycles):
   size        = int(args[0])
   filter      = int(args[1])


### PR DESCRIPTION
The system can now be simulated in two different modes:

1) **Normal decoupled system** with CVA6, Ara, and Memory.
2) **Ideal-Dispatcher system** with an Ideal Dispatcher, Ara, and Memory.

The Ideal Dispatcher is just a FIFO that contains the whole dynamic vector code trace of a particular program, and can dispatch one vector instruction per cycle to Ara.
This simulation mode is useful to remove the scalar core from the final performance equation, highlighting the limitations only due to Ara.

Currently, this mode has some limitations:
 - It can only be run using QuestaSim.
 - We do not check that the results are correct.

The `scripts/benchmark.sh` script now benchmarks both the modes by default, and uses an external `performance.py` script to extract the performance metrics. To do so, `QuestaSim` should be available on your system. If this is not the case, pass the `ci` option to the script to avoid benchmarking the system in ideal-dispatcher mode.

The vector trace to be stored in the FIFO is created by running the program with a modified version of Spike. This patched version is installed using the main Makefile by default.
This patched Spike automatically prints the scalar register file content, so that other scripts can build a trace of the vector instructions and the content of the desired register at precise cycles.

## Changelog

### Fixed

 - Fix the data target for `.spike` app compilations
 - `make -C apps clean` performs a deeper clean of the temporary object files

### Added

 - Add support for ideal-dispatcher simulation
 - Add compile-time garbage-collection to strip unused functions out and decrease the memory footprint of the binary
 - Add benchmarking capability with the ideal-dispatcher system + performance plotting. The support is limited to simluation with QuestaSim only

### Changed

 - Performance metrics are now calculated by an external performance.py script, instead of during the program simulation, which just prints out the cycle count
 - Update `Verilator` to `v4.226`

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed