### PR TITLE
[HW] Add support for vector fixed-point instructions

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -49,6 +49,7 @@ sources:
     - hardware/src/lane/operand_queues_stage.sv
     - hardware/src/lane/valu.sv
     - hardware/src/lane/vmfpu.sv
+    - hardware/src/lane/fixed_p_rounding.sv
     - hardware/src/vlsu/vlsu.sv
     # Level 3
     - hardware/src/lane/vector_fus_stage.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - fdotproduct benchmark to evaluate dot products with reductions
  - fredsum benchmark to evaluate fp-reductions
  - riscv-tests for `vfredusum`, `vfredosum`, `vfredmin`, `vfredmax`, `vfwredusum`, `vfwredosum`
+ - Support for vector single-width fractional multiply with rounding and saturation instruction: `vsmul`
+ - Support for vector single-width scaling shift instructions: `vssra`, `vssrl`
+ - Support for vector narrowing fixed-point clip instructions: `vnclip`, `vnclipu`
  - Vector floating-point classify instruction (`vfclass`)
  - Vector floating-point divide instructions (`vfdiv`, `vfrdiv`)
  - Vector floating-point square-root instruction (`vfsqrt`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+ - Fixed-Point instructions were added (`VSADDU`, `VSADD`, `VAADD`, `VAADDU`, `VSSUBU`, `VSSUB`, `VASUB`, `VASUBU`)
  - The main sequencer issues instructions every time the target unit has a non-full instruction queue
  - The main sequencer stalls if the instructions target a lane, and its operand requesters are not ready
  - New instructions enter the main sequencer with a token that marks them as new, and the related counter is updated upon arrival

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Support for vector mask instructions: `vmsbf`, `vmsof`, `vmsif`, `viota`, `vid`
  - Add support for vector mask population count and find first set bit instructions: `vcpop.m`, `vfirst.m`
  - Add Spyglass linting script
+ - Add parametrized support for Fixed-Point math
 
 ### Changed
 

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -78,3 +78,6 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 
 - Vector single-width saturating add and subtract: `vsaddu`, `vsadd`, `vssubu`,`vssub`
 - Vector single-width averaging add and subtract: `vaadd`, `vaaddu`, `vasub`, `vasubu`
+- Vector single-width fractional multiply with rounding and saturation instruction: `vsmul`
+- Vector single-width scaling shift instructions: `vssra`, `vssrl`
+- Vector narrowing fixed-point clip instructions: `vnclip`, `vnclipu`

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -73,3 +73,8 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 - Integer Scalar Move instructions: `vmv.x.s`, `vmv.s.x`
 - Floating-Point Scalar Move instructions: `vfmv.f.s`, `vfmv.s.f`
 - Vector slide instructions: `vslideup`, `vslidedown`, `vslide1up`, `vfslide1up`, `vslide1down`, `vfslide1down`
+
+## Vector fixed-point arithmetic instructions
+
+- Vector single-width saturating add and subtract: `vsaddu`, `vsadd`, `vssubu`,`vssub`
+- Vector single-width averaging add and subtract: `vaadd`, `vaaddu`, `vasub`, `vasubu`

--- a/apps/riscv-tests/isa/macros/vector/vector_macros.h
+++ b/apps/riscv-tests/isa/macros/vector/vector_macros.h
@@ -43,6 +43,7 @@ int test_case;
 #define read_vtype(buf) do { asm volatile ("csrr %[BUF], vtype" : [BUF] "=r" (buf)); } while (0);
 #define read_vl(buf)    do { asm volatile ("csrr %[BUF], vl" : [BUF] "=r" (buf)); } while (0);
 #define read_vxsat(buf) do { asm volatile ("csrr %[BUF], vxsat" : [BUF] "=r" (buf)); } while (0);
+#define set_vxrm(val) do { asm volatile ("csrw vxrm, %0" :: "rK"(val)); } while (0);
 
 #define vtype(golden_vtype, vlmul, vsew, vta, vma) (golden_vtype = vlmul << 0 | vsew << 3 | vta << 6 | vma << 7)
 

--- a/apps/riscv-tests/isa/macros/vector/vector_macros.h
+++ b/apps/riscv-tests/isa/macros/vector/vector_macros.h
@@ -43,6 +43,7 @@ int test_case;
 #define read_vtype(buf) do { asm volatile ("csrr %[BUF], vtype" : [BUF] "=r" (buf)); } while (0);
 #define read_vl(buf)    do { asm volatile ("csrr %[BUF], vl" : [BUF] "=r" (buf)); } while (0);
 #define read_vxsat(buf) do { asm volatile ("csrr %[BUF], vxsat" : [BUF] "=r" (buf)); } while (0);
+#define reset_vxsat     do { asm volatile ("csrw vxsat, %0" :: "rK"(0)); } while (0);
 #define set_vxrm(val) do { asm volatile ("csrw vxrm, %0" :: "rK"(val)); } while (0);
 
 #define vtype(golden_vtype, vlmul, vsew, vta, vma) (golden_vtype = vlmul << 0 | vsew << 3 | vta << 6 | vma << 7)

--- a/apps/riscv-tests/isa/macros/vector/vector_macros.h
+++ b/apps/riscv-tests/isa/macros/vector/vector_macros.h
@@ -42,6 +42,7 @@ int test_case;
 
 #define read_vtype(buf) do { asm volatile ("csrr %[BUF], vtype" : [BUF] "=r" (buf)); } while (0);
 #define read_vl(buf)    do { asm volatile ("csrr %[BUF], vl" : [BUF] "=r" (buf)); } while (0);
+#define read_vxsat(buf) do { asm volatile ("csrr %[BUF], vxsat" : [BUF] "=r" (buf)); } while (0);
 
 #define vtype(golden_vtype, vlmul, vsew, vta, vma) (golden_vtype = vlmul << 0 | vsew << 3 | vta << 6 | vma << 7)
 
@@ -57,6 +58,15 @@ int test_case;
   }}                                                        \
   else if (vtype != golden_vtype || avl != vl) {                                                                        \
     printf("FAILED. Got vtype = %lx, expected vtype = %lx. avl = %lx, vl = %lx.\n", vtype, golden_vtype, avl, vl); \
+    num_failed++;                                                                                                  \
+    return;                                                                                                        \
+  }                                                                                                                \
+  printf("PASSED.\n");
+
+#define check_vxsat(casenum, vxsat, golden_vxsat)                                                                  \
+  printf("Checking vxsat #%d...\n", casenum);                                                               \
+  if (vxsat != golden_vxsat) {                                                                        \
+    printf("FAILED. Got vxsat = %lx, expected vxsat = %lx.\n", vxsat, golden_vxsat); \
     num_failed++;                                                                                                  \
     return;                                                                                                        \
   }                                                                                                                \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -5,7 +5,11 @@
 # Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 #         Basile Bougenot <bbougenot@student.ethz.ch>
 
-rv64uv_sc_tests = vadd \
+rv64uv_sc_tests = vaadd \
+                  vaaddu\
+                  vsadd \
+                  vsaddu \
+                  vadd \
                   vsub \
                   vrsub \
                   vwaddu \

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -9,6 +9,11 @@ rv64uv_sc_tests = vaadd \
                   vaaddu\
                   vsadd \
                   vsaddu \
+                  vsmul \
+                  vssra \
+                  vssrl \
+                  vnclip \
+                  vnclipu \
                   vadd \
                   vsub \
                   vrsub \

--- a/apps/riscv-tests/isa/rv64uv/vaadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vaadd.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v1, 1, -2, -3, 4);
   VLOAD_8(v2, 1, 2, -3, 4);
   __asm__ volatile("vaadd.vv v3, v1, v2" ::);
-  VEC_CMP_8(1, v3, 1, 0, -3, 4);
+  VCMP_U8(1, v3, 1, 0, -3, 4);
 }
 
 void TEST_CASE2(void) {
@@ -20,9 +20,9 @@ void TEST_CASE2(void) {
   VLOAD_8(v1, 1, -2, -3, 4);
   VLOAD_8(v2, 1, 2, -3, 4);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vaadd.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_8(2, v3, 0, 0, 0, 4);
+  VCMP_U8(2, v3, 0, 0, 0, 4);
 }
 
 void TEST_CASE3(void) {
@@ -30,7 +30,7 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 1, -2, 3, -4);
   const uint32_t scalar = 5;
   __asm__ volatile("vaadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_32(3, v3, 3, 2, 4, 1);
+  VCMP_U32(3, v3, 3, 2, 4, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -39,9 +39,9 @@ void TEST_CASE4(void) {
   VLOAD_32(v1, 1, -2, 3, -4);
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vaadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_32(4, v3, 0, 2, 0, 1);
+  VCMP_U32(4, v3, 0, 2, 0, 1);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vaadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vaadd.c
@@ -8,40 +8,44 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
+  set_vxrm(0); // setting vxrm to rnu rounding mode
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, -2, -3, 4);
-  VLOAD_8(v2, 1, 2, -3, 4);
+  VLOAD_8(v2, 1, 2, -3, 3);
   __asm__ volatile("vaadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 1, 0, -3, 4);
 }
 
 void TEST_CASE2(void) {
+  set_vxrm(1); // setting vxrm to rne rounding mode
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, -2, -3, 4);
-  VLOAD_8(v2, 1, 2, -3, 4);
+  VLOAD_8(v2, 1, 9, -3, 5);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vaadd.vv v3, v1, v2, v0.t" ::);
-  VCMP_U8(2, v3, 0, 0, 0, 4);
+  VCMP_U8(2, v3, 0, 4, 0, 4);
 }
 
 void TEST_CASE3(void) {
+  set_vxrm(2); // setting vxrm to rdn rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, -2, 3, -4);
   const uint32_t scalar = 5;
   __asm__ volatile("vaadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VCMP_U32(3, v3, 3, 2, 4, 1);
+  VCMP_U32(3, v3, 3, 1, 4, 0);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
+  set_vxrm(3); // setting vxrm to rod rounding mode
   VSET(4, e32, m1);
-  VLOAD_32(v1, 1, -2, 3, -4);
+  VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vaadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VCMP_U32(4, v3, 0, 2, 0, 1);
+  VCMP_U32(4, v3, 0, 3, 0, 5);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vaaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vaaddu.c
@@ -8,40 +8,44 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
+  set_vxrm(0); // setting vxrm to rnu rounding mode
   VSET(4, e8, m1);
-  VLOAD_8(v1, 1, 2, 3, 4);
-  VLOAD_8(v2, 1, 2, 3, 4);
+  VLOAD_8(v1, 1, 2, 3, 5);
+  VLOAD_8(v2, 1, 3, 8, 4);
   __asm__ volatile("vaaddu.vv v3, v1, v2" ::);
-  VCMP_U8(1, v3, 1, 2, 3, 4);
+  VCMP_U8(1, v3, 1, 3, 6, 5);
 }
 
 void TEST_CASE2(void) {
+  set_vxrm(1); // setting vxrm to rne rounding mode
   VSET(4, e8, m1);
-  VLOAD_8(v1, 1, 2, 3, 4);
-  VLOAD_8(v2, 1, 2, 3, 4);
+  VLOAD_8(v1, 5, 8, 3, 7);
+  VLOAD_8(v2, 7, 5, 3, 5);
   VLOAD_8(v0, 0x0A, 0x00, 0x00, 0x00);
   VCLEAR(v3);
   __asm__ volatile("vaaddu.vv v3, v1, v2, v0.t" ::);
-  VCMP_U8(2, v3, 0, 2, 0, 4);
+  VCMP_U8(2, v3, 0, 6, 0, 6);
 }
 
 void TEST_CASE3(void) {
+  set_vxrm(2); // setting vxrm to rdn rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vaaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VCMP_U32(3, v3, 3, 4, 4, 5);
+  VCMP_U32(3, v3, 3, 3, 4, 4);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
+  set_vxrm(3); // setting vxrm to rod rounding mode
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vaaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VCMP_U32(4, v3, 0, 4, 0, 5);
+  VCMP_U32(4, v3, 0, 3, 0, 5);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vaaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vaaddu.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v1, 1, 2, 3, 4);
   VLOAD_8(v2, 1, 2, 3, 4);
   __asm__ volatile("vaaddu.vv v3, v1, v2" ::);
-  VEC_CMP_8(1, v3, 1, 2, 3, 4);
+  VCMP_U8(1, v3, 1, 2, 3, 4);
 }
 
 void TEST_CASE2(void) {
@@ -20,28 +20,28 @@ void TEST_CASE2(void) {
   VLOAD_8(v1, 1, 2, 3, 4);
   VLOAD_8(v2, 1, 2, 3, 4);
   VLOAD_8(v0, 0x0A, 0x00, 0x00, 0x00);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vaaddu.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_8(2, v3, 0, 2, 0, 4);
+  VCMP_U8(2, v3, 0, 2, 0, 4);
 }
 
 void TEST_CASE3(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 2, 3, 4);
+  VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vaaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_U32(3, v3, 3, 4, 4, 5);
+  VCMP_U32(3, v3, 3, 4, 4, 5);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 2, 3, 4);
+  VLOAD_32(v1, 1, 2, 3, 4);
   const uint32_t scalar = 5;
-  VLOAD_U32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
   __asm__ volatile("vaaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U32(4, v3, 0, 4, 0, 5);
+  VCMP_U32(4, v3, 0, 4, 0, 5);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vnclip.c
+++ b/apps/riscv-tests/isa/rv64uv/vnclip.c
@@ -1,0 +1,78 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Muhammad Ijaz
+
+#include "vector_macros.h"
+
+void TEST_CASE1() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  VLOAD_8(v4, 7, 7, 7, 7);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclip.wv v1, v2, v4");
+  VCMP_I8(1, v1, 6, 0xff, 0xff, 0);
+}
+
+void TEST_CASE2() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  VLOAD_8(v4, 7, 7, 7, 7);
+  VLOAD_8(v0, 0x5, 0, 0, 0);
+  VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclip.wv v1, v2, v4, v0.t");
+  VCMP_I8(2, v1, 6, 0, 0xff, 0);
+}
+
+void TEST_CASE3() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  int8_t scalar = 7;
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclip.wx v1, v2, %[A]" ::[A] "r"(scalar));
+  VCMP_I8(3, v1, 6, 0xff, 0xff, 0);
+}
+
+void TEST_CASE4() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  int8_t scalar = 7;
+  VLOAD_8(v0, 0x5, 0, 0);
+  VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclip.wx v1, v2, %[A], v0.t" ::[A] "r"(scalar));
+  VCMP_I8(4, v1, 6, 0, 0xff, 0);
+}
+
+void TEST_CASE5() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclip.wi v1, v2, 7");
+  VCMP_I8(5, v1, 6, 0xff, 0xff, 0);
+}
+
+void TEST_CASE6() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  VLOAD_8(v0, 0x5, 0, 0, 0);
+  VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclip.wi v1, v2, 7, v0.t");
+  VCMP_I8(6, v1, 6, 0, 0xff, 0);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  enable_fp();
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+  TEST_CASE6();
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vnclipu.c
+++ b/apps/riscv-tests/isa/rv64uv/vnclipu.c
@@ -1,0 +1,78 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Muhammad Ijaz
+
+#include "vector_macros.h"
+
+void TEST_CASE1() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  VLOAD_8(v4, 7, 7, 7, 7);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclipu.wv v1, v2, v4");
+  VCMP_U8(1, v1, 6, 0xff, 0xff, 0);
+}
+
+void TEST_CASE2() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  VLOAD_8(v4, 7, 7, 7, 7);
+  VLOAD_8(v0, 0x5, 0, 0, 0);
+  VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclipu.wv v1, v2, v4, v0.t");
+  VCMP_U8(2, v1, 6, 0, 0xff, 0);
+}
+
+void TEST_CASE3() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  int8_t scalar = 7;
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclipu.wx v1, v2, %[A]" ::[A] "r"(scalar));
+  VCMP_U8(3, v1, 6, 0xff, 0xff, 0);
+}
+
+void TEST_CASE4() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  int8_t scalar = 7;
+  VLOAD_8(v0, 0x5, 0, 0);
+  VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclipu.wx v1, v2, %[A], v0.t" ::[A] "r"(scalar));
+  VCMP_U8(4, v1, 6, 0, 0xff, 0);
+}
+
+void TEST_CASE5() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclipu.wi v1, v2, 7");
+  VCMP_U8(5, v1, 6, 0xff, 0xff, 0);
+}
+
+void TEST_CASE6() {
+  VSET(4, e8, m1);
+  VLOAD_16(v2, 800, 65535, -50, 25);
+  VLOAD_8(v0, 0x5, 0, 0, 0);
+  VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
+  __asm__ volatile("vnclipu.wi v1, v2, 7, v0.t");
+  VCMP_U8(6, v1, 6, 0, 0xff, 0);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  enable_fp();
+  TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
+  TEST_CASE4();
+  TEST_CASE5();
+  TEST_CASE6();
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -14,6 +14,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v2, -90, 2, 50, 4);
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
+
   read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
 }
@@ -27,6 +28,7 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(2, v3, 0, 4, 0, 8);
+
   read_vxsat(vxsat);
   check_vxsat(2, vxsat, 0);
 }
@@ -37,6 +39,7 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
+
   read_vxsat(vxsat);
   check_vxsat(3, vxsat, 1);
 }
@@ -50,6 +53,7 @@ void TEST_CASE4(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
   VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
+
   read_vxsat(vxsat);
   check_vxsat(4, vxsat, 1);
 }
@@ -61,6 +65,7 @@ void TEST_CASE5(void) {
   const uint32_t scalar = 5;
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
+
   read_vxsat(vxsat);
   check_vxsat(5, vxsat, 1);
 }
@@ -75,6 +80,7 @@ void TEST_CASE6(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
+
   read_vxsat(vxsat);
   check_vxsat(6, vxsat, 1);
 }

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -8,14 +8,18 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
+  uint64_t vxsat;
   VSET(4, e8, m1);
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
+  read_vxsat(vxsat)
+  check_vxsat(1, vxsat, 1);
 }
 
 void TEST_CASE2(void) {
+  uint64_t vxsat;
   VSET(4, e8, m1);
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
@@ -23,35 +27,47 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(2, v3, 0, 4, 0, 8);
+  read_vxsat(vxsat)
+  check_vxsat(2, vxsat, 0);
 }
 
 void TEST_CASE3(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
+  read_vxsat(vxsat)
+  check_vxsat(3, vxsat, 0);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0x7FFFFFFC);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
   VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
   VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
+  read_vxsat(vxsat)
+  check_vxsat(4, vxsat, 1);
 }
 
 void TEST_CASE5(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0x7FFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
+  read_vxsat(vxsat)
+  check_vxsat(5, vxsat, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE6(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7ffffffC, 3, 4);
   const uint32_t scalar = 5;
@@ -59,6 +75,8 @@ void TEST_CASE6(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
+  read_vxsat(vxsat)
+  check_vxsat(6, vxsat, 1);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -14,7 +14,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v2, -90, 2, 50, 4);
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
 }
 
@@ -27,7 +27,7 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(2, v3, 0, 4, 0, 8);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(2, vxsat, 0);
 }
 
@@ -37,8 +37,8 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
-  read_vxsat(vxsat)
-  check_vxsat(3, vxsat, 0);
+  read_vxsat(vxsat);
+  check_vxsat(3, vxsat, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -50,7 +50,7 @@ void TEST_CASE4(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
   VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(4, vxsat, 1);
 }
 
@@ -61,7 +61,7 @@ void TEST_CASE5(void) {
   const uint32_t scalar = 5;
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(5, vxsat, 1);
 }
 
@@ -75,7 +75,7 @@ void TEST_CASE6(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(6, vxsat, 1);
 }
 

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -14,7 +14,6 @@ void TEST_CASE1(void) {
   VLOAD_8(v2, -90, 2, 50, 4);
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
-
   read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
 }
@@ -28,7 +27,6 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
   VCMP_U8(2, v3, 0, 4, 0, 8);
-
   read_vxsat(vxsat);
   check_vxsat(2, vxsat, 0);
 }
@@ -39,7 +37,6 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
-
   read_vxsat(vxsat);
   check_vxsat(3, vxsat, 1);
 }
@@ -53,7 +50,6 @@ void TEST_CASE4(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
   VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
-
   read_vxsat(vxsat);
   check_vxsat(4, vxsat, 1);
 }
@@ -65,7 +61,6 @@ void TEST_CASE5(void) {
   const uint32_t scalar = 5;
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
-
   read_vxsat(vxsat);
   check_vxsat(5, vxsat, 1);
 }
@@ -80,7 +75,6 @@ void TEST_CASE6(void) {
   VCLEAR(v3);
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
-
   read_vxsat(vxsat);
   check_vxsat(6, vxsat, 1);
 }

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
   __asm__ volatile("vsadd.vv v3, v1, v2" ::);
-  VEC_CMP_8(1, v3, 0x80, 4, 127, 8);
+  VCMP_U8(1, v3, 0x80, 4, 127, 8);
 }
 
 void TEST_CASE2(void) {
@@ -20,16 +20,16 @@ void TEST_CASE2(void) {
   VLOAD_8(v1, -80, 2, 100, 4);
   VLOAD_8(v2, -90, 2, 50, 4);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsadd.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_8(2, v3, 0, 4, 0, 8);
+  VCMP_U8(2, v3, 0, 4, 0, 8);
 }
 
 void TEST_CASE3(void) {
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 0x7FFFFFFB, 3, 4);
   __asm__ volatile("vsadd.vi v3, v1, 5" ::);
-  VEC_CMP_32(3, v3, 6, 0x7FFFFFFF, 8, 9);
+  VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -37,9 +37,9 @@ void TEST_CASE4(void) {
   VSET(4, e32, m1);
   VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0x7FFFFFFC);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsadd.vi v3, v1, 5, v0.t" ::);
-  VEC_CMP_32(4, v3, 0, 7, 0, 0x7FFFFFFF);
+  VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
 }
 
 void TEST_CASE5(void) {
@@ -47,7 +47,7 @@ void TEST_CASE5(void) {
   VLOAD_32(v1, 0x7FFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vsadd.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_32(5, v3, 0x7FFFFFFF, 7, 8, 9);
+  VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -56,9 +56,9 @@ void TEST_CASE6(void) {
   VLOAD_32(v1, 1, 0x7ffffffC, 3, 4);
   const uint32_t scalar = 5;
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsadd.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_32(6, v3, 0, 0x7FFFFFFF, 0, 9);
+  VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vsadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vsadd.c
@@ -16,6 +16,7 @@ void TEST_CASE1(void) {
   VCMP_U8(1, v3, 0x80, 4, 127, 8);
   read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE2(void) {
@@ -29,6 +30,7 @@ void TEST_CASE2(void) {
   VCMP_U8(2, v3, 0, 4, 0, 8);
   read_vxsat(vxsat);
   check_vxsat(2, vxsat, 0);
+  reset_vxsat;
 }
 
 void TEST_CASE3(void) {
@@ -39,6 +41,7 @@ void TEST_CASE3(void) {
   VCMP_U32(3, v3, 6, 0x7FFFFFFF, 8, 9);
   read_vxsat(vxsat);
   check_vxsat(3, vxsat, 1);
+  reset_vxsat;
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -52,6 +55,7 @@ void TEST_CASE4(void) {
   VCMP_U32(4, v3, 0, 7, 0, 0x7FFFFFFF);
   read_vxsat(vxsat);
   check_vxsat(4, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE5(void) {
@@ -63,6 +67,7 @@ void TEST_CASE5(void) {
   VCMP_U32(5, v3, 0x7FFFFFFF, 7, 8, 9);
   read_vxsat(vxsat);
   check_vxsat(5, vxsat, 1);
+  reset_vxsat;
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -77,6 +82,7 @@ void TEST_CASE6(void) {
   VCMP_U32(6, v3, 0, 0x7FFFFFFF, 0, 9);
   read_vxsat(vxsat);
   check_vxsat(6, vxsat, 1);
+  reset_vxsat;
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -7,6 +7,7 @@
 
 #include "vector_macros.h"
 
+
 void TEST_CASE1(void) {
   uint64_t vxsat;
   VSET(4, e8, m1);

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -7,58 +7,90 @@
 
 #include "vector_macros.h"
 
+
 void TEST_CASE1(void) {
+  uint64_t vxsat;
   VSET(4, e8, m1);
   VLOAD_8(v1, 133, 2, 220, 4);
   VLOAD_8(v2, 133, 2, 50, 4);
   __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
-  VEC_CMP_8(1, v3, 255, 4, 255, 8);
+  VCMP_U8(1, v3, 255, 4, 255, 8);
+  read_vxsat(vxsat)
+  check_vxsat(1, vxsat, 1);
 }
 
 void TEST_CASE2(void) {
+  uint64_t vxsat;
   VSET(4, e8, m1);
   VLOAD_8(v1, 1, 2, 3, 154);
   VLOAD_8(v2, 1, 2, 3, 124);
   VLOAD_8(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsaddu.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_8(2, v3, 0, 4, 0, 255);
+  VCMP_U8(2, v3, 0, 4, 0, 255);
+  read_vxsat(vxsat);
+  check_vxsat(2, vxsat, 1);
 }
 
 void TEST_CASE3(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 0xFFFFFFFB, 3, 4);
+  VLOAD_32(v1, 1, 0xFFFFFFFB, 3, 4);
   __asm__ volatile("vsaddu.vi v3, v1, 5" ::);
-  VEC_CMP_U32(3, v3, 6, 0xFFFFFFFF, 8, 9);
+  VCMP_U32(3, v3, 6, 0xFFFFFFFF, 8, 9);
+  read_vxsat(vxsat);
+  check_vxsat(3, vxsat, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE4(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 2, 0xFFFFFFFD, 0xFFFFFFFC);
+  VLOAD_32(v1, 1, 2, 0xFFFFFFFD, 0xFFFFFFFC);
   VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vsaddu.vi v3, v1, 5, v0.t" ::);
-  VEC_CMP_U32(4, v3, 0, 7, 0, 0xFFFFFFFF);
+  VCMP_U32(4, v3, 0, 7, 0, 0xFFFFFFFF);
+  read_vxsat(vxsat);
+  check_vxsat(4, vxsat, 1);
 }
 
 void TEST_CASE5(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0xFFFFFFFD, 2, 3, 4);
   const uint32_t scalar = 5;
   __asm__ volatile("vsaddu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_32(5, v3, 0xFFFFFFFF, 7, 8, 9);
+  VCMP_U32(5, v3, 0xFFFFFFFF, 7, 8, 9);
+  read_vxsat(vxsat);
+  check_vxsat(5, vxsat, 1);
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE6(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 1, 0xfffffffC, 3, 4);
+  VLOAD_32(v1, 1, 0xfffffffC, 3, 4);
   const uint32_t scalar = 5;
-  VLOAD_U32(v0, 0xA, 0x0, 0x0, 0x0);
-  CLEAR(v3);
+  VLOAD_32(v0, 0xA, 0x0, 0x0, 0x0);
+  VCLEAR(v3);
   __asm__ volatile("vsaddu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U32(6, v3, 0, 0xFFFFFFFF, 0, 9);
+  VCMP_U32(6, v3, 0, 0xFFFFFFFF, 0, 9);
+  read_vxsat(vxsat);
+  check_vxsat(6, vxsat, 1);
+}
+
+// Dont use VCLEAR here, it results in a glitch where are values are off by 1
+void TEST_CASE7(void) {
+  uint64_t vxsat;
+  VSET(4, e32, m1);
+  VLOAD_32(v1, 1, 0x0000FFFF, 3, 4);
+  VLOAD_32(v2, 0xA, 0xFFFF0000, 0x0, 0x0);
+  VCLEAR(v3);
+  __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
+  VCMP_U32(7, v3, 0xB, 0xFFFFFFFF, 3, 4);
+  read_vxsat(vxsat);
+  check_vxsat(7, vxsat, 0);
 }
 
 int main(void) {
@@ -71,5 +103,6 @@ int main(void) {
   TEST_CASE4();
   TEST_CASE5();
   TEST_CASE6();
+  TEST_CASE7();
   EXIT_CHECK();
 }

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -7,7 +7,6 @@
 
 #include "vector_macros.h"
 
-
 void TEST_CASE1(void) {
   uint64_t vxsat;
   VSET(4, e8, m1);
@@ -80,7 +79,6 @@ void TEST_CASE6(void) {
   check_vxsat(6, vxsat, 1);
 }
 
-// Dont use VCLEAR here, it results in a glitch where are values are off by 1
 void TEST_CASE7(void) {
   uint64_t vxsat;
   VSET(4, e32, m1);

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -16,6 +16,7 @@ void TEST_CASE1(void) {
   VCMP_U8(1, v3, 255, 4, 255, 8);
   read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE2(void) {
@@ -29,6 +30,7 @@ void TEST_CASE2(void) {
   VCMP_U8(2, v3, 0, 4, 0, 255);
   read_vxsat(vxsat);
   check_vxsat(2, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE3(void) {
@@ -39,6 +41,7 @@ void TEST_CASE3(void) {
   VCMP_U32(3, v3, 6, 0xFFFFFFFF, 8, 9);
   read_vxsat(vxsat);
   check_vxsat(3, vxsat, 1);
+  reset_vxsat;
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -52,6 +55,7 @@ void TEST_CASE4(void) {
   VCMP_U32(4, v3, 0, 7, 0, 0xFFFFFFFF);
   read_vxsat(vxsat);
   check_vxsat(4, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE5(void) {
@@ -63,6 +67,7 @@ void TEST_CASE5(void) {
   VCMP_U32(5, v3, 0xFFFFFFFF, 7, 8, 9);
   read_vxsat(vxsat);
   check_vxsat(5, vxsat, 1);
+  reset_vxsat;
 }
 
 // Dont use VCLEAR here, it results in a glitch where are values are off by 1
@@ -77,6 +82,7 @@ void TEST_CASE6(void) {
   VCMP_U32(6, v3, 0, 0xFFFFFFFF, 0, 9);
   read_vxsat(vxsat);
   check_vxsat(6, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE7(void) {
@@ -89,6 +95,7 @@ void TEST_CASE7(void) {
   VCMP_U32(7, v3, 0xB, 0xFFFFFFFF, 3, 4);
   read_vxsat(vxsat);
   check_vxsat(7, vxsat, 0);
+  reset_vxsat;
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -7,7 +7,6 @@
 
 #include "vector_macros.h"
 
-
 void TEST_CASE1(void) {
   uint64_t vxsat;
   VSET(4, e8, m1);

--- a/apps/riscv-tests/isa/rv64uv/vsaddu.c
+++ b/apps/riscv-tests/isa/rv64uv/vsaddu.c
@@ -14,7 +14,7 @@ void TEST_CASE1(void) {
   VLOAD_8(v2, 133, 2, 50, 4);
   __asm__ volatile("vsaddu.vv v3, v1, v2" ::);
   VCMP_U8(1, v3, 255, 4, 255, 8);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
 }
 

--- a/apps/riscv-tests/isa/rv64uv/vsmul.c
+++ b/apps/riscv-tests/isa/rv64uv/vsmul.c
@@ -11,8 +11,9 @@ void TEST_CASE1() {
   VSET(3, e8, m1);
   VLOAD_8(v2, 127, 127, -50);
   VLOAD_8(v3, 127, 10, 127);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vsmul.vv v1, v2, v3");
-  VCMP_I8(1, v1, 126, 10, -50);
+  VCMP_I8(1, v1, 126, 9, -50);
 }
 
 void TEST_CASE2() {
@@ -21,6 +22,7 @@ void TEST_CASE2() {
   VLOAD_8(v3, 127, 10, 127);
   VLOAD_8(v0, 5, 0, 0);
   VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vsmul.vv v1, v2, v3, v0.t");
   VCMP_I8(2, v1, 126, 0, -50);
 }
@@ -29,8 +31,9 @@ void TEST_CASE3() {
   VSET(3, e8, m1);
   VLOAD_8(v2, 127, 63, -50);
   int8_t scalar = 55;
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vsmul.vx v1, v2, %[A]" ::[A] "r"(scalar));
-  VCMP_I8(3, v1, 55, 27, -21);
+  VCMP_I8(3, v1, 54, 27, -22);
 }
 
 void TEST_CASE4() {
@@ -39,8 +42,9 @@ void TEST_CASE4() {
   int8_t scalar = 55;
   VLOAD_8(v0, 5, 0, 0);
   VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vsmul.vx v1, v2, %[A], v0.t" ::[A] "r"(scalar));
-  VCMP_I8(4, v1, 55, 0, -21);
+  VCMP_I8(4, v1, 54, 0, -22);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vsmul.c
+++ b/apps/riscv-tests/isa/rv64uv/vsmul.c
@@ -12,7 +12,7 @@ void TEST_CASE1() {
   VLOAD_8(v2, 127, 127, -50);
   VLOAD_8(v3, 127, 10, 127);
   __asm__ volatile("vsmul.vv v1, v2, v3");
-  VEC_CMP_8(1, v1, 126, 10, -50);
+  VCMP_I8(1, v1, 126, 10, -50);
 }
 
 void TEST_CASE2() {
@@ -20,9 +20,9 @@ void TEST_CASE2() {
   VLOAD_8(v2, 127, 127, -50);
   VLOAD_8(v3, 127, 10, 127);
   VLOAD_8(v0, 5, 0, 0);
-  CLEAR(v1);
+  VCLEAR(v1);
   __asm__ volatile("vsmul.vv v1, v2, v3, v0.t");
-  VEC_CMP_8(2, v1, 126, 0, -50);
+  VCMP_I8(2, v1, 126, 0, -50);
 }
 
 void TEST_CASE3() {
@@ -30,7 +30,7 @@ void TEST_CASE3() {
   VLOAD_8(v2, 127, 63, -50);
   int8_t scalar = 55;
   __asm__ volatile("vsmul.vx v1, v2, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_8(3, v1, 55, 27, -21);
+  VCMP_I8(3, v1, 55, 27, -21);
 }
 
 void TEST_CASE4() {
@@ -38,9 +38,9 @@ void TEST_CASE4() {
   VLOAD_8(v2, 127, 127, -50);
   int8_t scalar = 55;
   VLOAD_8(v0, 5, 0, 0);
-  CLEAR(v1);
+  VCLEAR(v1);
   __asm__ volatile("vsmul.vx v1, v2, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_8(4, v1, 55, 0, -21);
+  VCMP_I8(4, v1, 55, 0, -21);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssra.c
+++ b/apps/riscv-tests/isa/rv64uv/vssra.c
@@ -12,7 +12,7 @@ void TEST_CASE1() {
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   VLOAD_8(v3, 1, 2, 3, 4);
   __asm__ volatile("vssra.vv v1, v2, v3");
-  VEC_CMP_8(1, v1, 0, 0, 0xfe, 1);
+  VCMP_U8(1, v1, 0, 0, 0xfe, 0);
 }
 
 void TEST_CASE2() {
@@ -20,25 +20,25 @@ void TEST_CASE2() {
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   VLOAD_8(v3, 1, 2, 3, 4);
   VLOAD_8(v0, 5, 0, 0, 0);
-  CLEAR(v1);
+  VCLEAR(v1);
   __asm__ volatile("vssra.vv v1, v2, v3, v0.t");
-  VEC_CMP_8(2, v1, 0, 0, 0xfe, 0);
+  VCMP_I8(2, v1, 0, 0, 0xfe, 0);
 }
 
 void TEST_CASE3() {
   VSET(4, e8, m1);
-  VLOAD_U8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   __asm__ volatile("vssra.vi v1, v2, 2");
-  VEC_CMP_U8(3, v1, 0, 0, 0xfc, 4);
+  VCMP_I8(3, v1, 0, 0, 0xfc, 4);
 }
 
 void TEST_CASE4() {
   VSET(4, e8, m1);
-  VLOAD_U8(v2, 0xff, 0x00, 0xf0, 0x0f);
-  VLOAD_U8(v0, 5, 0, 0, 0);
-  CLEAR(v1);
+  VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  VLOAD_8(v0, 5, 0, 0, 0);
+  VCLEAR(v1);
   __asm__ volatile("vssra.vi v1, v2, 2, v0.t");
-  VEC_CMP_U8(4, v1, 0, 0, 0xfc, 0);
+  VCMP_I8(4, v1, 0, 0, 0xfc, 0);
 }
 
 void TEST_CASE5() {
@@ -46,7 +46,7 @@ void TEST_CASE5() {
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   uint64_t scalar = 2;
   __asm__ volatile("vssra.vx v1, v2, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_8(5, v1, 0, 0, 0xfc, 4);
+  VCMP_I8(5, v1, 0, 0, 0xfc, 4);
 }
 
 void TEST_CASE6() {
@@ -54,9 +54,9 @@ void TEST_CASE6() {
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   uint64_t scalar = 2;
   VLOAD_8(v0, 5, 0, 0, 0);
-  CLEAR(v1);
+  VCLEAR(v1);
   __asm__ volatile("vssra.vx v1, v2, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_8(6, v1, 0, 0, 0xfc, 0);
+  VCMP_I8(6, v1, 0, 0, 0xfc, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssra.c
+++ b/apps/riscv-tests/isa/rv64uv/vssra.c
@@ -11,8 +11,9 @@ void TEST_CASE1() {
   VSET(4, e8, m1);
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   VLOAD_8(v3, 1, 2, 3, 4);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssra.vv v1, v2, v3");
-  VCMP_U8(1, v1, 0, 0, 0xfe, 0);
+  VCMP_I8(1, v1, 0xff, 0, 0xfe, 0);
 }
 
 void TEST_CASE2() {
@@ -21,15 +22,17 @@ void TEST_CASE2() {
   VLOAD_8(v3, 1, 2, 3, 4);
   VLOAD_8(v0, 5, 0, 0, 0);
   VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssra.vv v1, v2, v3, v0.t");
-  VCMP_I8(2, v1, 0, 0, 0xfe, 0);
+  VCMP_I8(2, v1, 0xff, 0, 0xfe, 0);
 }
 
 void TEST_CASE3() {
   VSET(4, e8, m1);
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssra.vi v1, v2, 2");
-  VCMP_I8(3, v1, 0, 0, 0xfc, 4);
+  VCMP_I8(3, v1, 0xff, 0, 0xfc, 3);
 }
 
 void TEST_CASE4() {
@@ -37,16 +40,18 @@ void TEST_CASE4() {
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   VLOAD_8(v0, 5, 0, 0, 0);
   VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssra.vi v1, v2, 2, v0.t");
-  VCMP_I8(4, v1, 0, 0, 0xfc, 0);
+  VCMP_I8(4, v1, 0xff, 0, 0xfc, 0);
 }
 
 void TEST_CASE5() {
   VSET(4, e8, m1);
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   uint64_t scalar = 2;
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssra.vx v1, v2, %[A]" ::[A] "r"(scalar));
-  VCMP_I8(5, v1, 0, 0, 0xfc, 4);
+  VCMP_I8(5, v1, 0xff, 0, 0xfc, 3);
 }
 
 void TEST_CASE6() {
@@ -55,8 +60,9 @@ void TEST_CASE6() {
   uint64_t scalar = 2;
   VLOAD_8(v0, 5, 0, 0, 0);
   VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssra.vx v1, v2, %[A], v0.t" ::[A] "r"(scalar));
-  VCMP_I8(6, v1, 0, 0, 0xfc, 0);
+  VCMP_I8(6, v1, 0xff, 0, 0xfc, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssrl.c
+++ b/apps/riscv-tests/isa/rv64uv/vssrl.c
@@ -11,8 +11,9 @@ void TEST_CASE1() {
   VSET(4, e8, m1);
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   VLOAD_8(v3, 1, 2, 3, 4);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssrl.vv v1, v2, v3");
-  VCMP_U8(1, v1, 0x80, 0, 0x1e, 0x00);
+  VCMP_U8(1, v1, 0x7f, 0, 0x1e, 0x00);
 }
 
 void TEST_CASE2() {
@@ -21,13 +22,15 @@ void TEST_CASE2() {
   VLOAD_8(v3, 1, 2, 3, 4);
   VLOAD_8(v0, 5, 0, 0, 0);
   VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssrl.vv v1, v2, v3, v0.t");
-  VCMP_U8(2, v1, 0x80, 0, 0x1e, 0);
+  VCMP_U8(2, v1, 0x7f, 0, 0x1e, 0);
 }
 
 void TEST_CASE3() {
   VSET(4, e8, m1);
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssrl.vi v1, v2, 5");
   VCMP_U8(3, v1, 7, 0, 7, 0);
 }
@@ -37,6 +40,7 @@ void TEST_CASE4() {
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   VLOAD_8(v0, 5, 0, 0, 0);
   VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssrl.vi v1, v2, 5, v0.t");
   VCMP_U8(4, v1, 7, 0, 7, 0);
 }
@@ -45,6 +49,7 @@ void TEST_CASE5() {
   VSET(4, e8, m1);
   VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   uint64_t scalar = 5;
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssrl.vx v1, v2, %[A]" ::[A] "r"(scalar));
   VCMP_U8(5, v1, 7, 0, 7, 0);
 }
@@ -55,6 +60,7 @@ void TEST_CASE6() {
   uint64_t scalar = 5;
   VLOAD_8(v0, 5, 0, 0, 0);
   VCLEAR(v1);
+  __asm__ volatile("csrw vxrm, 2");
   __asm__ volatile("vssrl.vx v1, v2, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U8(6, v1, 7, 0, 7, 0);
 }

--- a/apps/riscv-tests/isa/rv64uv/vssrl.c
+++ b/apps/riscv-tests/isa/rv64uv/vssrl.c
@@ -9,54 +9,54 @@
 
 void TEST_CASE1() {
   VSET(4, e8, m1);
-  VLOAD_U8(v2, 0xff, 0x00, 0xf0, 0x0f);
-  VLOAD_U8(v3, 1, 2, 3, 4);
+  VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  VLOAD_8(v3, 1, 2, 3, 4);
   __asm__ volatile("vssrl.vv v1, v2, v3");
-  VEC_CMP_U8(1, v1, 0x80, 0, 0x1e, 0x01);
+  VCMP_U8(1, v1, 0x80, 0, 0x1e, 0x00);
 }
 
 void TEST_CASE2() {
   VSET(4, e8, m1);
-  VLOAD_U8(v2, 0xff, 0x00, 0xf0, 0x0f);
-  VLOAD_U8(v3, 1, 2, 3, 4);
-  VLOAD_U8(v0, 5, 0, 0, 0);
-  CLEAR(v1);
+  VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  VLOAD_8(v3, 1, 2, 3, 4);
+  VLOAD_8(v0, 5, 0, 0, 0);
+  VCLEAR(v1);
   __asm__ volatile("vssrl.vv v1, v2, v3, v0.t");
-  VEC_CMP_U8(2, v1, 0x80, 0, 0x1e, 0);
+  VCMP_U8(2, v1, 0x80, 0, 0x1e, 0);
 }
 
 void TEST_CASE3() {
   VSET(4, e8, m1);
-  VLOAD_U8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   __asm__ volatile("vssrl.vi v1, v2, 5");
-  VEC_CMP_U8(3, v1, 8, 0, 8, 0);
+  VCMP_U8(3, v1, 7, 0, 7, 0);
 }
 
 void TEST_CASE4() {
   VSET(4, e8, m1);
-  VLOAD_U8(v2, 0xff, 0x00, 0xf0, 0x0f);
-  VLOAD_U8(v0, 5, 0, 0, 0);
-  CLEAR(v1);
+  VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  VLOAD_8(v0, 5, 0, 0, 0);
+  VCLEAR(v1);
   __asm__ volatile("vssrl.vi v1, v2, 5, v0.t");
-  VEC_CMP_U8(4, v1, 8, 0, 8, 0);
+  VCMP_U8(4, v1, 7, 0, 7, 0);
 }
 
 void TEST_CASE5() {
   VSET(4, e8, m1);
-  VLOAD_U8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   uint64_t scalar = 5;
   __asm__ volatile("vssrl.vx v1, v2, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_U8(5, v1, 8, 0, 8, 0);
+  VCMP_U8(5, v1, 7, 0, 7, 0);
 }
 
 void TEST_CASE6() {
   VSET(4, e8, m1);
-  VLOAD_U8(v2, 0xff, 0x00, 0xf0, 0x0f);
+  VLOAD_8(v2, 0xff, 0x00, 0xf0, 0x0f);
   uint64_t scalar = 5;
-  VLOAD_U8(v0, 5, 0, 0, 0);
-  CLEAR(v1);
+  VLOAD_8(v0, 5, 0, 0, 0);
+  VCLEAR(v1);
   __asm__ volatile("vssrl.vx v1, v2, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U8(6, v1, 8, 0, 8, 0);
+  VCMP_U8(6, v1, 7, 0, 7, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssub.c
+++ b/apps/riscv-tests/isa/rv64uv/vssub.c
@@ -8,14 +8,18 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   __asm__ volatile("vssub.vv v3, v1, v2" ::);
   VCMP_U32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
+  read_vxsat(vxsat)
+  check_vxsat(1, vxsat, 1);
 }
 
 void TEST_CASE2(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
@@ -23,14 +27,19 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vssub.vv v3, v1, v2, v0.t" ::);
   VCMP_U32(1, v3, 0, 0x7fffffff, 0, -5);
+  read_vxsat(vxsat)
+  check_vxsat(2, vxsat, 1);
 }
 
 void TEST_CASE3(void) {
+  uint64_t vxsat;
   VSET(4, e32, m1);
   VLOAD_32(v1, 5, -2147483645, 15, 20);
   const int64_t scalar = 5;
   __asm__ volatile("vssub.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(3, v3, 0, 0x80000000, 10, 15);
+  read_vxsat(vxsat)
+  check_vxsat(3, vxsat, 1);
 }
 
 void TEST_CASE4(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssub.c
+++ b/apps/riscv-tests/isa/rv64uv/vssub.c
@@ -12,7 +12,7 @@ void TEST_CASE1(void) {
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   __asm__ volatile("vssub.vv v3, v1, v2" ::);
-  VEC_CMP_32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
+  VCMP_U32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
 }
 
 void TEST_CASE2(void) {
@@ -20,9 +20,9 @@ void TEST_CASE2(void) {
   VLOAD_32(v1, 0xfffffff0, 0x7FFFFFFC, 15, 20);
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   VLOAD_32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vssub.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_32(1, v3, 0, 0x7fffffff, 0, -5);
+  VCMP_U32(1, v3, 0, 0x7fffffff, 0, -5);
 }
 
 void TEST_CASE3(void) {
@@ -30,7 +30,7 @@ void TEST_CASE3(void) {
   VLOAD_32(v1, 5, -2147483645, 15, 20);
   const int64_t scalar = 5;
   __asm__ volatile("vssub.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_32(3, v3, 0, 0x80000000, 10, 15);
+  VCMP_U32(3, v3, 0, 0x80000000, 10, 15);
 }
 
 void TEST_CASE4(void) {
@@ -38,9 +38,9 @@ void TEST_CASE4(void) {
   VLOAD_32(v1, 5, -2147483645, 15, 20);
   const int64_t scalar = 5;
   VLOAD_32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VCLEAR(v3);
   __asm__ volatile("vssub.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_32(4, v3, 0, 0x80000000, 0, 15);
+  VCMP_U32(4, v3, 0, 0x80000000, 0, 15);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssub.c
+++ b/apps/riscv-tests/isa/rv64uv/vssub.c
@@ -14,7 +14,7 @@ void TEST_CASE1(void) {
   VLOAD_32(v2, 0x7ffffff0, -500, 3, 25);
   __asm__ volatile("vssub.vv v3, v1, v2" ::);
   VCMP_U32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(1, vxsat, 1);
   reset_vxsat;
 }
@@ -28,7 +28,7 @@ void TEST_CASE2(void) {
   VCLEAR(v3);
   __asm__ volatile("vssub.vv v3, v1, v2, v0.t" ::);
   VCMP_U32(1, v3, 0, 0x7fffffff, 0, -5);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(2, vxsat, 1);
   reset_vxsat;
 }
@@ -40,7 +40,7 @@ void TEST_CASE3(void) {
   const int64_t scalar = 5;
   __asm__ volatile("vssub.vx v3, v1, %[A]" ::[A] "r"(scalar));
   VCMP_U32(3, v3, 0, 0x80000000, 10, 15);
-  read_vxsat(vxsat)
+  read_vxsat(vxsat);
   check_vxsat(3, vxsat, 1);
   reset_vxsat;
 }

--- a/apps/riscv-tests/isa/rv64uv/vssub.c
+++ b/apps/riscv-tests/isa/rv64uv/vssub.c
@@ -16,6 +16,7 @@ void TEST_CASE1(void) {
   VCMP_U32(1, v3, 0x80000000, 0x7fffffff, 12, -5);
   read_vxsat(vxsat)
   check_vxsat(1, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE2(void) {
@@ -29,6 +30,7 @@ void TEST_CASE2(void) {
   VCMP_U32(1, v3, 0, 0x7fffffff, 0, -5);
   read_vxsat(vxsat)
   check_vxsat(2, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE3(void) {
@@ -40,6 +42,7 @@ void TEST_CASE3(void) {
   VCMP_U32(3, v3, 0, 0x80000000, 10, 15);
   read_vxsat(vxsat)
   check_vxsat(3, vxsat, 1);
+  reset_vxsat;
 }
 
 void TEST_CASE4(void) {
@@ -50,6 +53,7 @@ void TEST_CASE4(void) {
   VCLEAR(v3);
   __asm__ volatile("vssub.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
   VCMP_U32(4, v3, 0, 0x80000000, 0, 15);
+  reset_vxsat;
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vssubu.c
+++ b/apps/riscv-tests/isa/rv64uv/vssubu.c
@@ -9,38 +9,38 @@
 
 void TEST_CASE1(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
-  VLOAD_U32(v2, 1, 2, 3, 25);
+  VLOAD_32(v1, 5, 10, 15, 20);
+  VLOAD_32(v2, 1, 2, 3, 25);
   __asm__ volatile("vssubu.vv v3, v1, v2" ::);
-  VEC_CMP_U32(1, v3, 4, 8, 12, 0);
+  VCMP_U32(1, v3, 4, 8, 12, 0);
 }
 
 void TEST_CASE2(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 10, 15, 20);
-  VLOAD_U32(v2, 1, 2, 3, 120);
-  VLOAD_U32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VLOAD_32(v1, 5, 10, 15, 20);
+  VLOAD_32(v2, 1, 2, 3, 120);
+  VLOAD_32(v0, 10, 0, 0, 0);
+  VCLEAR(v3);
   __asm__ volatile("vssubu.vv v3, v1, v2, v0.t" ::);
-  VEC_CMP_U32(2, v3, 0, 8, 0, 0);
+  VCMP_U32(2, v3, 0, 8, 0, 0);
 }
 
 void TEST_CASE3(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 1, 15, 20);
+  VLOAD_32(v1, 5, 1, 15, 20);
   const uint64_t scalar = 5;
   __asm__ volatile("vssubu.vx v3, v1, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_U32(3, v3, 0, 0, 10, 15);
+  VCMP_U32(3, v3, 0, 0, 10, 15);
 }
 
 void TEST_CASE4(void) {
   VSET(4, e32, m1);
-  VLOAD_U32(v1, 5, 1, 15, 20);
+  VLOAD_32(v1, 5, 1, 15, 20);
   const uint64_t scalar = 5;
-  VLOAD_U32(v0, 10, 0, 0, 0);
-  CLEAR(v3);
+  VLOAD_32(v0, 10, 0, 0, 0);
+  VCLEAR(v3);
   __asm__ volatile("vssubu.vx v3, v1, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_U32(4, v3, 0, 0, 0, 15);
+  VCMP_U32(4, v3, 0, 0, 0, 15);
 }
 
 int main(void) {

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -101,7 +101,7 @@ package ara_pkg;
     // Arithmetic and logic instructions
     VADD, VSUB, VADC, VSBC, VRSUB, VMINU, VMIN, VMAXU, VMAX, VAND, VOR, VXOR,
     // Fixed point
-    VSADDU, VSADD, VSSUBU, VSSUB, VAADDU, VAADD, VASUBU, VASUB,
+    VSADDU, VSADD, VSSUBU, VSSUB, VAADDU, VAADD, VASUBU, VASUB, VSSRL, VSSRA, VNCLIP, VNCLIPU,
     // Shifts,
     VSLL, VSRL, VSRA, VNSRL, VNSRA,
     // Merge
@@ -112,6 +112,8 @@ package ara_pkg;
     VREDSUM, VREDAND, VREDOR, VREDXOR, VREDMINU, VREDMIN, VREDMAXU, VREDMAX, VWREDSUMU, VWREDSUM,
     // Mul/Mul-Add
     VMUL, VMULH, VMULHU, VMULHSU, VMACC, VNMSAC, VMADD, VNMSUB,
+    // Fixed point multiplication
+    VSMUL,
     // Div
     VDIVU, VDIV, VREMU, VREM,
     // FPU
@@ -833,18 +835,18 @@ package ara_pkg;
   endfunction : deshuffle_index
 
   /////////////////////////
-  //  Fixed-Point        //
+  ////// Fixed-Point //////
   /////////////////////////
 
-  typedef logic                       vxsat_t;
-  typedef logic [1:0]                 vxrm_t;
+  typedef logic        vxsat_e;
+  typedef logic [1:0]  vxrm_t;
 
   typedef union packed {
     logic [0:0][7:0] w64;
     logic [1:0][3:0] w32;
     logic [3:0][1:0] w16;
     logic [7:0][0:0] w8;
-  } alu_vxsat_t;
+  } vxsat_t;
 
   /////////////////////////
   //  MASKU definitions  //

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -103,7 +103,7 @@ package ara_pkg;
   //  Operations  //
   //////////////////
 
-  typedef enum logic [6:0] {
+  typedef enum logic [7:0] {
     // Arithmetic and logic instructions
     VADD, VSUB, VADC, VSBC, VRSUB, VMINU, VMIN, VMAXU, VMAX, VAND, VOR, VXOR,
     // Fixed point

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -32,6 +32,12 @@ package ara_pkg;
 
   // Ara Features.
 
+  // Fixed-point support
+  typedef enum logic {
+    FixedPointDisable = 1'b0,
+    FixedPointEnable  = 1'b1
+  } fixpt_support_e;
+
   // The three bits correspond to {RVVD, RVVF, RVVH}
   typedef enum logic [2:0] {
     FPUSupportNone             = 3'b000,

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -91,7 +91,6 @@ package ara_pkg;
 
   typedef logic [$clog2(MAXVL+1)-1:0] vlen_t;
   typedef logic [$clog2(NrVInsn)-1:0] vid_t;
-
   typedef logic [ELEN-1:0] elen_t;
 
   //////////////////
@@ -101,6 +100,8 @@ package ara_pkg;
   typedef enum logic [6:0] {
     // Arithmetic and logic instructions
     VADD, VSUB, VADC, VSBC, VRSUB, VMINU, VMIN, VMAXU, VMAX, VAND, VOR, VXOR,
+    // Fixed point
+    VSADDU, VSADD, VSSUBU, VSSUB, VAADDU, VAADD, VASUBU, VASUB,
     // Shifts,
     VSLL, VSRL, VSRA, VNSRL, VNSRA,
     // Merge
@@ -830,6 +831,20 @@ package ara_pkg;
       end
     endcase
   endfunction : deshuffle_index
+
+  /////////////////////////
+  //  Fixed-Point        //
+  /////////////////////////
+
+  typedef logic                       vxsat_t;
+  typedef logic [1:0]                 vxrm_t;
+
+  typedef union packed {
+    logic [0:0][7:0] w64;
+    logic [1:0][3:0] w32;
+    logic [3:0][1:0] w16;
+    logic [7:0][0:0] w8;
+  } alu_vxsat_t;
 
   /////////////////////////
   //  MASKU definitions  //

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -11,6 +11,8 @@ module ara import ara_pkg::*; #(
     parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    // Support for fixed-point data types
+    parameter  logic                  FixPtSupport = FixedPointEnable,
     // AXI Interface
     parameter  int           unsigned AxiDataWidth = 0,
     parameter  int           unsigned AxiAddrWidth = 0,
@@ -232,8 +234,9 @@ module ara import ara_pkg::*; #(
 
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
-      .NrLanes   (NrLanes   ),
-      .FPUSupport(FPUSupport)
+      .NrLanes     (NrLanes     ),
+      .FPUSupport  (FPUSupport  ),
+      .FixPtSupport(FixPtSupport)
     ) i_lane (
       .clk_i                           (clk_i                               ),
       .rst_ni                          (rst_ni                              ),

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -82,6 +82,7 @@ module ara import ara_pkg::*; #(
   logic      [NrLanes-1:0][4:0] fflags_ex;
   logic      [NrLanes-1:0]      fflags_ex_valid;
   logic      [NrLanes-1:0]      vxsat_flag;
+  vxrm_t     [NrLanes-1:0]      alu_vxrm;
 
   ara_dispatcher #(
     .NrLanes(NrLanes)
@@ -104,6 +105,7 @@ module ara import ara_pkg::*; #(
     .ara_idle_i        (ara_idle        ),
     // Interface with the lanes
     .vxsat_flag_i      (vxsat_flag      ),
+    .alu_vxrm_o        (alu_vxrm        ),
     .fflags_ex_i       (fflags_ex       ),
     .fflags_ex_valid_i (fflags_ex_valid ),
     // Interface with the Vector Store Unit
@@ -241,6 +243,7 @@ module ara import ara_pkg::*; #(
       .lane_id_i                       (lane[idx_width(NrLanes)-1:0]        ),
       // Interface with the dispatcher
       .vxsat_flag_o                    (vxsat_flag[lane]                    ),
+      .alu_vxrm_i                      (alu_vxrm[lane]                      ),
       .fflags_ex_o                     (fflags_ex[lane]                     ),
       .fflags_ex_valid_o               (fflags_ex_valid[lane]               ),
       // Interface with the sequencer

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -81,34 +81,36 @@ module ara import ara_pkg::*; #(
   // Interface with the lanes
   logic      [NrLanes-1:0][4:0] fflags_ex;
   logic      [NrLanes-1:0]      fflags_ex_valid;
+  logic      [NrLanes-1:0]      vxsat_flag;
 
   ara_dispatcher #(
     .NrLanes(NrLanes)
   ) i_dispatcher (
-    .clk_i            (clk_i           ),
-    .rst_ni           (rst_ni          ),
+    .clk_i             (clk_i           ),
+    .rst_ni            (rst_ni          ),
     // Interface with Ariane
-    .acc_req_i        (acc_req_i       ),
-    .acc_req_valid_i  (acc_req_valid_i ),
-    .acc_req_ready_o  (acc_req_ready_o ),
-    .acc_resp_o       (acc_resp_o      ),
-    .acc_resp_valid_o (acc_resp_valid_o),
-    .acc_resp_ready_i (acc_resp_ready_i),
+    .acc_req_i         (acc_req_i       ),
+    .acc_req_valid_i   (acc_req_valid_i ),
+    .acc_req_ready_o   (acc_req_ready_o ),
+    .acc_resp_o        (acc_resp_o      ),
+    .acc_resp_valid_o  (acc_resp_valid_o),
+    .acc_resp_ready_i  (acc_resp_ready_i),
     // Interface with the sequencer
-    .ara_req_o        (ara_req         ),
-    .ara_req_valid_o  (ara_req_valid   ),
-    .ara_req_ready_i  (ara_req_ready   ),
-    .ara_resp_i       (ara_resp        ),
-    .ara_resp_valid_i (ara_resp_valid  ),
-    .ara_idle_i       (ara_idle        ),
+    .ara_req_o         (ara_req         ),
+    .ara_req_valid_o   (ara_req_valid   ),
+    .ara_req_ready_i   (ara_req_ready   ),
+    .ara_resp_i        (ara_resp        ),
+    .ara_resp_valid_i  (ara_resp_valid  ),
+    .ara_idle_i        (ara_idle        ),
     // Interface with the lanes
-    .fflags_ex_i      (fflags_ex       ),
-    .fflags_ex_valid_i(fflags_ex_valid ),
+    .vxsat_flag_i      (vxsat_flag      ),
+    .fflags_ex_i       (fflags_ex       ),
+    .fflags_ex_valid_i (fflags_ex_valid ),
     // Interface with the Vector Store Unit
-    .core_st_pending_o(core_st_pending ),
-    .load_complete_i  (load_complete   ),
-    .store_complete_i (store_complete  ),
-    .store_pending_i  (store_pending   )
+    .core_st_pending_o (core_st_pending ),
+    .load_complete_i   (load_complete   ),
+    .store_complete_i  (store_complete  ),
+    .store_pending_i   (store_pending   )
   );
 
   /////////////////
@@ -238,6 +240,7 @@ module ara import ara_pkg::*; #(
       .scan_data_o                     (/* Unused */                        ),
       .lane_id_i                       (lane[idx_width(NrLanes)-1:0]        ),
       // Interface with the dispatcher
+      .vxsat_flag_o                    (vxsat_flag[lane]                    ),
       .fflags_ex_o                     (fflags_ex[lane]                     ),
       .fflags_ex_valid_o               (fflags_ex_valid[lane]               ),
       // Interface with the sequencer

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -36,7 +36,6 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     input  logic              [NrLanes-1:0]      vxsat_flag_i,
     output vxrm_t             [NrLanes-1:0]      alu_vxrm_o,
     // Rounding mode is shared between all lanes
-
     // Interface with the Vector Store Unit
     output logic                                 core_st_pending_o,
     input  logic                                 load_complete_i,

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -33,9 +33,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     // Interface with the lanes
     input  logic              [NrLanes-1:0][4:0] fflags_ex_i,
     input  logic              [NrLanes-1:0]      fflags_ex_valid_i,
+    // Rounding mode is shared between all lanes
     input  logic              [NrLanes-1:0]      vxsat_flag_i,
     output vxrm_t             [NrLanes-1:0]      alu_vxrm_o,
-    // Rounding mode is shared between all lanes
     // Interface with the Vector Store Unit
     output logic                                 core_st_pending_o,
     input  logic                                 load_complete_i,

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -278,7 +278,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
     // Saturation in any lane will raise vxsat flag
     vxsat_d = |vxsat_flag_i;
-    alu_vxrm_o = vxrm_q;
+    // Fixed-point rounding mode is applied to all lanes
+    for (int lane = 0; lane < NrLanes; lane++) alu_vxrm_o[lane] = vxrm_q;
     // Rounding mode is shared between all lanes
     for (int lane = 0; lane < NrLanes; lane++) acc_resp_o.fflags |= fflags_ex_i[lane];
     // Special states

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -9,9 +9,11 @@
 // response or an error message.
 
 module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int           unsigned NrLanes    = 0,
+    parameter int           unsigned NrLanes      = 0,
     // Support for floating-point data types
-    parameter fpu_support_e          FPUSupport = FPUSupportHalfSingleDouble
+    parameter fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    // Support for fixed-point data types
+    parameter logic                  FixPtSupport = FixedPointEnable
   ) (
     // Clock and reset
     input  logic                                 clk_i,
@@ -2952,6 +2954,11 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
           end
         endcase
       end
+
+      // Check that we have fixed-point support if requested
+      // vxsat and vxrm are always accessible anyway
+      if (ara_req_valid_d && (ara_req_d.op inside {[VSADDU:VNCLIPU], VSMUL}) && (FixPtSupport == FixedPointDisable))
+        illegal_insn = 1'b1;
 
       // Check if we need to reshuffle our vector registers involved in the operation
       // This operation is costly when occurs, so avoid it if possible

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -34,6 +34,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     input  logic              [NrLanes-1:0][4:0] fflags_ex_i,
     input  logic              [NrLanes-1:0]      fflags_ex_valid_i,
     input  logic              [NrLanes-1:0]      vxsat_flag_i,
+    output vxrm_t             [NrLanes-1:0]      alu_vxrm_o,
+    // Rounding mode is shared between all lanes
+
     // Interface with the Vector Store Unit
     output logic                                 core_st_pending_o,
     input  logic                                 load_complete_i,
@@ -275,6 +278,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
     // Saturation in any lane will raise vxsat flag
     vxsat_d = |vxsat_flag_i;
+    alu_vxrm_o = vxrm_q;
+    // Rounding mode is shared between all lanes
+    for (int lane = 0; lane < NrLanes; lane++) acc_resp_o.fflags |= fflags_ex_i[lane];
     // Special states
     case (state_q)
       // Is Ara idle?
@@ -2749,11 +2755,11 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     acc_resp_o.result = vstart_q;
                   end
                   riscv::CSR_VXRM: begin
-                    vxrm_d            = acc_req_i.rs1[1:0];
+                    vxrm_d            = vxrm_t'(acc_req_i.rs1[1:0]);
                     acc_resp_o.result = vlen_t'(vxrm_q);
                   end
                   riscv::CSR_VXSAT: begin
-                    vxsat_d           = acc_req_i.rs1[0];
+                    vxsat_d           = vxsat_t'(acc_req_i.rs1[0]);
                     acc_resp_o.result = vlen_t'(vxsat_q);
                   end
                   default: acc_resp_o.error = 1'b1;
@@ -2786,7 +2792,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     acc_resp_o.result = vlen_t'(vxrm_q);
                   end
                   riscv::CSR_VXSAT: begin
-                    vxsat_d           = vxsat_q | vlen_t'(acc_req_i.rs1[0]);
+                    vxsat_d           = vxsat_q | vxsat_t'(acc_req_i.rs1[0]);
                     acc_resp_o.result = vlen_t'(vxsat_q);
                   end
                   default: acc_resp_o.error = 1'b1;
@@ -2814,6 +2820,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
                     else acc_resp_o.error                                 = 1'b1;
                   end
+                  riscv::CSR_VXSAT: begin
+                    vxsat_d           = vxsat_q & ~vxsat_t'(acc_req_i.rs1[0]);
+                    acc_resp_o.result = vxsat_q;
+                  end
                   default: acc_resp_o.error = 1'b1;
                 endcase
               end
@@ -2826,8 +2836,12 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     acc_resp_o.result = vstart_q;
                   end
                   riscv::CSR_VXRM: begin
-                    vxrm_d            = vxrm_t'(acc_req_i.insn.itype.rs1[1:0]);
+                    vxrm_d            = vxrm_t'(acc_req_i.rs1[1:0]);
                     acc_resp_o.result = vlen_t'(vxrm_q);
+                  end
+                  riscv::CSR_VXSAT: begin
+                    vxsat_d           = acc_req_i.insn.itype.rs1[0];
+                    acc_resp_o.result = vxsat_q;
                   end
                   default: acc_resp_o.error = 1'b1;
                 endcase
@@ -2854,6 +2868,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
                     else acc_resp_o.error                                 = 1'b1;
                   end
+                  riscv::CSR_VXSAT: begin
+                    vxsat_d           = vxsat_q | vxsat_t'(acc_req_i.insn.itype.rs1[0]);
+                    acc_resp_o.result = vxsat_q;
+                  end
                   default: acc_resp_o.error = 1'b1;
                 endcase
               end
@@ -2878,6 +2896,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     // Only reads are allowed
                     if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
                     else acc_resp_o.error                                 = 1'b1;
+                  end
+                  riscv::CSR_VXSAT: begin
+                    vxsat_d           = vxsat_q & ~vxsat_t'(acc_req_i.insn.itype.rs1[0]);
+                    acc_resp_o.result = vxsat_q;
                   end
                   default: acc_resp_o.error = 1'b1;
                 endcase

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -33,6 +33,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     // Interface with the lanes
     input  logic              [NrLanes-1:0][4:0] fflags_ex_i,
     input  logic              [NrLanes-1:0]      fflags_ex_valid_i,
+    input  logic              [NrLanes-1:0]      vxsat_flag_i,
     // Interface with the Vector Store Unit
     output logic                                 core_st_pending_o,
     input  logic                                 load_complete_i,
@@ -53,11 +54,14 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
   vlen_t  vstart_d, vstart_q;
   vlen_t  vl_d, vl_q;
   vtype_t vtype_d, vtype_q;
+  vxsat_t vxsat_d, vxsat_q;
+  vxrm_t  vxrm_d, vxrm_q;
 
   `FF(vstart_q, vstart_d, '0)
   `FF(vl_q, vl_d, '0)
   `FF(vtype_q, vtype_d, '{vill: 1'b1, default: '0})
-
+  `FF(vxsat_q, vxsat_d, '0)
+  `FF(vxrm_q, vxrm_d, '0)
   // Converts between the internal representation of `vtype_t` and the full XLEN-bit CSR.
   function automatic riscv::xlen_t xlen_vtype(vtype_t vtype);
     xlen_vtype = {vtype.vill, {riscv::XLEN-9{1'b0}}, vtype.vma, vtype.vta, vtype.vsew,
@@ -220,6 +224,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     vs_buffer_d      = vs_buffer_q;
 
     illegal_insn = 1'b0;
+    vxsat_d      = vxsat_q;
 
     is_vload      = 1'b0;
     is_vstore     = 1'b0;
@@ -268,6 +273,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     // The token must change at every new instruction
     ara_req_d.token = (ara_req_valid_o && ara_req_ready_i) ? ~ara_req_o.token : ara_req_o.token;
 
+    // Saturation in any lane will raise vxsat flag
+    vxsat_d = |vxsat_flag_i;
     // Special states
     case (state_q)
       // Is Ara idle?
@@ -544,6 +551,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.op      = ara_pkg::VMERGE;
                     ara_req_d.use_vs2 = !insn.varith_type.vm; // vmv.v.v does not use vs2
                   end
+                  6'b100000: ara_req_d.op = ara_pkg::VSADDU;
+                  6'b100001: ara_req_d.op = ara_pkg::VSADD;
+                  6'b100010: ara_req_d.op = ara_pkg::VSSUBU;
+                  6'b100011: ara_req_d.op = ara_pkg::VSSUB;
                   6'b100101: ara_req_d.op = ara_pkg::VSLL;
                   6'b101000: ara_req_d.op = ara_pkg::VSRL;
                   6'b101001: ara_req_d.op = ara_pkg::VSRA;
@@ -761,6 +772,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.op      = ara_pkg::VMERGE;
                     ara_req_d.use_vs2 = !insn.varith_type.vm; // vmv.v.x does not use vs2
                   end
+                  6'b100000: ara_req_d.op = ara_pkg::VSADDU;
+                  6'b100001: ara_req_d.op = ara_pkg::VSADD;
+                  6'b100010: ara_req_d.op = ara_pkg::VSSUBU;
+                  6'b100011: ara_req_d.op = ara_pkg::VSSUB;
                   6'b100101: ara_req_d.op = ara_pkg::VSLL;
                   6'b101000: ara_req_d.op = ara_pkg::VSRL;
                   6'b101001: ara_req_d.op = ara_pkg::VSRA;
@@ -916,6 +931,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.op      = ara_pkg::VMERGE;
                     ara_req_d.use_vs2 = !insn.varith_type.vm; // vmv.v.i does not use vs2
                   end
+                  6'b100000: ara_req_d.op = ara_pkg::VSADDU;
+                  6'b100001: ara_req_d.op = ara_pkg::VSADD;
                   6'b100101: ara_req_d.op = ara_pkg::VSLL;
                   6'b100111: begin // vmv<nr>r.v
                     automatic int unsigned vlmax;
@@ -1135,6 +1152,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       5'b10001: ara_req_d.op = ara_pkg::VID;
                     endcase
                   end
+                  6'b001000: ara_req_d.op = ara_pkg::VAADDU;
+                  6'b001001: ara_req_d.op = ara_pkg::VAADD;
+                  6'b001010: ara_req_d.op = ara_pkg::VASUBU;
+                  6'b001011: ara_req_d.op = ara_pkg::VASUB;
                   6'b011000: begin
                     ara_req_d.op        = ara_pkg::VMANDNOT;
                     ara_req_d.use_vd_op = 1'b1;
@@ -1437,6 +1458,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Decode based on the func6 field
                 unique case (insn.varith_type.func6)
+                  6'b001000: ara_req_d.op = ara_pkg::VAADDU;
+                  6'b001001: ara_req_d.op = ara_pkg::VAADD;
+                  6'b001010: ara_req_d.op = ara_pkg::VASUBU;
+                  6'b001011: ara_req_d.op = ara_pkg::VASUB;
                   // Slides
                   6'b001110: begin // vslide1up
                     ara_req_d.op      = ara_pkg::VSLIDEUP;
@@ -2723,6 +2748,14 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     vstart_d          = acc_req_i.rs1;
                     acc_resp_o.result = vstart_q;
                   end
+                  riscv::CSR_VXRM: begin
+                    vxrm_d            = acc_req_i.rs1[1:0];
+                    acc_resp_o.result = vlen_t'(vxrm_q);
+                  end
+                  riscv::CSR_VXSAT: begin
+                    vxsat_d           = acc_req_i.rs1[0];
+                    acc_resp_o.result = vlen_t'(vxsat_q);
+                  end
                   default: acc_resp_o.error = 1'b1;
                 endcase
               end
@@ -2747,6 +2780,14 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     // Only reads are allowed
                     if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
                     else acc_resp_o.error                                 = 1'b1;
+                  end
+                  riscv::CSR_VXRM: begin
+                    vxrm_d            = vxrm_q | vlen_t'(acc_req_i.rs1[1:0]);
+                    acc_resp_o.result = vlen_t'(vxrm_q);
+                  end
+                  riscv::CSR_VXSAT: begin
+                    vxsat_d           = vxsat_q | vlen_t'(acc_req_i.rs1[0]);
+                    acc_resp_o.result = vlen_t'(vxsat_q);
                   end
                   default: acc_resp_o.error = 1'b1;
                 endcase
@@ -2783,6 +2824,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   riscv::CSR_VSTART: begin
                     vstart_d          = vlen_t'(acc_req_i.insn.itype.rs1);
                     acc_resp_o.result = vstart_q;
+                  end
+                  riscv::CSR_VXRM: begin
+                    vxrm_d            = vxrm_t'(acc_req_i.insn.itype.rs1[1:0]);
+                    acc_resp_o.result = vlen_t'(vxrm_q);
                   end
                   default: acc_resp_o.error = 1'b1;
                 endcase

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -11,6 +11,8 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    // Support for fixed-point data types
+    parameter  logic                  FixPtSupport = FixedPointEnable,
     // AXI Interface
     parameter  int           unsigned AxiDataWidth = 32*NrLanes,
     parameter  int           unsigned AxiAddrWidth = 64,
@@ -442,6 +444,7 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   ara_system #(
     .NrLanes           (NrLanes              ),
     .FPUSupport        (FPUSupport           ),
+    .FixPtSupport      (FixPtSupport         ),
     .ArianeCfg         (ArianeAraConfig      ),
     .AxiAddrWidth      (AxiAddrWidth         ),
     .AxiIdWidth        (AxiCoreIdWidth       ),

--- a/hardware/src/ara_system.sv
+++ b/hardware/src/ara_system.sv
@@ -11,6 +11,8 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
     parameter int                      unsigned NrLanes            = 0,                               // Number of parallel vector lanes.
     // Support for floating-point data types
     parameter fpu_support_e                     FPUSupport         = FPUSupportHalfSingleDouble,
+    // Support for fixed-point data types
+    parameter  logic                            FixPtSupport       = FixedPointEnable,
     // Ariane configuration
     parameter ariane_pkg::ariane_cfg_t          ArianeCfg          = ariane_pkg::ArianeDefaultConfig,
     // AXI Interface

--- a/hardware/src/lane/fixed_p_rounding.sv
+++ b/hardware/src/lane/fixed_p_rounding.sv
@@ -1,0 +1,180 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Muhammad Ijaz
+// Description:
+// Ara's fixed point rounding module, operating on elements 64-bit wide, and generating rounding r for each stream of elements.
+
+module fixed_p_rounding import ara_pkg::*; import rvv_pkg::*; #(
+    // Dependant parameters. DO NOT CHANGE!
+    localparam int  unsigned DataWidth = $bits(elen_t),
+    localparam int  unsigned StrbWidth = DataWidth/8,
+    localparam type          strb_t    = logic [StrbWidth-1:0]
+  ) (
+    input  elen_t   operand_a_i,
+    input  elen_t   operand_b_i,
+    input  logic    valid_i,
+    input  ara_op_e op_i,
+    input  vew_e    vew_i,
+    input  vxrm_t   vxrm_i,
+    output strb_t   r
+  );
+
+  /////////////////
+  // Definitions //
+  /////////////////
+
+  typedef union packed {
+    logic [0:0][63:0] w64;
+    logic [1:0][31:0] w32;
+    logic [3:0][15:0] w16;
+    logic [7:0][ 7:0] w8;
+  } rounding_args;
+
+  rounding_args opa, opb;
+  assign opa = operand_a_i;
+  assign opb = operand_b_i;
+
+  vxrm_t vxrm;
+  assign vxrm = vxrm_i;
+
+  elen_t [DataWidth-1:0] bit_select;
+  int j;
+
+  always_comb begin
+    if (valid_i) begin
+      unique case (op_i)
+        VSSRA, VSSRL, VNCLIP, VNCLIPU : begin
+          unique case (vew_i)
+            EW8 : begin
+              unique case (vxrm)
+                2'b00: begin
+                  for (int i=0; i<8; i++) begin
+                    j    = opa.w8[i];
+                    r[i] = opb.w8[i][j-1];
+                  end
+                end
+                2'b01: begin
+                  for (int i=0; i<8; i++) begin
+                    j    = opa.w8[i];
+                    r[i] = opb.w8[i][j-1] & opb.w8[i][j];
+                  end
+                end
+                2'b10: begin
+                  r = '0;
+                end
+                2'b11: begin
+                  for (int i=0; i<8; i++) begin
+                    j    = opa.w8[i];
+                    r[i] = !opb.w8[i][j] & |(opb.w8[i] & bit_select);
+                  end
+                end
+              endcase
+            end
+            EW16: begin
+              unique case (vxrm)
+                2'b00: begin
+                  for (int i=0; i<4; i++) begin
+                    j    = opa.w16[i];
+                    r[i] = opb.w16[i][j-1];
+                  end
+                end
+                2'b01: begin
+                  for (int i=0; i<4; i++) begin
+                    j    = opa.w16[i];
+                    r[i] = opb.w16[i][j-1] & opb.w16[i][j];
+                  end
+                end
+                2'b10: begin
+                  r = '0;
+                end
+                2'b11: begin
+                  for (int i=0; i<4; i++) begin
+                    j    = opa.w16[i];
+                    r[i] = !opb.w16[i][j] & |(opb.w16[i] & bit_select);
+                  end
+                end
+              endcase
+            end
+            EW32: begin
+              unique case (vxrm)
+                2'b00: begin
+                  for (int i=0; i<2; i++) begin
+                    j    = opa.w32[i];
+                    r[i] = opb.w32[i][j-1];
+                  end
+                end
+                2'b01: begin
+                  for (int i=0; i<2; i++) begin
+                    j    = opa.w32[i];
+                    r[i] = opb.w32[i][j-1] & opb.w32[i][j];
+                  end
+                end
+                2'b10: begin
+                  r = '0;
+                end
+                2'b11: begin
+                  for (int i=0; i<2; i++) begin
+                    j    = opa.w32[i];
+                    r[i] = !opb.w32[i][j] & |(opb.w32[i] & bit_select);
+                  end
+                end
+              endcase
+            end
+            EW64: begin
+              unique case (vxrm)
+                2'b00: begin
+                  for (int i=0; i<1; i++) begin
+                    j    = opa.w64[i];
+                    r[i] = opb.w64[i][j-1];
+                  end
+                end
+                2'b01: begin
+                  for (int i=0; i<1; i++) begin
+                    j    = opa.w64[i];
+                    r[i] = opb.w64[i][j-1] & opb.w64[i][j];
+                  end
+                end
+                2'b10: begin
+                  r = '0;
+                end
+                2'b11: begin
+                  for (int i=0; i<1; i++) begin
+                    j    = opa.w64[i];
+                    r[i] = !opb.w64[i][j] & |(opb.w64[i] & bit_select);
+                  end
+                end
+              endcase
+            end
+          endcase
+        end
+        default: r=0;
+      endcase
+    end else begin
+      r = '0;
+    end
+  end
+
+  //////////////////
+  // Lookup Table //
+  //////////////////
+
+  assign bit_select = {64'h0000000000000000, 64'h0000000000000001, 64'h0000000000000003, 64'h0000000000000007,
+                       64'h000000000000000F, 64'h000000000000001F, 64'h000000000000003F, 64'h000000000000007F,
+                       64'h00000000000000FF, 64'h00000000000001FF, 64'h00000000000003FF, 64'h00000000000007FF,
+                       64'h0000000000000FFF, 64'h0000000000001FFF, 64'h0000000000003FFF, 64'h0000000000007FFF,
+                       64'h000000000000FFFF, 64'h000000000001FFFF, 64'h000000000003FFFF, 64'h000000000007FFFF,
+                       64'h00000000000FFFFF, 64'h00000000001FFFFF, 64'h00000000003FFFFF, 64'h00000000007FFFFF,
+                       64'h0000000000FFFFFF, 64'h0000000001FFFFFF, 64'h0000000003FFFFFF, 64'h0000000007FFFFFF,
+                       64'h000000000FFFFFFF, 64'h000000001FFFFFFF, 64'h000000003FFFFFFF, 64'h000000007FFFFFFF,
+                       64'h00000000FFFFFFFF, 64'h00000001FFFFFFFF, 64'h00000003FFFFFFFF, 64'h00000007FFFFFFFF,
+                       64'h0000000FFFFFFFFF, 64'h0000001FFFFFFFFF, 64'h0000003FFFFFFFFF, 64'h0000007FFFFFFFFF,
+                       64'h000000FFFFFFFFFF, 64'h000001FFFFFFFFFF, 64'h000003FFFFFFFFFF, 64'h000007FFFFFFFFFF,
+                       64'h00000FFFFFFFFFFF, 64'h00001FFFFFFFFFFF, 64'h00003FFFFFFFFFFF, 64'h00007FFFFFFFFFFF,
+                       64'h0000FFFFFFFFFFFF, 64'h0001FFFFFFFFFFFF, 64'h0003FFFFFFFFFFFF, 64'h0007FFFFFFFFFFFF,
+                       64'h000FFFFFFFFFFFFF, 64'h001FFFFFFFFFFFFF, 64'h003FFFFFFFFFFFFF, 64'h007FFFFFFFFFFFFF,
+                       64'h00FFFFFFFFFFFFFF, 64'h01FFFFFFFFFFFFFF, 64'h03FFFFFFFFFFFFFF, 64'h07FFFFFFFFFFFFFF,
+                       64'h0FFFFFFFFFFFFFFF, 64'h1FFFFFFFFFFFFFFF, 64'h3FFFFFFFFFFFFFFF, 64'h7FFFFFFFFFFFFFFF};
+
+endmodule : fixed_p_rounding

--- a/hardware/src/lane/fixed_p_rounding.sv
+++ b/hardware/src/lane/fixed_p_rounding.sv
@@ -18,7 +18,7 @@ module fixed_p_rounding import ara_pkg::*; import rvv_pkg::*; #(
     input  ara_op_e op_i,
     input  vew_e    vew_i,
     input  vxrm_t   vxrm_i,
-    output strb_t   r
+    output strb_t   r_o
   );
 
   /////////////////
@@ -43,6 +43,9 @@ module fixed_p_rounding import ara_pkg::*; import rvv_pkg::*; #(
   int j;
 
   always_comb begin
+    j   =  0;
+    r_o = '0;
+
     if (valid_i) begin
       unique case (op_i)
         VSSRA, VSSRL, VNCLIP, VNCLIPU : begin
@@ -51,23 +54,23 @@ module fixed_p_rounding import ara_pkg::*; import rvv_pkg::*; #(
               unique case (vxrm)
                 2'b00: begin
                   for (int i=0; i<8; i++) begin
-                    j    = opa.w8[i];
-                    r[i] = opb.w8[i][j-1];
+                    j      = opa.w8[i];
+                    r_o[i] = opb.w8[i][j-1];
                   end
                 end
                 2'b01: begin
                   for (int i=0; i<8; i++) begin
-                    j    = opa.w8[i];
-                    r[i] = opb.w8[i][j-1] & opb.w8[i][j];
+                    j      = opa.w8[i];
+                    r_o[i] = opb.w8[i][j-1] & opb.w8[i][j];
                   end
                 end
                 2'b10: begin
-                  r = '0;
+                  r_o = '0;
                 end
                 2'b11: begin
                   for (int i=0; i<8; i++) begin
-                    j    = opa.w8[i];
-                    r[i] = !opb.w8[i][j] & |(opb.w8[i] & bit_select);
+                    j      = opa.w8[i];
+                    r_o[i] = !opb.w8[i][j] & |(opb.w8[i] & bit_select);
                   end
                 end
               endcase
@@ -76,23 +79,23 @@ module fixed_p_rounding import ara_pkg::*; import rvv_pkg::*; #(
               unique case (vxrm)
                 2'b00: begin
                   for (int i=0; i<4; i++) begin
-                    j    = opa.w16[i];
-                    r[i] = opb.w16[i][j-1];
+                    j      = opa.w16[i];
+                    r_o[i] = opb.w16[i][j-1];
                   end
                 end
                 2'b01: begin
                   for (int i=0; i<4; i++) begin
-                    j    = opa.w16[i];
-                    r[i] = opb.w16[i][j-1] & opb.w16[i][j];
+                    j      = opa.w16[i];
+                    r_o[i] = opb.w16[i][j-1] & opb.w16[i][j];
                   end
                 end
                 2'b10: begin
-                  r = '0;
+                  r_o = '0;
                 end
                 2'b11: begin
                   for (int i=0; i<4; i++) begin
-                    j    = opa.w16[i];
-                    r[i] = !opb.w16[i][j] & |(opb.w16[i] & bit_select);
+                    j      = opa.w16[i];
+                    r_o[i] = !opb.w16[i][j] & |(opb.w16[i] & bit_select);
                   end
                 end
               endcase
@@ -101,23 +104,23 @@ module fixed_p_rounding import ara_pkg::*; import rvv_pkg::*; #(
               unique case (vxrm)
                 2'b00: begin
                   for (int i=0; i<2; i++) begin
-                    j    = opa.w32[i];
-                    r[i] = opb.w32[i][j-1];
+                    j      = opa.w32[i];
+                    r_o[i] = opb.w32[i][j-1];
                   end
                 end
                 2'b01: begin
                   for (int i=0; i<2; i++) begin
-                    j    = opa.w32[i];
-                    r[i] = opb.w32[i][j-1] & opb.w32[i][j];
+                    j      = opa.w32[i];
+                    r_o[i] = opb.w32[i][j-1] & opb.w32[i][j];
                   end
                 end
                 2'b10: begin
-                  r = '0;
+                  r_o = '0;
                 end
                 2'b11: begin
                   for (int i=0; i<2; i++) begin
-                    j    = opa.w32[i];
-                    r[i] = !opb.w32[i][j] & |(opb.w32[i] & bit_select);
+                    j      = opa.w32[i];
+                    r_o[i] = !opb.w32[i][j] & |(opb.w32[i] & bit_select);
                   end
                 end
               endcase
@@ -126,33 +129,33 @@ module fixed_p_rounding import ara_pkg::*; import rvv_pkg::*; #(
               unique case (vxrm)
                 2'b00: begin
                   for (int i=0; i<1; i++) begin
-                    j    = opa.w64[i];
-                    r[i] = opb.w64[i][j-1];
+                    j      = opa.w64[i];
+                    r_o[i] = opb.w64[i][j-1];
                   end
                 end
                 2'b01: begin
                   for (int i=0; i<1; i++) begin
-                    j    = opa.w64[i];
-                    r[i] = opb.w64[i][j-1] & opb.w64[i][j];
+                    j      = opa.w64[i];
+                    r_o[i] = opb.w64[i][j-1] & opb.w64[i][j];
                   end
                 end
                 2'b10: begin
-                  r = '0;
+                  r_o = '0;
                 end
                 2'b11: begin
                   for (int i=0; i<1; i++) begin
-                    j    = opa.w64[i];
-                    r[i] = !opb.w64[i][j] & |(opb.w64[i] & bit_select);
+                    j      = opa.w64[i];
+                    r_o[i] = !opb.w64[i][j] & |(opb.w64[i] & bit_select);
                   end
                 end
               endcase
             end
           endcase
         end
-        default: r=0;
+        default: r_o = '0;
       endcase
     end else begin
-      r = '0;
+      r_o = '0;
     end
   end
 

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -34,6 +34,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  logic     [cf_math_pkg::idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with the dispatcher
     output logic                                           vxsat_flag_o,
+    input  vxrm_t                                          alu_vxrm_i,
     output logic     [4:0]                                 fflags_ex_o,
     output logic                                           fflags_ex_valid_o,
     // Interface with the sequencer
@@ -358,6 +359,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .lane_id_i            (lane_id_i                              ),
     // Interface with Dispatcher
     .vxsat_flag_o         (vxsat_flag_o                           ),
+    .alu_vxrm_i           (alu_vxrm_i                             ),
     // Interface with CVA6
     .fflags_ex_o          (fflags_ex_o                            ),
     .fflags_ex_valid_o    (fflags_ex_valid_o                      ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -33,6 +33,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     // Lane ID
     input  logic     [cf_math_pkg::idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with the dispatcher
+    output logic                                           vxsat_flag_o,
     output logic     [4:0]                                 fflags_ex_o,
     output logic                                           fflags_ex_valid_o,
     // Interface with the sequencer
@@ -355,6 +356,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .clk_i                (clk_i                                  ),
     .rst_ni               (rst_ni                                 ),
     .lane_id_i            (lane_id_i                              ),
+    // Interface with Dispatcher
+    .vxsat_flag_o         (vxsat_flag_o                           ),
     // Interface with CVA6
     .fflags_ex_o          (fflags_ex_o                            ),
     .fflags_ex_valid_o    (fflags_ex_valid_o                      ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -13,6 +13,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int           unsigned NrLanes         = 1, // Number of lanes
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport      = FPUSupportHalfSingleDouble,
+    // Support for fixed-point data types
+    parameter  logic                  FixPtSupport    = FixedPointEnable,
     // Dependant parameters. DO NOT CHANGE!
     // VRF Parameters
     localparam int           unsigned MaxVLenPerLane  = VLEN / NrLanes,       // In bits
@@ -350,9 +352,10 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic sldu_alu_ready, sldu_mfpu_ready;
 
   vector_fus_stage #(
-    .NrLanes   (NrLanes   ),
-    .FPUSupport(FPUSupport),
-    .vaddr_t   (vaddr_t   )
+    .NrLanes     (NrLanes     ),
+    .FPUSupport  (FPUSupport  ),
+    .FixPtSupport(FixPtSupport),
+    .vaddr_t     (vaddr_t     )
   ) i_vfus (
     .clk_i                (clk_i                                  ),
     .rst_ni               (rst_ni                                 ),

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -24,7 +24,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     input  vxrm_t      vxrm_i,
     output elen_t      result_o
   );
-  
+
   ///////////////////
   //  Definitions  //
   ///////////////////

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -25,13 +25,6 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     output elen_t      result_o
   );
   
-  // Temp logic rounding mode CSR (vxrm_i) needs to be integrated as input to alu
-  vxrm_t       vxrm_i;
-  logic        r;
-  // logic        vxsat;
-
-  assign vxrm_i = 0;
-
   ///////////////////
   //  Definitions  //
   ///////////////////

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -109,7 +109,8 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
 
   always_comb begin: p_alu
     // Default assignment
-    res = '0;
+    res   = '0;
+    vxsat = 1'b0;
 
     if (valid_i)
       unique case (op_i)

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -24,6 +24,13 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     input  vxrm_t      vxrm_i,
     output elen_t      result_o
   );
+  
+  // Temp logic rounding mode CSR (vxrm_i) needs to be integrated as input to alu
+  vxrm_t       vxrm_i;
+  logic        r;
+  // logic        vxsat;
+
+  assign vxrm_i = 0;
 
   ///////////////////
   //  Definitions  //
@@ -56,7 +63,6 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
 
   assign vxrm = vxrm_i;
   assign vxsat_o = vxsat;
-
   ///////////////////
   //  Comparisons  //
   ///////////////////

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -21,16 +21,10 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     input  ara_op_e    op_i,
     input  vew_e       vew_i,
     output alu_vxsat_t vxsat_o,
+    input  vxrm_t      vxrm_i,
     output elen_t      result_o
   );
   
-  // Temp logic rounding mode CSR (vxrm_i) needs to be integrated as input to alu
-  vxrm_t       vxrm_i;
-  logic        r;
-  // logic        vxsat;
-
-  assign vxrm_i = 0;
-
   ///////////////////
   //  Definitions  //
   ///////////////////
@@ -57,9 +51,11 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
 
   alu_sat_operand_t sat_sum, sat_sub;
   alu_vxsat_t vxsat;
-  
+  vxrm_t      vxrm;
+  logic       r;
+
+  assign vxrm = vxrm_i;
   assign vxsat_o = vxsat;
-  // assign vxsat_o = |vxsat.w8;
 
   ///////////////////
   //  Comparisons  //
@@ -187,7 +183,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VAADD, VAADDU: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
               automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
@@ -197,7 +193,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW16: for (int b = 0; b < 4; b++) begin
                 automatic logic [16:0] sum = opa.w16[b] + opb.w16[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
@@ -207,7 +203,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW32: for (int b = 0; b < 2; b++) begin
                 automatic logic [32:0] sum = opa.w32[b] + opb.w32[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
@@ -217,7 +213,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW64: for (int b = 0; b < 1; b++) begin
                 automatic logic [64:0] sum = opa.w64[b] + opb.w64[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
@@ -323,7 +319,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VASUB, VASUBU: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [ 8:0] sub = opb.w8 [b] - opa.w8 [b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
@@ -333,7 +329,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW16: for (int b = 0; b < 4; b++) begin
                 automatic logic [ 16:0] sub = opb.w16[b] - opa.w16[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
@@ -343,7 +339,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW32: for (int b = 0; b < 2; b++) begin
                 automatic logic [ 32:0] sub = opb.w32[b] - opa.w32[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
@@ -353,7 +349,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
               end
             EW64: for (int b = 0; b < 1; b++) begin
                 automatic logic [ 64:0] sub = opb.w64[b] - opa.w64[b];
-                unique case (vxrm_i)
+                unique case (vxrm)
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -187,7 +187,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sum[1] & sum[0];
+                  2'b11: r = !sum[1] & (sum[0]!=0);
                 endcase
                 res.w8[b] = (op_i == VAADDU) ? sum[8:1] + r : {sum[7], sum[7:1]} + r;
               end
@@ -197,7 +197,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sum[1] & sum[0];
+                  2'b11: r = !sum[1] & (sum[0]!=0);
                 endcase
                 res.w16[b] = (op_i == VAADDU) ? sum[16:1] + r : {sum[15], sum[15:1]} + r;
               end
@@ -207,7 +207,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sum[1] & sum[0];
+                  2'b11: r = !sum[1] & (sum[0]!=0);
                 endcase
                 res.w32[b] = (op_i == VAADDU) ? sum[32:1] + r : {sum[31], sum[31:1]} + r;
               end
@@ -217,7 +217,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sum[0];
                   2'b01: r = &sum[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sum[1] & sum[0];
+                  2'b11: r = !sum[1] & (sum[0]!=0);
                 endcase
                 res.w64[b] = (op_i == VAADDU) ? sum[64:1] + r : {sum[63], sum[63:1]} + r;
               end
@@ -323,7 +323,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sub[1] & sub[0];
+                  2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
                 res.w8[b] = (op_i == VSSUBU) ? (sub[7:0] >> 1) + r : $signed(sub[7:0]) >>> 1 + r;
               end
@@ -333,7 +333,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sub[1] & sub[0];
+                  2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
                 res.w16[b] = (op_i == VSSUBU) ? (sub[15:0] >> 1) + r : $signed(sub[15:0]) >>> 1 + r;
               end
@@ -343,7 +343,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sub[1] & sub[0];
+                  2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
                 res.w32[b] = (op_i == VSSUBU) ? (sub[31:0] >> 1) + r : $signed(sub[31:0]) >>> 1 + r;
               end
@@ -353,7 +353,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                   2'b00: r = sub[0];
                   2'b01: r = &sub[1:0];
                   2'b10: r = 1'b0;
-                  2'b11: r = !sub[1] & sub[0];
+                  2'b11: r = !sub[1] & (sub[0]!=0);
                 endcase
                 res.w64[b] = (op_i == VSSUBU) ? (sub[63:0] >> 1) + r : $signed(sub[63:0]) >>> 1 + r;
               end

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -20,7 +20,8 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     input  logic       narrowing_select_i,
     input  ara_op_e    op_i,
     input  vew_e       vew_i,
-    output alu_vxsat_t vxsat_o,
+    output vxsat_t     vxsat_o,
+    input  strb_t      rm,
     input  vxrm_t      vxrm_i,
     output elen_t      result_o
   );
@@ -50,7 +51,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
   } alu_sat_operand_t;
 
   alu_sat_operand_t sat_sum, sat_sub;
-  alu_vxsat_t vxsat;
+  vxsat_t     vxsat;
   vxrm_t      vxrm;
   logic       r;
 
@@ -393,6 +394,80 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
                 $signed(opb.w32[b]) >>> opa.w32[b][4:0];
             EW32: for (int b = 0; b < 1; b++) res.w32[2*b + narrowing_select_i] =
                 $signed(opb.w64[b]) >>> opa.w64[b][5:0];
+          endcase
+
+        // Fixed point shift instructions
+        VSSRA: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+                automatic logic [7:0] sra = $signed(opb.w8 [b]) >>> opa.w8 [b][2:0];
+                res.w8[b] = sra + rm[b];
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+                automatic logic [15:0] sra = $signed(opb.w16[b]) >>> opa.w16[b][3:0];
+                res.w16[b] = sra + rm[b];
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+                automatic logic [31:0] sra = $signed(opb.w32[b]) >>> opa.w32[b][4:0];
+                res.w32[b] = sra + rm[b];
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+                automatic logic [63:0] sra = $signed(opb.w64[b]) >>> opa.w64[b][5:0];
+                res.w64[b] = sra + rm[b];
+              end
+          endcase
+        VSSRL: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+                automatic logic [8:0] srl = opb.w8 [b] >> opa.w8 [b];
+                res.w8[b] = srl + rm[b];
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+                automatic logic [16:0] srl = opb.w16[b] >> opa.w16[b];
+                res.w16[b] = srl + rm[b];
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+                automatic logic [32:0] srl = opb.w32[b] >> opa.w32[b];
+                res.w32[b] = srl + rm[b];
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+                automatic logic [64:0] srl = opb.w64[b] >> opa.w64[b];
+                res.w64[b] = srl + rm[b];
+              end
+          endcase
+
+        // Fixed point clip instructions
+        VNCLIP: unique case (vew_i)
+            EW8 : for (int b = 0; b < 4; b++) begin
+                automatic logic [15:0] clip = $signed(opb.w16[b]) >>> opa.w16[b][3:0];
+                vxsat.w8[b]   = |clip[15:8];
+                res.w8 [2*b + narrowing_select_i] = ($signed(opb.w16[b]) >>> opa.w16[b][3:0]) + rm[b];
+              end
+            EW16: for (int b = 0; b < 2; b++) begin
+                automatic logic [31:0] clip = $signed(opb.w32[b]) >>> opa.w32[b][4:0];
+                vxsat.w8[b]   = |clip[31:16];
+                res.w16[2*b + narrowing_select_i] = ($signed(opb.w32[b]) >>> opa.w32[b][4:0]) + rm[b];
+              end
+            EW32: for (int b = 0; b < 1; b++) begin
+                automatic logic [63:0] clip = $signed(opb.w64[b]) >>> opa.w64[b][5:0];
+                vxsat.w8[b]   = |clip[63:32];
+                res.w32[2*b + narrowing_select_i] = ($signed(opb.w64[b]) >>> opa.w64[b][5:0]) + rm[b];
+              end
+          endcase
+        VNCLIPU: unique case (vew_i)
+            EW8 : for (int b = 0; b < 4; b++) begin
+                automatic logic [15:0] clipu = opb.w16[b] >> opa.w16[b][3:0];
+                vxsat.w8[b]   = |clipu[15:8];
+                res.w8 [2*b + narrowing_select_i] = (opb.w16[b] >> opa.w16[b][3:0]) + rm[b];
+              end
+            EW16: for (int b = 0; b < 2; b++) begin
+                automatic logic [31:0] clipu = opb.w32[b] >> opa.w32[b][4:0];
+                vxsat.w8[b]   = |clipu[31:16];
+                res.w16[2*b + narrowing_select_i] = (opb.w32[b] >> opa.w32[b][4:0]) + rm[b];
+              end
+            EW32: for (int b = 0; b < 1; b++) begin
+                automatic logic [63:0] clipu = opb.w64[b] >> opa.w64[b][5:0];
+                vxsat.w8[b]   = |clipu[63:32];
+                res.w32[2*b + narrowing_select_i] = (opb.w64[b] >> opa.w64[b][5:0]) + rm[b];
+              end
           endcase
 
         // Merge instructions

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -12,16 +12,24 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     localparam int  unsigned StrbWidth = DataWidth/8,
     localparam type          strb_t    = logic [StrbWidth-1:0]
   ) (
-    input  elen_t   operand_a_i,
-    input  elen_t   operand_b_i,
-    input  logic    valid_i,
-    input  logic    vm_i,
-    input  strb_t   mask_i,
-    input  logic    narrowing_select_i,
-    input  ara_op_e op_i,
-    input  vew_e    vew_i,
-    output elen_t   result_o
+    input  elen_t      operand_a_i,
+    input  elen_t      operand_b_i,
+    input  logic       valid_i,
+    input  logic       vm_i,
+    input  strb_t      mask_i,
+    input  logic       narrowing_select_i,
+    input  ara_op_e    op_i,
+    input  vew_e       vew_i,
+    output alu_vxsat_t vxsat_o,
+    output elen_t      result_o
   );
+  
+  // Temp logic rounding mode CSR (vxrm_i) needs to be integrated as input to alu
+  vxrm_t       vxrm_i;
+  logic        r;
+  // logic        vxsat;
+
+  assign vxrm_i = 0;
 
   ///////////////////
   //  Definitions  //
@@ -38,6 +46,20 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
   assign opa      = operand_a_i;
   assign opb      = operand_b_i;
   assign result_o = res;
+
+
+  typedef union packed {
+    logic [0:0][71:0] w64;
+    logic [1:0][35:0] w32;
+    logic [3:0][17:0] w16;
+    logic [7:0][ 8:0] w8;
+  } alu_sat_operand_t;
+
+  alu_sat_operand_t sat_sum, sat_sub;
+  alu_vxsat_t vxsat;
+  
+  assign vxsat_o = vxsat;
+  // assign vxsat_o = |vxsat.w8;
 
   ///////////////////
   //  Comparisons  //
@@ -118,7 +140,93 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VCPOP, VFIRST : res = operand_b_i;
 
         // Arithmetic instructions
-        VADD, VADC, VMADC, VREDSUM, VWREDSUMU, VWREDSUM: unique case (vew_i)
+        VSADDU: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+                automatic logic [8:0] sum = opa.w8[b] + opb.w8[b];
+                vxsat.w8[b]   = sum[8];
+                res.w8[b]     = vxsat.w8[b] ? {8{1'b1}} : sum[7:0];
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+                automatic logic [16:0] sum = opa.w16[b] + opb.w16[b];
+                vxsat.w16[b]   = {2{sum[16]}};
+                res.w16[b]     = &vxsat.w16[b] ? {16{1'b1}} : sum[15:0];
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+                automatic logic [32:0] sum = opa.w32[b] + opb.w32[b];
+                vxsat.w32[b]   = {4{sum[32]}};
+                res.w32[b]     = &vxsat.w32[b] ? {32{1'b1}} : sum[31:0];
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+                automatic logic [64:0] sum = opa.w64[b] + opb.w64[b];
+                vxsat.w64[b]   = {8{sum[64]}};
+                res.w64[b]     = &vxsat.w64[b] ? {64{1'b1}} : sum[63:0];
+              end
+          endcase
+        VSADD: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+                automatic logic [8:0] sum = opa.w8[b] + opb.w8[b];
+                vxsat.w8[b]   = sum[8] && !(opa.w8 [b] [ 7] ^ opb.w8 [b] [ 7]);
+                res.w8[b]     = vxsat.w8[b] ? {1'b1, {7{1'b0}}} : sum[7:0];
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+                automatic logic [16:0] sum = opa.w16[b] + opb.w16[b];
+                vxsat.w16[b]   = {2{sum[16] && !(opa.w16 [b] [15] ^ opb.w16 [b] [15])}};
+                res.w16[b]     = &vxsat.w16[b] ? {1'b1, {15{1'b0}}} : sum[15:0];
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+                automatic logic [32:0] sum = opa.w32[b] + opb.w32[b];
+                vxsat.w32[b]   = {4{sum[32] && !(opa.w32 [b] [31] ^ opb.w32 [b] [31])}};
+                res.w32[b]     = &vxsat.w32[b] ? {1'b1, {31{1'b0}}} : sum[31:0];
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+                automatic logic [64:0] sum = opa.w64[b] + opb.w64[b];
+                vxsat.w64[b]   = {8{sum[64] && !(opa.w64 [b] [63] ^ opb.w64 [b] [63])}};
+                res.w64[b]     = &vxsat.w64[b] ? {1'b1, {63{1'b0}}} : sum[63:0];
+              end
+          endcase
+        VAADD, VAADDU: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+              automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b];
+                unique case (vxrm_i)
+                  2'b00: r = sum[0];
+                  2'b01: r = &sum[1:0];
+                  2'b10: r = 1'b0;
+                  2'b11: r = !sum[1] & sum[0];
+                endcase
+                res.w8[b] = (op_i == VAADDU) ? sum[8:1] + r : {sum[7], sum[7:1]} + r;
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+                automatic logic [16:0] sum = opa.w16[b] + opb.w16[b];
+                unique case (vxrm_i)
+                  2'b00: r = sum[0];
+                  2'b01: r = &sum[1:0];
+                  2'b10: r = 1'b0;
+                  2'b11: r = !sum[1] & sum[0];
+                endcase
+                res.w16[b] = (op_i == VAADDU) ? sum[16:1] + r : {sum[15], sum[15:1]} + r;
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+                automatic logic [32:0] sum = opa.w32[b] + opb.w32[b];
+                unique case (vxrm_i)
+                  2'b00: r = sum[0];
+                  2'b01: r = &sum[1:0];
+                  2'b10: r = 1'b0;
+                  2'b11: r = !sum[1] & sum[0];
+                endcase
+                res.w32[b] = (op_i == VAADDU) ? sum[32:1] + r : {sum[31], sum[31:1]} + r;
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+                automatic logic [64:0] sum = opa.w64[b] + opb.w64[b];
+                unique case (vxrm_i)
+                  2'b00: r = sum[0];
+                  2'b01: r = &sum[1:0];
+                  2'b10: r = 1'b0;
+                  2'b11: r = !sum[1] & sum[0];
+                endcase
+                res.w64[b] = (op_i == VAADDU) ? sum[64:1] + r : {sum[63], sum[63:1]} + r;
+              end
+          endcase
+          VADD, VADC, VMADC, VREDSUM, VWREDSUMU, VWREDSUM: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b] +
                 logic'(op_i inside {VADC, VMADC} && mask_i[1*b] && !vm_i);
@@ -167,6 +275,92 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
             EW16: for (int b = 0; b < 4; b++) res.w16[b] = opa.w16[b] - opb.w16[b];
             EW32: for (int b = 0; b < 2; b++) res.w32[b] = opa.w32[b] - opb.w32[b];
             EW64: for (int b = 0; b < 1; b++) res.w64[b] = opa.w64[b] - opb.w64[b];
+          endcase
+        VSSUBU: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+                automatic logic [8:0] sub = opb.w8 [b] - opa.w8 [b];
+                vxsat.w8[b]   = sub[8];
+                res.w8[b]     = vxsat.w8[b] ? {8{1'b0}} : sub[7:0];
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+                automatic logic [16:0] sub = opb.w16[b] - opa.w16[b];
+                vxsat.w16[b]   = {2{sub[16]}};
+                res.w16[b]     = &vxsat.w16[b] ? {16{1'b0}} : sub[15:0];
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+                automatic logic [32:0] sub = opb.w32[b] - opa.w32[b];
+                vxsat.w32[b]   = {4{sub[32]}};
+                res.w32[b]     = &vxsat.w32[b] ? {32{1'b0}} : sub[31:0];
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+                automatic logic [64:0] sub = opb.w64[b] - opa.w64[b];
+                vxsat.w64[b]   = {8{sub[64]}};
+                res.w64[b]     = &vxsat.w64[b] ? {64{1'b0}} : sub[63:0];
+              end
+          endcase
+      VSSUB: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+                automatic logic [8:0] sub = opb.w8 [b] - opa.w8 [b];
+                vxsat.w8[b]   = ^sub[8:7];
+                res.w8[b]     = vxsat.w8[b] ? {8{1'b0}} : sub[7:0];
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+                automatic logic [16:0] sub = opb.w16[b] - opa.w16[b];
+                vxsat.w16[b]   = {2{^sub[16:15]}};
+                res.w16[b]     = &vxsat.w16[b] ? {16{1'b0}} : sub[15:0];
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+                automatic logic [32:0] sub = opb.w32[b] - opa.w32[b];
+                vxsat.w32[b]   = {4{^sub[32:31]}};
+                res.w32[b]     = &vxsat.w32[b] ? {32{1'b0}} : sub[31:0];
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+                automatic logic [64:0] sub = opb.w64[b] - opa.w64[b];
+                vxsat.w64[b]   = {8{^sub[64:63]}};
+                res.w64[b]     = &vxsat.w64[b] ? {64{1'b0}} : sub[63:0];
+              end
+          endcase
+        VASUB, VASUBU: unique case (vew_i)
+            EW8: for (int b = 0; b < 8; b++) begin
+                automatic logic [ 8:0] sub = opb.w8 [b] - opa.w8 [b];
+                unique case (vxrm_i)
+                  2'b00: r = sub[0];
+                  2'b01: r = &sub[1:0];
+                  2'b10: r = 1'b0;
+                  2'b11: r = !sub[1] & sub[0];
+                endcase
+                res.w8[b] = (op_i == VSSUBU) ? (sub[7:0] >> 1) + r : $signed(sub[7:0]) >>> 1 + r;
+              end
+            EW16: for (int b = 0; b < 4; b++) begin
+                automatic logic [ 16:0] sub = opb.w16[b] - opa.w16[b];
+                unique case (vxrm_i)
+                  2'b00: r = sub[0];
+                  2'b01: r = &sub[1:0];
+                  2'b10: r = 1'b0;
+                  2'b11: r = !sub[1] & sub[0];
+                endcase
+                res.w16[b] = (op_i == VSSUBU) ? (sub[15:0] >> 1) + r : $signed(sub[15:0]) >>> 1 + r;
+              end
+            EW32: for (int b = 0; b < 2; b++) begin
+                automatic logic [ 32:0] sub = opb.w32[b] - opa.w32[b];
+                unique case (vxrm_i)
+                  2'b00: r = sub[0];
+                  2'b01: r = &sub[1:0];
+                  2'b10: r = 1'b0;
+                  2'b11: r = !sub[1] & sub[0];
+                endcase
+                res.w32[b] = (op_i == VSSUBU) ? (sub[31:0] >> 1) + r : $signed(sub[31:0]) >>> 1 + r;
+              end
+            EW64: for (int b = 0; b < 1; b++) begin
+                automatic logic [ 64:0] sub = opb.w64[b] - opa.w64[b];
+                unique case (vxrm_i)
+                  2'b00: r = sub[0];
+                  2'b01: r = &sub[1:0];
+                  2'b10: r = 1'b0;
+                  2'b11: r = !sub[1] & sub[0];
+                endcase
+                res.w64[b] = (op_i == VSSUBU) ? (sub[63:0] >> 1) + r : $signed(sub[63:0]) >>> 1 + r;
+              end
           endcase
 
         // Shift instructions

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -24,7 +24,7 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     input  vxrm_t      vxrm_i,
     output elen_t      result_o
   );
-  
+
   ///////////////////
   //  Definitions  //
   ///////////////////
@@ -161,23 +161,23 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         VSADD: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [8:0] sum = opa.w8[b] + opb.w8[b];
-                vxsat.w8[b]   = sum[8] && !(opa.w8 [b] [ 7] ^ opb.w8 [b] [ 7]);
-                res.w8[b]     = vxsat.w8[b] ? {1'b1, {7{1'b0}}} : sum[7:0];
+                vxsat.w8[b]   = (sum[7]^opa.w8[b][7]) & ~(opa.w8[b][7] ^ opb.w8[b][7]);
+                res.w8[b]     = vxsat.w8[b] ? (sum[7] ? {1'b0, {7{1'b1}}} : {1'b1, {7{1'b0}}} ) : sum[7:0];
               end
             EW16: for (int b = 0; b < 4; b++) begin
                 automatic logic [16:0] sum = opa.w16[b] + opb.w16[b];
-                vxsat.w16[b]   = {2{sum[16] && !(opa.w16 [b] [15] ^ opb.w16 [b] [15])}};
-                res.w16[b]     = &vxsat.w16[b] ? {1'b1, {15{1'b0}}} : sum[15:0];
+                vxsat.w16[b]   = {2{(sum[15] ^ opa.w16[b][15]) & ~(opa.w16[b][15] ^ opb.w16[b][15])}};
+                res.w16[b]     = &vxsat.w16[b] ? (sum[15] ? {1'b0, {15{1'b1}}} : {1'b1, {15{1'b0}}} ) : sum[15:0];
               end
             EW32: for (int b = 0; b < 2; b++) begin
                 automatic logic [32:0] sum = opa.w32[b] + opb.w32[b];
-                vxsat.w32[b]   = {4{sum[32] && !(opa.w32 [b] [31] ^ opb.w32 [b] [31])}};
-                res.w32[b]     = &vxsat.w32[b] ? {1'b1, {31{1'b0}}} : sum[31:0];
+                vxsat.w32[b]   = {4{(sum[31] ^ opa.w32[b][31]) && !(opa.w32[b][31] ^ opb.w32[b][31])}};
+                res.w32[b]     = &vxsat.w32[b] ? (sum[31] ? {1'b0, {31{1'b1}}} : {1'b1, {31{1'b0}}} ) : sum[31:0];
               end
             EW64: for (int b = 0; b < 1; b++) begin
                 automatic logic [64:0] sum = opa.w64[b] + opb.w64[b];
-                vxsat.w64[b]   = {8{sum[64] && !(opa.w64 [b] [63] ^ opb.w64 [b] [63])}};
-                res.w64[b]     = &vxsat.w64[b] ? {1'b1, {63{1'b0}}} : sum[63:0];
+                vxsat.w64[b]   = {8{(sum[63] ^ opa.w64[b][63]) & ~(opa.w64[b][63] ^ opb.w64[b][63])}};
+                res.w64[b]     = &vxsat.w64[b] ? (sum[63] ? {1'b0, {63{1'b1}}} : {1'b1, {63{1'b0}}} ) : sum[63:0];
               end
           endcase
         VAADD, VAADDU: unique case (vew_i)
@@ -225,44 +225,44 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
           VADD, VADC, VMADC, VREDSUM, VWREDSUMU, VWREDSUM: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [ 8:0] sum = opa.w8 [b] + opb.w8 [b] +
-                logic'(op_i inside {VADC, VMADC} && mask_i[1*b] && !vm_i);
+                logic'(op_i inside {VADC, VMADC} && mask_i[1*b] & ~vm_i);
                 res.w8[b] = (op_i == VMADC) ? {6'b0, 1'b1, sum[8]} : sum[7:0];
               end
             EW16: for (int b = 0; b < 4; b++) begin
                 automatic logic [16:0] sum = opa.w16[b] + opb.w16[b] +
-                logic'(op_i inside {VADC, VMADC} && mask_i[2*b] && !vm_i);
+                logic'(op_i inside {VADC, VMADC} && mask_i[2*b] & ~vm_i);
                 res.w16[b] = (op_i == VMADC) ? {14'b0, 1'b1, sum[16]} : sum[15:0];
               end
             EW32: for (int b = 0; b < 2; b++) begin
                 automatic logic [32:0] sum = opa.w32[b] + opb.w32[b] +
-                logic'(op_i inside {VADC, VMADC} && mask_i[4*b] && !vm_i);
+                logic'(op_i inside {VADC, VMADC} && mask_i[4*b] & ~vm_i);
                 res.w32[b] = (op_i == VMADC) ? {30'b0, 1'b1, sum[32]} : sum[31:0];
               end
             EW64: for (int b = 0; b < 1; b++) begin
                 automatic logic [64:0] sum = opa.w64[b] + opb.w64[b] +
-                logic'(op_i inside {VADC, VMADC} && mask_i[8*b] && !vm_i);
+                logic'(op_i inside {VADC, VMADC} && mask_i[8*b] & ~vm_i);
                 res.w64[b] = (op_i == VMADC) ? {62'b0, 1'b1, sum[64]} : sum[63:0];
               end
           endcase
         VSUB, VSBC, VMSBC: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin
                 automatic logic [ 8:0] sub = opb.w8 [b] - opa.w8 [b] -
-                logic'(op_i inside {VSBC, VMSBC} && mask_i[1*b] && !vm_i);
+                logic'(op_i inside {VSBC, VMSBC} && mask_i[1*b] & ~vm_i);
                 res.w8[b] = (op_i == VMSBC) ? {6'b0, 1'b1, sub[8]} : sub[7:0];
               end
             EW16: for (int b = 0; b < 4; b++) begin
                 automatic logic [16:0] sub = opb.w16[b] - opa.w16[b] -
-                logic'(op_i inside {VSBC, VMSBC} && mask_i[2*b] && !vm_i);
+                logic'(op_i inside {VSBC, VMSBC} && mask_i[2*b] & ~vm_i);
                 res.w16[b] = (op_i == VMSBC) ? {14'b0, 1'b1, sub[16]} : sub[15:0];
               end
             EW32: for (int b = 0; b < 2; b++) begin
                 automatic logic [32:0] sub = opb.w32[b] - opa.w32[b] -
-                logic'(op_i inside {VSBC, VMSBC} && mask_i[4*b] && !vm_i);
+                logic'(op_i inside {VSBC, VMSBC} && mask_i[4*b] & ~vm_i);
                 res.w32[b] = (op_i == VMSBC) ? {30'b0, 1'b1, sub[32]} : sub[31:0];
               end
             EW64: for (int b = 0; b < 1; b++) begin
                 automatic logic [64:0] sub = opb.w64[b] - opa.w64[b] -
-                logic'(op_i inside {VSBC, VMSBC} && mask_i[8*b] && !vm_i);
+                logic'(op_i inside {VSBC, VMSBC} && mask_i[8*b] & ~vm_i);
                 res.w64[b] = (op_i == VMSBC) ? {62'b0, 1'b1, sub[64]} : sub[63:0];
               end
           endcase

--- a/hardware/src/lane/simd_mul.sv
+++ b/hardware/src/lane/simd_mul.sv
@@ -152,7 +152,7 @@ module simd_mul import ara_pkg::*; import rvv_pkg::*; #(
     for (genvar l = 0; l < 1; l++) begin: gen_mul
       assign mul_res.w128[l] =
       $signed({opa.w64[l][63] & signed_a, opa.w64[l]}) * $signed({opb.w64[l][63] & signed_b, opb.w64[l]});
-      assign vxsat.w64[l]   = |mul_res.w128[l][127:64];
+        assign vxsat.w64[l] = (op == VSMUL) ? result_o[(l+1)*64-1] ^ mul_res.w128[l][127] : '0;
     end : gen_mul
 
     always_comb begin : p_mul
@@ -186,7 +186,7 @@ module simd_mul import ara_pkg::*; import rvv_pkg::*; #(
     for (genvar l = 0; l < 2; l++) begin: gen_mul
       assign mul_res.w64[l] =
       $signed({opa.w32[l][31] & signed_a, opa.w32[l]}) * $signed({opb.w32[l][31] & signed_b, opb.w32[l]});
-      assign vxsat.w32[l]   = |mul_res.w64[l][63:32];
+        assign vxsat.w32[l] = (op == VSMUL) ? result_o[(l+1)*32-1] ^ mul_res.w64[l][63] : '0;
     end: gen_mul
 
     always_comb begin : p_mul
@@ -218,7 +218,7 @@ module simd_mul import ara_pkg::*; import rvv_pkg::*; #(
     for (genvar l = 0; l < 4; l++) begin: gen_mul
       assign mul_res.w32[l] =
       $signed({opa.w16[l][15] & signed_a, opa.w16[l]}) * $signed({opb.w16[l] [15] & signed_b, opb.w16[l]});
-      assign vxsat.w16[l]   = |mul_res.w32[l][31:16];
+        assign vxsat.w16[l] = (op == VSMUL) ? result_o[(l+1)*16-1] ^ mul_res.w32[l][31] : '0;
     end : gen_mul
 
     always_comb begin : p_mul
@@ -250,7 +250,7 @@ module simd_mul import ara_pkg::*; import rvv_pkg::*; #(
     for (genvar l = 0; l < 8; l++) begin: gen_mul
       assign mul_res.w16[l] =
       $signed({opa.w8[l][7] & signed_a, opa.w8[l]}) * $signed({opb.w8[l][7] & signed_b, opb.w8[l]});
-      assign vxsat.w8[l]   = |mul_res.w16[l][15:8];
+        assign vxsat.w8[l] = (op == VSMUL) ? result_o[(l+1)*8-1] ^ mul_res.w16[l][15] : '0;
     end : gen_mul
 
     always_comb begin : p_mul

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -455,7 +455,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                 result_queue_d[result_queue_write_pnt_q].be = be(element_cnt, vinsn_issue_q.vtype.vsew) & (vinsn_issue_q.vm || vinsn_issue_q.op inside {VMERGE, VADC, VSBC} ? {StrbWidth{1'b1}} : mask_i);
 
                 // Did Alu saturated when computing any elemnts?
-              vxsat_flag_o = alu_vxsat & result_queue_d[result_queue_write_pnt_q].be;
+              vxsat_flag_o = |(alu_vxsat & result_queue_d[result_queue_write_pnt_q].be);
 
                 // Did Alu saturated when computing any elemnts?
               vxsat_flag_o = alu_vxsat & result_queue_d[result_queue_write_pnt_q].be;

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -21,6 +21,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     input  logic[idx_width(NrLanes)-1:0] lane_id_i,
     // Interface with Dispatcher
     output logic                         vxsat_flag_o,
+    input  vxrm_t                        alu_vxrm_i,
     // Interface with the lane sequencer
     input  vfu_operation_t               vfu_operation_i,
     input  logic                         vfu_operation_valid_i,
@@ -362,6 +363,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     .op_i              (vinsn_issue_q.op                                                ),
     .vew_i             (vinsn_issue_q.vtype.vsew                                        ),
     .vxsat_o           (alu_vxsat                                                       ),
+    .vxrm_i            (alu_vxrm_i                                                      ),
     .result_o          (valu_result                                                     )
   );
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -453,7 +453,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
               result_queue_d[result_queue_write_pnt_q].mask  = vinsn_issue_q.vfu == VFU_MaskUnit;
               if (!narrowing(vinsn_issue_q.op) || !narrowing_select_q)
                 result_queue_d[result_queue_write_pnt_q].be = be(element_cnt, vinsn_issue_q.vtype.vsew) & (vinsn_issue_q.vm || vinsn_issue_q.op inside {VMERGE, VADC, VSBC} ? {StrbWidth{1'b1}} : mask_i);
-              
+
                 // Did Alu saturated when computing any elemnts?
               vxsat_flag_o = alu_vxsat & result_queue_d[result_queue_write_pnt_q].be;
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -453,6 +453,9 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
               result_queue_d[result_queue_write_pnt_q].mask  = vinsn_issue_q.vfu == VFU_MaskUnit;
               if (!narrowing(vinsn_issue_q.op) || !narrowing_select_q)
                 result_queue_d[result_queue_write_pnt_q].be = be(element_cnt, vinsn_issue_q.vtype.vsew) & (vinsn_issue_q.vm || vinsn_issue_q.op inside {VMERGE, VADC, VSBC} ? {StrbWidth{1'b1}} : mask_i);
+              
+                // Did Alu saturated when computing any elemnts?
+              vxsat_flag_o = alu_vxsat & result_queue_d[result_queue_write_pnt_q].be;
 
                 // Did Alu saturated when computing any elemnts?
               vxsat_flag_o = alu_vxsat & result_queue_d[result_queue_write_pnt_q].be;

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -454,12 +454,8 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
               if (!narrowing(vinsn_issue_q.op) || !narrowing_select_q)
                 result_queue_d[result_queue_write_pnt_q].be = be(element_cnt, vinsn_issue_q.vtype.vsew) & (vinsn_issue_q.vm || vinsn_issue_q.op inside {VMERGE, VADC, VSBC} ? {StrbWidth{1'b1}} : mask_i);
 
-                // Did Alu saturated when computing any elemnts?
+              // Did Alu saturated when computing any elemnts?
               vxsat_flag_o = |(alu_vxsat & result_queue_d[result_queue_write_pnt_q].be);
-
-                // Did Alu saturated when computing any elemnts?
-              vxsat_flag_o = alu_vxsat & result_queue_d[result_queue_write_pnt_q].be;
-
               // Is this a narrowing instruction?
               if (narrowing(vinsn_issue_q.op)) begin
                 // How many elements did we calculate in this iteration?

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -20,6 +20,8 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     input  logic                              clk_i,
     input  logic                              rst_ni,
     input  logic [idx_width(NrLanes)-1:0]     lane_id_i,
+    // Interface with Dispatcher
+    output logic                              vxsat_flag_o,
     // Interface with CVA6
     output logic           [4:0]              fflags_ex_o,
     output logic                              fflags_ex_valid_o,
@@ -93,6 +95,8 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .clk_i                (clk_i                          ),
     .rst_ni               (rst_ni                         ),
     .lane_id_i            (lane_id_i                      ),
+    // Interface with Dispatcher
+    .vxsat_flag_o         (vxsat_flag_o                   ),
     // Interface with the lane sequencer
     .vfu_operation_i      (vfu_operation_i                ),
     .vfu_operation_valid_i(vfu_operation_valid_i          ),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -22,6 +22,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     input  logic [idx_width(NrLanes)-1:0]     lane_id_i,
     // Interface with Dispatcher
     output logic                              vxsat_flag_o,
+    input  vxrm_t                             alu_vxrm_i,
     // Interface with CVA6
     output logic           [4:0]              fflags_ex_o,
     output logic                              fflags_ex_valid_o,
@@ -97,6 +98,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .lane_id_i            (lane_id_i                      ),
     // Interface with Dispatcher
     .vxsat_flag_o         (vxsat_flag_o                   ),
+    .alu_vxrm_i           (alu_vxrm_i                     ),
     // Interface with the lane sequencer
     .vfu_operation_i      (vfu_operation_i                ),
     .vfu_operation_valid_i(vfu_operation_valid_i          ),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -8,14 +8,16 @@
 // of each lane, namely the ALU and the Multiplier/FPU.
 
 module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
-    parameter  int           unsigned NrLanes    = 0,
+    parameter  int           unsigned NrLanes      = 0,
     // Support for floating-point data types
-    parameter  fpu_support_e          FPUSupport = FPUSupportHalfSingleDouble,
+    parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    // Support for fixed-point data types
+    parameter  logic                  FixPtSupport = FixedPointEnable,
     // Type used to address vector register file elements
-    parameter  type                   vaddr_t    = logic,
+    parameter  type                   vaddr_t      = logic,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int           unsigned DataWidth  = $bits(elen_t),
-    localparam type                   strb_t     = logic [DataWidth/8-1:0]
+    localparam int           unsigned DataWidth    = $bits(elen_t),
+    localparam type                   strb_t       = logic [DataWidth/8-1:0]
   ) (
     input  logic                              clk_i,
     input  logic                              rst_ni,
@@ -95,6 +97,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
 
   valu #(
     .NrLanes(NrLanes),
+    .FixPtSupport(FixPtSupport),
     .vaddr_t(vaddr_t)
   ) i_valu (
     .clk_i                (clk_i                          ),
@@ -142,6 +145,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
   vmfpu #(
     .NrLanes   (NrLanes   ),
     .FPUSupport(FPUSupport),
+    .FixPtSupport(FixPtSupport),
     .vaddr_t   (vaddr_t   )
   ) i_vmfpu (
     .clk_i                (clk_i                           ),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -85,6 +85,10 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
   logic mfpu_mask_ready;
   assign mask_ready_o = alu_mask_ready | mfpu_mask_ready;
 
+  // saturation selection
+  logic alu_vxsat, mfpu_vxsat;
+  assign vxsat_flag_o = mfpu_vxsat | alu_vxsat;
+
   //////////////////
   //  Vector ALU  //
   //////////////////
@@ -97,7 +101,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .rst_ni               (rst_ni                         ),
     .lane_id_i            (lane_id_i                      ),
     // Interface with Dispatcher
-    .vxsat_flag_o         (vxsat_flag_o                   ),
+    .vxsat_flag_o         (alu_vxsat                      ),
     .alu_vxrm_i           (alu_vxrm_i                     ),
     // Interface with the lane sequencer
     .vfu_operation_i      (vfu_operation_i                ),
@@ -143,6 +147,9 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .clk_i                (clk_i                           ),
     .rst_ni               (rst_ni                          ),
     .lane_id_i            (lane_id_i                       ),
+    // Interface with Dispatcher
+    .mfpu_vxsat_o         (mfpu_vxsat                      ),
+    .mfpu_vxrm_i          (alu_vxrm_i                      ),
     // Interface with CVA6
     .fflags_ex_o          (fflags_ex_o                     ),
     .fflags_ex_valid_o    (fflags_ex_valid_o               ),

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -22,6 +22,9 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     input  logic                         clk_i,
     input  logic                         rst_ni,
     input  logic[idx_width(NrLanes)-1:0] lane_id_i,
+    // Interface with Dispatcher
+    output logic                         mfpu_vxsat_o,
+    input  vxrm_t                        mfpu_vxrm_i,
     // Interface with CVA6
     output logic           [4:0]         fflags_ex_o,
     output logic                         fflags_ex_valid_o,
@@ -177,7 +180,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
 
   logic vinsn_issue_mul, vinsn_issue_div, vinsn_issue_fpu;
 
-  assign vinsn_issue_mul = vinsn_issue_q.op inside {[VMUL:VNMSUB]};
+  assign vinsn_issue_mul = vinsn_issue_q.op inside {[VMUL:VSMUL]};
   assign vinsn_issue_div = vinsn_issue_q.op inside {[VDIVU:VREM]};
   assign vinsn_issue_fpu = vinsn_issue_q.op inside {[VFADD:VMFGE]};
 
@@ -280,7 +283,12 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   // We let the mask percolate throughout the pipeline to have the mask unit synchronized with the
   // operand queues
   // Another choice would be to delay the mask grant when the vmul_result is committed
-  strb_t [3:0] vmul_simd_mask;
+  strb_t  [3:0] vmul_simd_mask;
+  vxsat_t [3:0] mfpu_vxsat;
+  logic   [7:0] mfpu_vxsat_q, mfpu_vxsat_d;
+
+  // mfpu saturation calculation
+  assign mfpu_vxsat_o = |(mfpu_vxsat_q & result_queue_q[result_queue_read_pnt_q].be);
 
   simd_mul #(
     .NumPipeRegs (LatMultiplierEW64),
@@ -293,6 +301,8 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     .operand_c_i(mfpu_operand_i[2]                                          ),
     .mask_i     (mask_i                                                     ),
     .op_i       (vinsn_issue_q.op                                           ),
+    .vxsat_o    (mfpu_vxsat[EW64]                                           ),
+    .vxrm_i     (mfpu_vxrm_i                                                ),
     .result_o   (vmul_simd_result[EW64]                                     ),
     .mask_o     (vmul_simd_mask[EW64]                                       ),
     .valid_i    (vmul_simd_in_valid[EW64]                                   ),
@@ -312,6 +322,8 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     .operand_c_i(mfpu_operand_i[2]                                          ),
     .mask_i     (mask_i                                                     ),
     .op_i       (vinsn_issue_q.op                                           ),
+    .vxsat_o    (mfpu_vxsat[EW32]                                           ),
+    .vxrm_i     (mfpu_vxrm_i                                                ),
     .result_o   (vmul_simd_result[EW32]                                     ),
     .mask_o     (vmul_simd_mask[EW32]                                       ),
     .valid_i    (vmul_simd_in_valid[EW32]                                   ),
@@ -331,6 +343,8 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     .operand_c_i(mfpu_operand_i[2]                                          ),
     .mask_i     (mask_i                                                     ),
     .op_i       (vinsn_issue_q.op                                           ),
+    .vxsat_o    (mfpu_vxsat[EW16]                                           ),
+    .vxrm_i     (mfpu_vxrm_i                                                ),
     .result_o   (vmul_simd_result[EW16]                                     ),
     .mask_o     (vmul_simd_mask[EW16]                                       ),
     .valid_i    (vmul_simd_in_valid[EW16]                                   ),
@@ -350,6 +364,8 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     .operand_c_i(mfpu_operand_i[2]                                          ),
     .mask_i     (mask_i                                                     ),
     .op_i       (vinsn_issue_q.op                                           ),
+    .vxsat_o    (mfpu_vxsat[EW8]                                            ),
+    .vxrm_i     (mfpu_vxrm_i                                                ),
     .result_o   (vmul_simd_result[EW8]                                      ),
     .mask_o     (vmul_simd_mask[EW8]                                        ),
     .valid_i    (vmul_simd_in_valid[EW8]                                    ),
@@ -371,6 +387,9 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     vmul_simd_in_valid                           = '0;
     vmul_simd_in_valid[vinsn_issue_q.vtype.vsew] = vmul_in_valid;
     vmul_in_ready                                = vmul_simd_in_ready[vinsn_issue_q.vtype.vsew];
+
+    // Saturation flag
+    mfpu_vxsat_d        = mfpu_vxsat[vinsn_processing_q.vtype.vsew];
 
     // We read the responses of a single SIMD Multiplier
     vmul_result         = vmul_simd_result[vinsn_processing_q.vtype.vsew];
@@ -1138,7 +1157,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
 
         // Select the correct valid, result, and mask, to write in the result queue
         case (vinsn_processing_q.op) inside
-          [VMUL:VNMSUB]: begin
+          [VMUL:VSMUL]: begin
             unit_out_valid  = vmul_out_valid;
             unit_out_result = vmul_result;
             unit_out_mask   = vmul_mask;
@@ -1869,6 +1888,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       intra_issued_op_cnt_q   <= '0;
       intra_op_rx_cnt_q       <= '0;
       osum_issue_cnt_q        <= '0;
+      mfpu_vxsat_q            <= '0;
     end else begin
       issue_cnt_q             <= issue_cnt_d;
       to_process_cnt_q        <= to_process_cnt_d;
@@ -1891,6 +1911,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       intra_issued_op_cnt_q   <= intra_issued_op_cnt_d;
       intra_op_rx_cnt_q       <= intra_op_rx_cnt_d;
       osum_issue_cnt_q        <= osum_issue_cnt_d;
+      mfpu_vxsat_q            <= mfpu_vxsat_d;
     end
   end
 

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -9,15 +9,17 @@
 
 module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   import cf_math_pkg::idx_width; #(
-    parameter  int           unsigned NrLanes    = 0,
+    parameter  int           unsigned NrLanes      = 0,
     // Support for floating-point data types
-    parameter  fpu_support_e          FPUSupport = FPUSupportHalfSingleDouble,
+    parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    // Support for fixed-point data types
+    parameter  logic                  FixPtSupport = FixedPointEnable,
     // Type used to address vector register file elements
-    parameter  type                   vaddr_t    = logic,
+    parameter  type                   vaddr_t      = logic,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int           unsigned DataWidth  = $bits(elen_t),
-    localparam int           unsigned StrbWidth  = DataWidth/8,
-    localparam type                   strb_t     = logic [DataWidth/8-1:0]
+    localparam int           unsigned DataWidth    = $bits(elen_t),
+    localparam int           unsigned StrbWidth    = DataWidth/8,
+    localparam type                   strb_t       = logic [DataWidth/8-1:0]
   ) (
     input  logic                         clk_i,
     input  logic                         rst_ni,
@@ -291,6 +293,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   assign mfpu_vxsat_o = |(mfpu_vxsat_q & result_queue_q[result_queue_read_pnt_q].be);
 
   simd_mul #(
+    .FixPtSupport(FixPtSupport     ),
     .NumPipeRegs (LatMultiplierEW64),
     .ElementWidth(EW64             )
   ) i_simd_mul_ew64 (
@@ -312,6 +315,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   );
 
   simd_mul #(
+    .FixPtSupport(FixPtSupport     ),
     .NumPipeRegs (LatMultiplierEW32),
     .ElementWidth(EW32             )
   ) i_simd_mul_ew32 (
@@ -333,6 +337,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   );
 
   simd_mul #(
+    .FixPtSupport(FixPtSupport     ),
     .NumPipeRegs (LatMultiplierEW16),
     .ElementWidth(EW16             )
   ) i_simd_mul_ew16 (
@@ -354,6 +359,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   );
 
   simd_mul #(
+    .FixPtSupport(FixPtSupport     ),
     .NumPipeRegs (LatMultiplierEW8),
     .ElementWidth(EW8             )
   ) i_simd_mul_ew8 (

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -102,7 +102,7 @@ module ara_tb;
     if (binary != "") begin
       // Read ELF
       read_elf(binary);
-      $display("Loading %s", binary);
+      $display("Loading ELF file %s", binary);
       while (get_section(address, length)) begin
         // Read sections
         automatic int nwords = (length + AxiWideBeWidth - 1)/AxiWideBeWidth;
@@ -123,6 +123,9 @@ module ara_tb;
             $display("Cannot initialize address %x, which doesn't fall into the L2 region.", address);
         end
       end
+    end else begin
+        $error("Expecting a firmware to run, non was provided!");
+        $finish;
     end
   end : dram_init
 

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -124,8 +124,8 @@ module ara_tb;
         end
       end
     end else begin
-        $error("Expecting a firmware to run, none was provided!");
-        $finish;
+      $error("Expecting a firmware to run, none was provided!");
+      $finish;
     end
   end : dram_init
 

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -124,7 +124,7 @@ module ara_tb;
         end
       end
     end else begin
-        $error("Expecting a firmware to run, non was provided!");
+        $error("Expecting a firmware to run, none was provided!");
         $finish;
     end
   end : dram_init


### PR DESCRIPTION
Add support for `vssra`, `vssrl`, `vnclip`, `vnclipu` and `vsmul` vector fixed-point instructions

## Changelog

### Fixed

- N/A

### Added

- Support for vector single-width fractional multiply with rounding and saturation instruction: `vsmul`
- Support for vector single-width scaling shift instructions: `vssra`, `vssrl`
- Support for vector narrowing fixed-point clip instructions: `vnclip`, `vnclipu`
- Test for `vnclip` and `vnclipu` vector fixed-point instructions

### Changed

- Updated tests for `vssra`, `vssrl` and `vsmul` vector fixed-point instructions

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
