### PR TITLE
[HW] :bug: Reshuffle the source registers when VSEW != EEW_Q

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - `vslide1up` always writes the scalar element in `vd`
  - Don't trim `vslide1up` counters since it always writes the scalar element
  - Wait for the current reduction to be over to execute the next VALU instruction, also when reduction workload is unbalanced and some lanes are only a pass-through
+ - Reshuffle the source registers vs when an in-lane operation operates on element with vsew != eew_q[vs]
 
 ### Added
 
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Vector floating-point classify instruction (`vfclass`)
  - Vector floating-point divide instructions (`vfdiv`, `vfrdiv`)
  - Vector floating-point square-root instruction (`vfsqrt`)
+ - Add simple test for source registers reshuffle, when VSEW != EEW_vs
 
 ### Changed
 
@@ -78,6 +80,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Halve CVA6's L1 caches to ease backend timing closure
  - Remove CVA6's cache patch from `hardware/patches` (CVA6 is now updated)
  - Increase addrgen queue depth to four, to better hide memory latency
+ - The RESHUFFLE state is now iterative and reshuffles all the vector registers that need this operation
 
 ## 2.2.0 - 2021-11-02
 

--- a/apps/riscv-tests/isa/rv64uv/vadd.c
+++ b/apps/riscv-tests/isa/rv64uv/vadd.c
@@ -175,6 +175,17 @@ void TEST_CASE6(void) {
   VCMP_U64(24, v3, 0, 7, 0, 9, 0, 11, 0, 13, 0, 7, 0, 9, 0, 11, 0, 13);
 }
 
+// Check that the addition also works when source register EEWs are changed
+void TEST_CASE7(void) {
+  VSET(16, e8, m1);
+  VLOAD_8(v1, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VLOAD_8(v2, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+  VSET(8, e16, m1);
+  asm volatile("vadd.vv v3, v1, v2");
+  VSET(16, e8, m1);
+  VCMP_U8(25, v3, 2, 4, 6, 8, 10, 12, 14, 16, 2, 4, 6, 8, 10, 12, 14, 16);
+}
+
 int main(void) {
   INIT_CHECK();
   enable_vec();
@@ -185,6 +196,7 @@ int main(void) {
   TEST_CASE4();
   TEST_CASE5();
   TEST_CASE6();
+  TEST_CASE7();
 
   EXIT_CHECK();
 }

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -231,7 +231,16 @@ package ara_pkg;
   typedef struct packed {
     ara_op_e op; // Operation
 
-    // Rescale vl taking into account the new and old EEW
+    // Stores and slides do not re-shuffle the
+    // source registers. In these two cases, vl refers
+    // to the target EEW and vtype.vsew, respectively.
+    // Since operand requesters work with the old
+    // eew of the source registers, we should rescale
+    // vl to the old eew to fetch the correct number of Bytes.
+    //
+    // Another solution would be to pass directly the target
+    // eew (vstores) or the vtype.vsew (vslides), but this would
+    // create confusion with the current naming convention
     logic scale_vl;
 
     // Mask vector register operand

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -290,22 +290,22 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
           unique case (cmd.ntr_red)
             2'b00: begin
               unique case (cmd.eew)
-                EW16: conv_operand = {32'd0, ibuf_operand[31:0]};
-                EW32: conv_operand = ibuf_operand;
+                EW32: conv_operand = {32'd0, ibuf_operand[31:0]};
+                EW64: conv_operand = ibuf_operand;
                 default:;
               endcase
             end
             2'b01: begin
               unique case (cmd.eew)
-                EW16: conv_operand = {32'h7f800000, ibuf_operand[31:0]};
-                EW32: conv_operand = ibuf_operand;
+                EW32: conv_operand = {32'h7f800000, ibuf_operand[31:0]};
+                EW64: conv_operand = ibuf_operand;
                 default:;
               endcase
             end
             2'b10: begin
               unique case (cmd.eew)
-                EW16: conv_operand = {32'hff800000, ibuf_operand[31:0]};
-                EW32: conv_operand = ibuf_operand;
+                EW32: conv_operand = {32'hff800000, ibuf_operand[31:0]};
+                EW64: conv_operand = ibuf_operand;
                 default:;
               endcase
             end
@@ -315,22 +315,22 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
           unique case (cmd.ntr_red)
             2'b00: begin
               unique case (cmd.eew)
-                EW16: conv_operand = '0;
                 EW32: conv_operand = '0;
+                EW64: conv_operand = '0;
                 default:;
               endcase
             end
             2'b01: begin
               unique case (cmd.eew)
-                EW16: conv_operand = {2{32'h7f800000}};
-                EW32: conv_operand = 64'h7ff0000000000000;
+                EW32: conv_operand = {2{32'h7f800000}};
+                EW64: conv_operand = 64'h7ff0000000000000;
                 default:;
               endcase
             end
             2'b10: begin
               unique case (cmd.eew)
-                EW16: conv_operand = {2{32'hff800000}};
-                EW32: conv_operand = 64'hfff0000000000000;
+                EW32: conv_operand = {2{32'hff800000}};
+                EW64: conv_operand = 64'hfff0000000000000;
                 default:;
               endcase
             end


### PR DESCRIPTION
Currently, the `eew` signals are not fully consistent within the design, and lead to several bugs.
With this PR, we will define strict rules to implement correctly VRF Byte encoding, Undisturbed Policy, and Reading from registers with a `EEW` (and encoding!) different from `VSEW`. 

In the case of an operation executed within the lanes (e.g., `vadd`), the lanes cannot read the vector correctly if the `vsew` of the source register is different from the `eew_q` of that register (different byte layout!). So, we need to reshuffle in this case as well. Since this is costly, the suggested software procedure is to avoid filling a register with a specific encoding and using it with a different one.

## Changelog

### Added

- Add simple test for reshuffle operation when `vsew != eew_vs`

### Fixed

- Reshuffle the source registers `vs` when an in-lane operation operates on element with `vsew != eew_q[vs]`

### Changed

- The `RESHUFFLE` state is now iterative and reshuffles all the vector registers that need this operation.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
