### PR TITLE
[SW] New Benchmarks: `exp-cos-log` (+plot performance)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        app:        [hello_world, imatmul, fmatmul, iconv2d, fconv2d, fconv3d, jacobi2d, dropout, fft, dwt]
+        app:        [hello_world, imatmul, fmatmul, iconv2d, fconv2d, fconv3d, jacobi2d, dropout, fft, dwt, exp]
         ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["compile-ara", "compile-apps"]
     steps:
@@ -566,6 +566,11 @@ jobs:
       with:
         name: dwt_roofline
         path: dwt.png
+    - name: Upload the exp roofline
+      uses: actions/upload-artifact@v2
+      with:
+        name: exp_roofline
+        path: exp.png
 
 ####################
 #  Clean-up stage  #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Plot dropout performance
  - Add FFT benchmark and print its performance
  - Add DWT benchmark and print its performance
+ - Add fp-exp, fp-cos, fp-log benchmarks from rivec bmark suite + print performance
+ - Ideal Dispatcher tracer now supports strided memory operations
 
 ### Changed
 
@@ -100,6 +102,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Default con vlen in the config files is now NR_LANES*1024
  - Optimize jacobi2d in ASM, +align store address
  - Replace `apps/common/script/datagen.sh` with new input data source-of-truth (`apps/common/default_arguments.mk`) during app compilation
+ - benchmark.sh can now also benchmark just one app at a time via an input argument
 
 ## 2.2.0 - 2021-11-02
 

--- a/apps/benchmarks/benchmark/exp.bmark
+++ b/apps/benchmarks/benchmark/exp.bmark
@@ -1,0 +1,64 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Matteo Perotti
+
+#include "../kernel/exp.h"
+
+#include "runtime.h"
+#include "util.h"
+
+#ifndef SPIKE
+#include "printf.h"
+#else
+#include <stdio.h>
+#endif
+
+extern size_t N_f64;
+extern double exponents_f64[] __attribute__((aligned(4 * NR_LANES)));
+extern double results_f64[] __attribute__((aligned(4 * NR_LANES)));
+extern double gold_results_f64[] __attribute__((aligned(4 * NR_LANES)));
+
+extern size_t N_f32;
+extern float exponents_f32[] __attribute__((aligned(4 * NR_LANES)));
+extern float results_f32[] __attribute__((aligned(4 * NR_LANES)));
+extern float gold_results_f32[] __attribute__((aligned(4 * NR_LANES)));
+
+#define THRESHOLD 1
+
+int main() {
+  printf("\n");
+  printf("==========\n");
+  printf("=  FEXP  =\n");
+  printf("==========\n");
+  printf("\n");
+  printf("\n");
+
+  int64_t runtime;
+
+  printf("Executing exponential on %d 64-bit data...\n", N_f64);
+
+  start_timer();
+  exp_1xf64_bmark(exponents_f64, results_f64, N_f64);
+  stop_timer();
+
+  runtime = get_timer();
+  printf("The execution took %d cycles.\n", runtime);
+
+  printf("[cycles]: %ld\n", runtime);
+
+  return 0;
+}

--- a/apps/benchmarks/kernel/exp.c
+++ b/apps/benchmarks/kernel/exp.c
@@ -1,0 +1,1 @@
+../../exp/kernel/exp.c

--- a/apps/benchmarks/kernel/exp.h
+++ b/apps/benchmarks/kernel/exp.h
@@ -1,0 +1,1 @@
+../../exp/kernel/exp.h

--- a/apps/benchmarks/main.c
+++ b/apps/benchmarks/main.c
@@ -55,6 +55,9 @@
 #elif defined(DWT)
 #include "benchmark/dwt.bmark"
 
+#elif defined(EXP)
+#include "benchmark/exp.bmark"
+
 #else
 #error                                                                         \
     "Error, no kernel was specified. Please, run 'make bin/benchmarks ENV_DEFINES=-D${KERNEL}', where KERNEL contains the kernel to benchmark. For example: 'make bin/benchmarks ENV_DEFINES=-DIMATMUL'."

--- a/apps/common/default_args.mk
+++ b/apps/common/default_args.mk
@@ -14,3 +14,7 @@ def_args_dropout     = "1024"
 def_args_fft         = "64 float32"
 # Vector size
 def_args_dwt         = "512"
+# Vector size
+def_args_exp         = "512"
+def_args_cos         = "512"
+def_args_log         = "512"

--- a/apps/common/rivec/LICENSE
+++ b/apps/common/rivec/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2020, Barcelona Supercomputing Center
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met: redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer;
+redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution;
+neither the name of the copyright holders nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+If you use this software or a modified version of it for your research, please cite the paper:
+Cristóbal Ramírez, César Hernandez, Oscar Palomar, Osman Unsal, Marco Ramírez, and Adrián Cristal. 2020. A RISC-V Simulator and Benchmark Suite for Designing and Evaluating Vector Architectures. ACM Trans. Archit. Code Optim. 17, 4, Article 38 (October 2020), 29 pages. https://doi.org/10.1145/3422667

--- a/apps/common/rivec/vector_defines.h
+++ b/apps/common/rivec/vector_defines.h
@@ -1,0 +1,130 @@
+// Modified version of:
+// vector_defines.h
+// https://github.com/RALC88/riscv-vectorized-benchmark-suite/blob/rvv-1.0/common/vector_defines.h
+// Find details on the original version below
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+// RISC-V VECTOR intrinsics mapping by Cristóbal Ramírez Lazo, "Barcelona 2019"
+
+#include "riscv_vector.h"
+
+/*
+  Data-Type Intrinsics
+*/
+
+#define _MMR_f64 vfloat64m1_t
+#define _MMR_f32 vfloat32m1_t
+
+#define _MMR_i64 vint64m1_t
+#define _MMR_i32 vint32m1_t
+
+#define _MMR_u64 vuint64m1_t
+#define _MMR_u32 vuint32m1_t
+
+#define _MMR_MASK_i64 vbool64_t
+#define _MMR_MASK_i32 vbool32_t
+
+/*
+  Reinterpret Intrinsics
+*/
+
+#define _MM_CAST_i32_u32(op1) vreinterpret_v_u32m1_i32m1(op1)
+#define _MM_CAST_u32_i32(op1) vreinterpret_v_i32m1_u32m1(op1)
+#define _MM_CAST_i64_u64(op1) vreinterpret_v_u64m1_i64m1(op1)
+#define _MM_CAST_u64_i64(op1) vreinterpret_v_i64m1_u64m1(op1)
+
+#define _MM_CAST_i32_f32(op1) vreinterpret_v_f32m1_i32m1(op1)
+#define _MM_CAST_u32_f32(op1) vreinterpret_v_f32m1_u32m1(op1)
+#define _MM_CAST_f32_i32(op1) vreinterpret_v_i32m1_f32m1(op1)
+#define _MM_CAST_f32_u32(op1) vreinterpret_v_u32m1_f32m1(op1)
+
+#define _MM_CAST_i64_f64(op1) vreinterpret_v_f64m1_i64m1(op1)
+#define _MM_CAST_u64_f64(op1) vreinterpret_v_f64m1_u64m1(op1)
+#define _MM_CAST_f64_i64(op1) vreinterpret_v_i64m1_f64m1(op1)
+#define _MM_CAST_f64_u64(op1) vreinterpret_v_u64m1_f64m1(op1)
+
+/*
+  Integer Intrinsics
+*/
+
+#define _MM_SET_i64(op1, vl) vmv_v_x_i64m1(op1, vl)
+#define _MM_SET_i32(op1, vl) vmv_v_x_i32m1(op1, vl)
+
+#define _MM_MERGE_i64(op1, op2, op3, vl) vmerge_vvm_i64m1(op3, op1, op2, vl)
+#define _MM_MERGE_i32(op1, op2, op3, vl) vmerge_vvm_i32m1(op3, op1, op2, vl)
+
+#define _MM_AND_i64(op1, op2, vl) vand_vv_i64m1(op1, op2, vl)
+#define _MM_AND_i32(op1, op2, vl) vand_vv_i32m1(op1, op2, vl)
+
+#define _MM_OR_i64(op1, op2, vl) vor_vv_i64m1(op1, op2, vl)
+#define _MM_OR_i32(op1, op2, vl) vor_vv_i32m1(op1, op2, vl)
+
+#define _MM_XOR_i64(op1, op2, vl) vxor_vv_i64m1(op1, op2, vl)
+#define _MM_XOR_i32(op1, op2, vl) vxor_vv_i32m1(op1, op2, vl)
+
+#define _MM_SLL_i64(op1, op2, vl) vsll_vv_i64m1(op1, op2, vl)
+#define _MM_SLL_i32(op1, op2, vl) vsll_vv_i32m1(op1, op2, vl)
+
+#define _MM_SRL_i64(op1, op2, vl) vsrl_vv_u64m1(op1, op2, vl)
+#define _MM_SRL_i32(op1, op2, vl) vsrl_vv_u32m1(op1, op2, vl)
+
+#define _MM_ADD_i64(op1, op2, vl) vadd_vv_i64m1(op1, op2, vl)
+#define _MM_ADD_i32(op1, op2, vl) vadd_vv_i32m1(op1, op2, vl)
+
+#define _MM_SUB_i64(op1, op2, vl) vsub_vv_i64m1(op1, op2, vl)
+#define _MM_SUB_i32(op1, op2, vl)  vsub_vv_i32m1(op1, op2, vl)
+
+#define _MM_MUL_i64(op1, op2, vl) vmul_vv_i64m1(op1, op2, vl)
+#define _MM_MUL_i32(op1, op2, vl) vmul_vv_i32m1(op1, op2, vl)
+
+#define _MM_VMSEQ_i64(op1, op2, vl) vmseq_vv_i64m1_b64(op1, op2, vl)
+#define _MM_VMSEQ_i32(op1, op2, vl) vmseq_vv_i32m1_b32(op1, op2, vl)
+
+/*
+  Floating-Point Intrinsics
+*/
+
+#define _MM_SET_f64(op1, vl) vfmv_v_f_f64m1(op1, vl)
+#define _MM_SET_f32(op1, vl) vfmv_v_f_f32m1(op1, vl)
+
+#define _MM_MERGE_f64(op1, op2, op3, vl) vmerge_vvm_f64m1(op3, op1, op2, vl)
+#define _MM_MERGE_f32(op1, op2, op3, vl) vmerge_vvm_f32m1(op3, op1, op2, vl)
+
+#define _MM_MAX_f64(op1, op2, vl) vfmax_vv_f64m1(op1, op2, vl)
+#define _MM_MAX_f32(op1, op2, vl) vfmax_vv_f32m1(op1, op2, vl)
+
+#define _MM_ADD_f64(op1, op2, vl) vfadd_vv_f64m1(op1, op2, vl)
+#define _MM_ADD_f32(op1, op2, vl) vfadd_vv_f32m1(op1, op2, vl)
+
+#define _MM_SUB_f64(op1, op2, vl) vfsub_vv_f64m1(op1, op2, vl)
+#define _MM_SUB_f32(op1, op2, vl) vfsub_vv_f32m1(op1, op2, vl)
+
+#define _MM_MUL_f64(op1, op2, vl) vfmul_vv_f64m1(op1, op2, vl)
+#define _MM_MUL_f32(op1, op2, vl) vfmul_vv_f32m1(op1, op2, vl)
+
+#define _MM_MACC_f64(op1, op2, op3, vl) vfmacc_vv_f64m1(op1, op2, op3, vl)
+#define _MM_MACC_f32(op1, op2, op3, vl) vfmacc_vv_f32m1(op1, op2, op3, vl)
+
+#define _MM_MADD_f64(op1, op2, op3, vl) vfmadd_vv_f64m1(op1, op2, op3, vl)
+#define _MM_MADD_f32(op1, op2, op3, vl) vfmadd_vv_f32m1(op1, op2, op3, vl)
+
+#define _MM_VFCVT_F_X_f64(op1, vl)  vfcvt_f_x_v_f64m1(op1, vl)
+#define _MM_VFCVT_F_X_f32(op1, vl)  vfcvt_f_x_v_f32m1(op1, vl)
+#define _MM_VFCVT_X_F_i64(op1, vl)  vfcvt_x_f_v_i64m1(op1, vl)
+#define _MM_VFCVT_X_F_i32(op1, vl)  vfcvt_x_f_v_i32m1(op1, vl)
+#define _MM_VFWCVT_F_F_f64(op1, vl) vfwcvt_f_f_v_f64m2(op1, vl)
+#define _MM_VFNCVT_F_F_f32(op1, vl) vfncvt_f_f_w_f32m1(op1, vl)
+#define _MM_VFWCVT_F_X_f64(op1, vl) vfwcvt_f_x_v_f64m2(op1, vl)
+#define _MM_VFCVT_f32_i32(op1, vl)  vfcvt_f_x_v_f32m1(op1, vl)
+
+#define _MM_VFLE_f64(op1, op2, vl) vmfle_vv_f64m1_b64(op1, op2, vl)
+#define _MM_VFLE_f32(op1, op2, vl) vmfle_vv_f32m1_b32(op1, op2, vl)
+
+#define _MM_VFLT_f64(op1, op2, vl) vmflt_vv_f64m1_b64(op1, op2, vl)
+#define _MM_VFLT_f32(op1, op2, vl) vmflt_vv_f32m1_b32(op1, op2, vl)
+
+/*
+  Ancillary Defines
+*/
+
+#define FENCE() asm volatile("fence");

--- a/apps/common/rivec/vector_defines.h
+++ b/apps/common/rivec/vector_defines.h
@@ -72,7 +72,7 @@
 #define _MM_ADD_i32(op1, op2, vl) vadd_vv_i32m1(op1, op2, vl)
 
 #define _MM_SUB_i64(op1, op2, vl) vsub_vv_i64m1(op1, op2, vl)
-#define _MM_SUB_i32(op1, op2, vl)  vsub_vv_i32m1(op1, op2, vl)
+#define _MM_SUB_i32(op1, op2, vl) vsub_vv_i32m1(op1, op2, vl)
 
 #define _MM_MUL_i64(op1, op2, vl) vmul_vv_i64m1(op1, op2, vl)
 #define _MM_MUL_i32(op1, op2, vl) vmul_vv_i32m1(op1, op2, vl)
@@ -108,14 +108,14 @@
 #define _MM_MADD_f64(op1, op2, op3, vl) vfmadd_vv_f64m1(op1, op2, op3, vl)
 #define _MM_MADD_f32(op1, op2, op3, vl) vfmadd_vv_f32m1(op1, op2, op3, vl)
 
-#define _MM_VFCVT_F_X_f64(op1, vl)  vfcvt_f_x_v_f64m1(op1, vl)
-#define _MM_VFCVT_F_X_f32(op1, vl)  vfcvt_f_x_v_f32m1(op1, vl)
-#define _MM_VFCVT_X_F_i64(op1, vl)  vfcvt_x_f_v_i64m1(op1, vl)
-#define _MM_VFCVT_X_F_i32(op1, vl)  vfcvt_x_f_v_i32m1(op1, vl)
+#define _MM_VFCVT_F_X_f64(op1, vl) vfcvt_f_x_v_f64m1(op1, vl)
+#define _MM_VFCVT_F_X_f32(op1, vl) vfcvt_f_x_v_f32m1(op1, vl)
+#define _MM_VFCVT_X_F_i64(op1, vl) vfcvt_x_f_v_i64m1(op1, vl)
+#define _MM_VFCVT_X_F_i32(op1, vl) vfcvt_x_f_v_i32m1(op1, vl)
 #define _MM_VFWCVT_F_F_f64(op1, vl) vfwcvt_f_f_v_f64m2(op1, vl)
 #define _MM_VFNCVT_F_F_f32(op1, vl) vfncvt_f_f_w_f32m1(op1, vl)
 #define _MM_VFWCVT_F_X_f64(op1, vl) vfwcvt_f_x_v_f64m2(op1, vl)
-#define _MM_VFCVT_f32_i32(op1, vl)  vfcvt_f_x_v_f32m1(op1, vl)
+#define _MM_VFCVT_f32_i32(op1, vl) vfcvt_f_x_v_f32m1(op1, vl)
 
 #define _MM_VFLE_f64(op1, op2, vl) vmfle_vv_f64m1_b64(op1, op2, vl)
 #define _MM_VFLE_f32(op1, op2, vl) vmfle_vv_f32m1_b32(op1, op2, vl)

--- a/apps/cos/LICENSE
+++ b/apps/cos/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2020, Barcelona Supercomputing Center
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met: redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer;
+redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution;
+neither the name of the copyright holders nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+If you use this software or a modified version of it for your research, please cite the paper:
+Cristóbal Ramírez, César Hernandez, Oscar Palomar, Osman Unsal, Marco Ramírez, and Adrián Cristal. 2020. A RISC-V Simulator and Benchmark Suite for Designing and Evaluating Vector Architectures. ACM Trans. Archit. Code Optim. 17, 4, Article 38 (October 2020), 29 pages. https://doi.org/10.1145/3422667

--- a/apps/cos/kernel/cos.c
+++ b/apps/cos/kernel/cos.c
@@ -16,8 +16,9 @@
 //
 // Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
-void cos_1xf64_bmark(double* angles, double* results, size_t len) {
 #include "cos.h"
+
+void cos_1xf64_bmark(double *angles, double *results, size_t len) {
 
   size_t avl = len;
   vfloat64m1_t cos_vec, res_vec;
@@ -33,11 +34,11 @@ void cos_1xf64_bmark(double* angles, double* results, size_t len) {
     vse64_v_f64m1(results, res_vec, vl);
     // Bump pointers
     angles += vl;
-    results   += vl;
+    results += vl;
   }
 }
 
-void cos_2xf32_bmark(float* angles, float* results, size_t len) {
+void cos_2xf32_bmark(float *angles, float *results, size_t len) {
 
   size_t avl = len;
   vfloat32m1_t cos_vec, res_vec;
@@ -53,6 +54,6 @@ void cos_2xf32_bmark(float* angles, float* results, size_t len) {
     vse32_v_f32m1(results, res_vec, vl);
     // Bump pointers
     angles += vl;
-    results   += vl;
+    results += vl;
   }
 }

--- a/apps/cos/kernel/cos.c
+++ b/apps/cos/kernel/cos.c
@@ -1,0 +1,58 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+void cos_1xf64_bmark(double* angles, double* results, size_t len) {
+#include "cos.h"
+
+  size_t avl = len;
+  vfloat64m1_t cos_vec, res_vec;
+
+  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e64m1(avl);
+    // Load vector
+    cos_vec = vle64_v_f64m1(angles, vl);
+    // Compute
+    res_vec = __cos_1xf64(cos_vec, vl);
+    // Store
+    vse64_v_f64m1(results, res_vec, vl);
+    // Bump pointers
+    angles += vl;
+    results   += vl;
+  }
+}
+
+void cos_2xf32_bmark(float* angles, float* results, size_t len) {
+
+  size_t avl = len;
+  vfloat32m1_t cos_vec, res_vec;
+
+  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e32m1(avl);
+    // Load vector
+    cos_vec = vle32_v_f32m1(angles, vl);
+    // Compute
+    res_vec = __cos_2xf32(cos_vec, vl);
+    // Store
+    vse32_v_f32m1(results, res_vec, vl);
+    // Bump pointers
+    angles += vl;
+    results   += vl;
+  }
+}

--- a/apps/cos/kernel/cos.h
+++ b/apps/cos/kernel/cos.h
@@ -1,10 +1,11 @@
 // Modified version of:
-// "RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
-// Find details on the original version below
-// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+// "RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona
+// 2019"" Find details on the original version below Author: Matteo Perotti
+// <mperotti@iis.ee.ethz.ch>
 
-// RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
-// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+// RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona
+// 2019" This RISC-V Vector implementation is based on the original code
+// presented by Julien Pommier
 
 /*
    AVX implementation of sin, cos, sincos, exp and log
@@ -36,238 +37,249 @@
 
 #include "rivec/vector_defines.h"
 
-void cos_1xf64_bmark(double* angles, double* results, size_t len);
-void cos_2xf32_bmark(float* angles, float* results, size_t len);
+void cos_1xf64_bmark(double *angles, double *results, size_t len);
+void cos_2xf32_bmark(float *angles, float *results, size_t len);
 
-inline _MMR_f64 __cos_1xf64(_MMR_f64 x , size_t gvl) {
+inline _MMR_f64 __cos_1xf64(_MMR_f64 x, size_t gvl) {
 
-_MMR_i64   _ps_inv_sign_mask    = _MM_SET_i64(~0x8000000000000000,gvl);
-_MMR_f64   _ps_cephes_FOPI      = _MM_SET_f64(1.27323954473516,gvl); // 4 / M_PI
-_MMR_i64   _pi32_1              = _MM_SET_i64(1,gvl);
-_MMR_i64   _pi32_inv1           = _MM_SET_i64(~0x0000000000000001,gvl);
-_MMR_i64   _pi32_2              = _MM_SET_i64(2,gvl);
-_MMR_i64   _pi32_4              = _MM_SET_i64(4,gvl);
-_MMR_i64   _Zero                = _MM_SET_i64(0,gvl);
+  _MMR_i64 _ps_inv_sign_mask = _MM_SET_i64(~0x8000000000000000, gvl);
+  _MMR_f64 _ps_cephes_FOPI = _MM_SET_f64(1.27323954473516, gvl); // 4 / M_PI
+  _MMR_i64 _pi32_1 = _MM_SET_i64(1, gvl);
+  _MMR_i64 _pi32_inv1 = _MM_SET_i64(~0x0000000000000001, gvl);
+  _MMR_i64 _pi32_2 = _MM_SET_i64(2, gvl);
+  _MMR_i64 _pi32_4 = _MM_SET_i64(4, gvl);
+  _MMR_i64 _Zero = _MM_SET_i64(0, gvl);
 
-_MMR_f64   xmm2 =  _MM_SET_f64(0.0f,gvl);
-_MMR_f64   xmm1;
-_MMR_f64   xmm3;
-_MMR_f64   y;
+  _MMR_f64 xmm2 = _MM_SET_f64(0.0f, gvl);
+  _MMR_f64 xmm1;
+  _MMR_f64 xmm3;
+  _MMR_f64 y;
 
-_MMR_i64   emm0;
-_MMR_i64   emm2;
+  _MMR_i64 emm0;
+  _MMR_i64 emm2;
 
-_MMR_MASK_i64 xMask;
+  _MMR_MASK_i64 xMask;
   /* take the absolute value */
-  x = _MM_CAST_f64_i64(_MM_AND_i64(_MM_CAST_i64_f64(x), _ps_inv_sign_mask, gvl));
+  x = _MM_CAST_f64_i64(
+      _MM_AND_i64(_MM_CAST_i64_f64(x), _ps_inv_sign_mask, gvl));
 
   /* scale by 4/Pi */
   y = _MM_MUL_f64(x, _ps_cephes_FOPI, gvl);
 
   /* store the integer part of y in mm0 */
-  emm2 = _MM_VFCVT_X_F_i64(y,gvl);
+  emm2 = _MM_VFCVT_X_F_i64(y, gvl);
 
   /* j=(j+1) & (~1) (see the cephes sources) */
-  emm2 = _MM_ADD_i64(emm2,_pi32_1,gvl);
-  emm2 = _MM_AND_i64(emm2, _pi32_inv1,gvl);
-  y = _MM_VFCVT_F_X_f64(emm2,gvl);
+  emm2 = _MM_ADD_i64(emm2, _pi32_1, gvl);
+  emm2 = _MM_AND_i64(emm2, _pi32_inv1, gvl);
+  y = _MM_VFCVT_F_X_f64(emm2, gvl);
 
-  emm2 = _MM_SUB_i64(emm2, _pi32_2,gvl);
+  emm2 = _MM_SUB_i64(emm2, _pi32_2, gvl);
 
   /* get the swap sign flag */
-  emm0 = _MM_XOR_i64(emm2, _MM_SET_i64(0xffffffffffffffff,gvl),gvl);
-  emm0 = _MM_AND_i64(emm0, _pi32_4,gvl);
+  emm0 = _MM_XOR_i64(emm2, _MM_SET_i64(0xffffffffffffffff, gvl), gvl);
+  emm0 = _MM_AND_i64(emm0, _pi32_4, gvl);
 
-  emm0 = _MM_SLL_i64(emm0, _MM_CAST_u64_i64(_MM_SET_i64(61,gvl)),gvl);
+  emm0 = _MM_SLL_i64(emm0, _MM_CAST_u64_i64(_MM_SET_i64(61, gvl)), gvl);
 
   /* get the polynom selection mask */
-  emm2 = _MM_AND_i64(emm2, _pi32_2 ,gvl);
-  xMask= _MM_VMSEQ_i64(emm2,_Zero,gvl);
-  emm2 = _MM_MERGE_i64(_Zero,_MM_SET_i64(0xffffffffffffffff,gvl), xMask,gvl);
+  emm2 = _MM_AND_i64(emm2, _pi32_2, gvl);
+  xMask = _MM_VMSEQ_i64(emm2, _Zero, gvl);
+  emm2 = _MM_MERGE_i64(_Zero, _MM_SET_i64(0xffffffffffffffff, gvl), xMask, gvl);
 
-  _MMR_f64 sign_bit =  _MM_CAST_f64_i64(emm0);
-  _MMR_f64 poly_mask =  _MM_CAST_f64_i64(emm2);
+  _MMR_f64 sign_bit = _MM_CAST_f64_i64(emm0);
+  _MMR_f64 poly_mask = _MM_CAST_f64_i64(emm2);
 
   /* The magic pass: "Extended precision modular arithmetic"
      x = ((x - y * DP1) - y * DP2) - y * DP3; */
 
-  _MMR_f64   _ps_minus_cephes_DP1    = _MM_SET_f64(-0.78515625,gvl);
-  _MMR_f64   _ps_minus_cephes_DP2    = _MM_SET_f64(-2.4187564849853515625E-4,gvl);
-  _MMR_f64   _ps_minus_cephes_DP3    = _MM_SET_f64(-3.77489497744594108E-8,gvl);
+  _MMR_f64 _ps_minus_cephes_DP1 = _MM_SET_f64(-0.78515625, gvl);
+  _MMR_f64 _ps_minus_cephes_DP2 = _MM_SET_f64(-2.4187564849853515625E-4, gvl);
+  _MMR_f64 _ps_minus_cephes_DP3 = _MM_SET_f64(-3.77489497744594108E-8, gvl);
 
   xmm1 = _ps_minus_cephes_DP1;
   xmm2 = _ps_minus_cephes_DP2;
   xmm3 = _ps_minus_cephes_DP3;
 
-  xmm1 = _MM_MUL_f64(y, xmm1,gvl);
-  xmm2 = _MM_MUL_f64(y, xmm2,gvl);
-  xmm3 = _MM_MUL_f64(y, xmm3,gvl);
+  xmm1 = _MM_MUL_f64(y, xmm1, gvl);
+  xmm2 = _MM_MUL_f64(y, xmm2, gvl);
+  xmm3 = _MM_MUL_f64(y, xmm3, gvl);
 
-  x = _MM_ADD_f64(x, xmm1,gvl);
-  x = _MM_ADD_f64(x, xmm2,gvl);
-  x = _MM_ADD_f64(x, xmm3,gvl);
+  x = _MM_ADD_f64(x, xmm1, gvl);
+  x = _MM_ADD_f64(x, xmm2, gvl);
+  x = _MM_ADD_f64(x, xmm3, gvl);
 
   /* Evaluate the first polynom  (0 <= x <= Pi/4) */
-  _MMR_f64   _ps_coscof_p0      = _MM_SET_f64(2.443315711809948E-005,gvl);
-  _MMR_f64   _ps_coscof_p1      = _MM_SET_f64(-1.388731625493765E-003,gvl);
-  _MMR_f64   _ps_coscof_p2      = _MM_SET_f64(4.166664568298827E-002,gvl);
-  _MMR_f64   _ps_0p5            = _MM_SET_f64(0.5f,gvl);
+  _MMR_f64 _ps_coscof_p0 = _MM_SET_f64(2.443315711809948E-005, gvl);
+  _MMR_f64 _ps_coscof_p1 = _MM_SET_f64(-1.388731625493765E-003, gvl);
+  _MMR_f64 _ps_coscof_p2 = _MM_SET_f64(4.166664568298827E-002, gvl);
+  _MMR_f64 _ps_0p5 = _MM_SET_f64(0.5f, gvl);
 
   _MMR_f64 z;
   _MMR_f64 tmp;
 
   y = _ps_coscof_p0;
-  z = _MM_MUL_f64(x,x,gvl);
+  z = _MM_MUL_f64(x, x, gvl);
 
-  y = _MM_MUL_f64(y, z,gvl);
-  y = _MM_ADD_f64(y, _ps_coscof_p1,gvl);
-  y = _MM_MUL_f64(y, z,gvl);
-  y = _MM_ADD_f64(y, _ps_coscof_p2,gvl);
-  y = _MM_MUL_f64(y, z,gvl);
-  y = _MM_MUL_f64(y, z,gvl);
-  tmp = _MM_MUL_f64(z, _ps_0p5,gvl);
-  y = _MM_SUB_f64(y, tmp,gvl);
-  y = _MM_ADD_f64(y, _MM_SET_f64(1.0,gvl) ,gvl);
+  y = _MM_MUL_f64(y, z, gvl);
+  y = _MM_ADD_f64(y, _ps_coscof_p1, gvl);
+  y = _MM_MUL_f64(y, z, gvl);
+  y = _MM_ADD_f64(y, _ps_coscof_p2, gvl);
+  y = _MM_MUL_f64(y, z, gvl);
+  y = _MM_MUL_f64(y, z, gvl);
+  tmp = _MM_MUL_f64(z, _ps_0p5, gvl);
+  y = _MM_SUB_f64(y, tmp, gvl);
+  y = _MM_ADD_f64(y, _MM_SET_f64(1.0, gvl), gvl);
 
   /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
-  _MMR_f64 _ps_sincof_p0 = _MM_SET_f64(-1.9515295891E-4,gvl);
+  _MMR_f64 _ps_sincof_p0 = _MM_SET_f64(-1.9515295891E-4, gvl);
   FENCE();
-  _MMR_f64 _ps_sincof_p1 = _MM_SET_f64(8.3321608736E-3,gvl);
-  _MMR_f64 _ps_sincof_p2 = _MM_SET_f64(-1.6666654611E-1,gvl);
+  _MMR_f64 _ps_sincof_p1 = _MM_SET_f64(8.3321608736E-3, gvl);
+  _MMR_f64 _ps_sincof_p2 = _MM_SET_f64(-1.6666654611E-1, gvl);
   _MMR_f64 y2;
 
   y2 = _ps_sincof_p0;
-  y2 = _MM_MUL_f64(y2, z ,gvl);
-  y2 = _MM_ADD_f64(y2, _ps_sincof_p1 ,gvl);
-  y2 = _MM_MUL_f64(y2, z ,gvl);
-  y2 = _MM_ADD_f64(y2, _ps_sincof_p2 ,gvl);
-  y2 = _MM_MUL_f64(y2, z ,gvl);
-  y2 = _MM_MUL_f64(y2, x ,gvl);
-  y2 = _MM_ADD_f64(y2, x ,gvl);
+  y2 = _MM_MUL_f64(y2, z, gvl);
+  y2 = _MM_ADD_f64(y2, _ps_sincof_p1, gvl);
+  y2 = _MM_MUL_f64(y2, z, gvl);
+  y2 = _MM_ADD_f64(y2, _ps_sincof_p2, gvl);
+  y2 = _MM_MUL_f64(y2, z, gvl);
+  y2 = _MM_MUL_f64(y2, x, gvl);
+  y2 = _MM_ADD_f64(y2, x, gvl);
 
   /* select the correct result from the two polynoms */
   xmm3 = poly_mask;
-  y2 = _MM_CAST_f64_i64(_MM_AND_i64(_MM_CAST_i64_f64(xmm3), _MM_CAST_i64_f64(y2), gvl));
-  y = _MM_CAST_f64_i64(_MM_AND_i64(_MM_XOR_i64(_MM_CAST_i64_f64(xmm3), _MM_SET_i64(0xffffffffffffffff,gvl),gvl),_MM_CAST_i64_f64(y),gvl));
-  y = _MM_ADD_f64(y, y2 ,gvl);
+  y2 = _MM_CAST_f64_i64(
+      _MM_AND_i64(_MM_CAST_i64_f64(xmm3), _MM_CAST_i64_f64(y2), gvl));
+  y = _MM_CAST_f64_i64(
+      _MM_AND_i64(_MM_XOR_i64(_MM_CAST_i64_f64(xmm3),
+                              _MM_SET_i64(0xffffffffffffffff, gvl), gvl),
+                  _MM_CAST_i64_f64(y), gvl));
+  y = _MM_ADD_f64(y, y2, gvl);
   /* update the sign */
-  y = _MM_CAST_f64_i64(_MM_XOR_i64(_MM_CAST_i64_f64(y), _MM_CAST_i64_f64(sign_bit) , gvl));
+  y = _MM_CAST_f64_i64(
+      _MM_XOR_i64(_MM_CAST_i64_f64(y), _MM_CAST_i64_f64(sign_bit), gvl));
 
   return y;
 }
 
-inline _MMR_f32 __cos_2xf32(_MMR_f32 x , size_t gvl) {
+inline _MMR_f32 __cos_2xf32(_MMR_f32 x, size_t gvl) {
 
-_MMR_i32   _ps_inv_sign_mask    = _MM_SET_i32(~0x80000000,gvl);
-_MMR_f32   _ps_cephes_FOPI      = _MM_SET_f32(1.27323954473516,gvl); // 4 / M_PI
-_MMR_i32   _pi32_1              = _MM_SET_i32(0x00000001,gvl);
-_MMR_i32   _pi32_inv1           = _MM_SET_i32(~0x00000001,gvl);
-_MMR_i32   _pi32_2              = _MM_SET_i32(2,gvl);
-_MMR_i32   _pi32_4              = _MM_SET_i32(4,gvl);
-_MMR_i32   _Zero                = _MM_SET_i32(0,gvl);
+  _MMR_i32 _ps_inv_sign_mask = _MM_SET_i32(~0x80000000, gvl);
+  _MMR_f32 _ps_cephes_FOPI = _MM_SET_f32(1.27323954473516, gvl); // 4 / M_PI
+  _MMR_i32 _pi32_1 = _MM_SET_i32(0x00000001, gvl);
+  _MMR_i32 _pi32_inv1 = _MM_SET_i32(~0x00000001, gvl);
+  _MMR_i32 _pi32_2 = _MM_SET_i32(2, gvl);
+  _MMR_i32 _pi32_4 = _MM_SET_i32(4, gvl);
+  _MMR_i32 _Zero = _MM_SET_i32(0, gvl);
 
-_MMR_f32   xmm2 =  _MM_SET_f32(0.0f,gvl);
-_MMR_f32   xmm1;
-_MMR_f32   xmm3;
-_MMR_f32   y;
+  _MMR_f32 xmm2 = _MM_SET_f32(0.0f, gvl);
+  _MMR_f32 xmm1;
+  _MMR_f32 xmm3;
+  _MMR_f32 y;
 
-_MMR_i32   emm0;
-_MMR_i32   emm2;
+  _MMR_i32 emm0;
+  _MMR_i32 emm2;
 
-_MMR_MASK_i32 xMask;
+  _MMR_MASK_i32 xMask;
   /* take the absolute value */
-  x = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(x), _ps_inv_sign_mask,gvl));
+  x = _MM_CAST_f32_i32(
+      _MM_AND_i32(_MM_CAST_i32_f32(x), _ps_inv_sign_mask, gvl));
 
   /* scale by 4/Pi */
-  y = _MM_MUL_f32(x, _ps_cephes_FOPI,gvl);
+  y = _MM_MUL_f32(x, _ps_cephes_FOPI, gvl);
 
   /* store the integer part of y in mm0 */
-  emm2 = _MM_VFCVT_X_F_i32(y,gvl);
+  emm2 = _MM_VFCVT_X_F_i32(y, gvl);
 
   /* j=(j+1) & (~1) (see the cephes sources) */
-  emm2 = _MM_ADD_i32(emm2,_pi32_1,gvl);
-  emm2 = _MM_AND_i32(emm2, _pi32_inv1,gvl);
-  y = _MM_VFCVT_F_X_f32(emm2,gvl);
+  emm2 = _MM_ADD_i32(emm2, _pi32_1, gvl);
+  emm2 = _MM_AND_i32(emm2, _pi32_inv1, gvl);
+  y = _MM_VFCVT_F_X_f32(emm2, gvl);
 
-  emm2 = _MM_SUB_i32(emm2, _pi32_2,gvl);
+  emm2 = _MM_SUB_i32(emm2, _pi32_2, gvl);
 
   /* get the swap sign flag */
-  emm0 = _MM_XOR_i32(emm2, _MM_SET_i32(0xffffffff,gvl),gvl);
-  emm0 = _MM_AND_i32(emm0, _pi32_4,gvl);
+  emm0 = _MM_XOR_i32(emm2, _MM_SET_i32(0xffffffff, gvl), gvl);
+  emm0 = _MM_AND_i32(emm0, _pi32_4, gvl);
 
-  emm0 = _MM_SLL_i32(emm0, _MM_CAST_u32_i32(_MM_SET_i32(29,gvl)),gvl);
+  emm0 = _MM_SLL_i32(emm0, _MM_CAST_u32_i32(_MM_SET_i32(29, gvl)), gvl);
 
   /* get the polynom selection mask */
-  emm2 = _MM_AND_i32(emm2, _pi32_2 ,gvl);
-  xMask= _MM_VMSEQ_i32(emm2,_Zero,gvl);
-  emm2 = _MM_MERGE_i32(_Zero,_MM_SET_i32(0xffffffff,gvl), xMask,gvl);
+  emm2 = _MM_AND_i32(emm2, _pi32_2, gvl);
+  xMask = _MM_VMSEQ_i32(emm2, _Zero, gvl);
+  emm2 = _MM_MERGE_i32(_Zero, _MM_SET_i32(0xffffffff, gvl), xMask, gvl);
 
-  _MMR_f32 sign_bit =  _MM_CAST_f32_i32(emm0);
-  _MMR_f32 poly_mask =  _MM_CAST_f32_i32(emm2);
+  _MMR_f32 sign_bit = _MM_CAST_f32_i32(emm0);
+  _MMR_f32 poly_mask = _MM_CAST_f32_i32(emm2);
 
   /* The magic pass: "Extended precision modular arithmetic"
      x = ((x - y * DP1) - y * DP2) - y * DP3; */
 
-  _MMR_f32   _ps_minus_cephes_DP1    = _MM_SET_f32(-0.78515625,gvl);
-  _MMR_f32   _ps_minus_cephes_DP2    = _MM_SET_f32(-2.4187564849853515625E-4,gvl);
-  _MMR_f32   _ps_minus_cephes_DP3    = _MM_SET_f32(-3.77489497744594108E-8,gvl);
+  _MMR_f32 _ps_minus_cephes_DP1 = _MM_SET_f32(-0.78515625, gvl);
+  _MMR_f32 _ps_minus_cephes_DP2 = _MM_SET_f32(-2.4187564849853515625E-4, gvl);
+  _MMR_f32 _ps_minus_cephes_DP3 = _MM_SET_f32(-3.77489497744594108E-8, gvl);
 
   xmm1 = _ps_minus_cephes_DP1;
   xmm2 = _ps_minus_cephes_DP2;
   xmm3 = _ps_minus_cephes_DP3;
 
-  xmm1 = _MM_MUL_f32(y, xmm1,gvl);
-  xmm2 = _MM_MUL_f32(y, xmm2,gvl);
-  xmm3 = _MM_MUL_f32(y, xmm3,gvl);
+  xmm1 = _MM_MUL_f32(y, xmm1, gvl);
+  xmm2 = _MM_MUL_f32(y, xmm2, gvl);
+  xmm3 = _MM_MUL_f32(y, xmm3, gvl);
 
-  x = _MM_ADD_f32(x, xmm1,gvl);
-  x = _MM_ADD_f32(x, xmm2,gvl);
-  x = _MM_ADD_f32(x, xmm3,gvl);
+  x = _MM_ADD_f32(x, xmm1, gvl);
+  x = _MM_ADD_f32(x, xmm2, gvl);
+  x = _MM_ADD_f32(x, xmm3, gvl);
 
   /* Evaluate the first polynom  (0 <= x <= Pi/4) */
-  _MMR_f32   _ps_coscof_p0      = _MM_SET_f32(2.443315711809948E-005,gvl);
-  _MMR_f32   _ps_coscof_p1      = _MM_SET_f32(-1.388731625493765E-003,gvl);
-  _MMR_f32   _ps_coscof_p2      = _MM_SET_f32(4.166664568298827E-002,gvl);
-  _MMR_f32   _ps_0p5            = _MM_SET_f32(0.5f,gvl);
+  _MMR_f32 _ps_coscof_p0 = _MM_SET_f32(2.443315711809948E-005, gvl);
+  _MMR_f32 _ps_coscof_p1 = _MM_SET_f32(-1.388731625493765E-003, gvl);
+  _MMR_f32 _ps_coscof_p2 = _MM_SET_f32(4.166664568298827E-002, gvl);
+  _MMR_f32 _ps_0p5 = _MM_SET_f32(0.5f, gvl);
 
   _MMR_f32 z;
   _MMR_f32 tmp;
 
   y = _ps_coscof_p0;
-  z = _MM_MUL_f32(x,x,gvl);
+  z = _MM_MUL_f32(x, x, gvl);
 
-  y = _MM_MUL_f32(y, z,gvl);
-  y = _MM_ADD_f32(y, _ps_coscof_p1,gvl);
-  y = _MM_MUL_f32(y, z,gvl);
-  y = _MM_ADD_f32(y, _ps_coscof_p2,gvl);
-  y = _MM_MUL_f32(y, z,gvl);
-  y = _MM_MUL_f32(y, z,gvl);
-  tmp = _MM_MUL_f32(z, _ps_0p5,gvl);
-  y = _MM_SUB_f32(y, tmp,gvl);
-  y = _MM_ADD_f32(y, _MM_SET_f32(1.0,gvl) ,gvl);
+  y = _MM_MUL_f32(y, z, gvl);
+  y = _MM_ADD_f32(y, _ps_coscof_p1, gvl);
+  y = _MM_MUL_f32(y, z, gvl);
+  y = _MM_ADD_f32(y, _ps_coscof_p2, gvl);
+  y = _MM_MUL_f32(y, z, gvl);
+  y = _MM_MUL_f32(y, z, gvl);
+  tmp = _MM_MUL_f32(z, _ps_0p5, gvl);
+  y = _MM_SUB_f32(y, tmp, gvl);
+  y = _MM_ADD_f32(y, _MM_SET_f32(1.0, gvl), gvl);
 
   /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
-  _MMR_f32   _ps_sincof_p0      = _MM_SET_f32(-1.9515295891E-4,gvl);
-  _MMR_f32   _ps_sincof_p1      = _MM_SET_f32(8.3321608736E-3,gvl);
-  _MMR_f32   _ps_sincof_p2      = _MM_SET_f32(-1.6666654611E-1,gvl);
+  _MMR_f32 _ps_sincof_p0 = _MM_SET_f32(-1.9515295891E-4, gvl);
+  _MMR_f32 _ps_sincof_p1 = _MM_SET_f32(8.3321608736E-3, gvl);
+  _MMR_f32 _ps_sincof_p2 = _MM_SET_f32(-1.6666654611E-1, gvl);
   _MMR_f32 y2;
 
   y2 = _ps_sincof_p0;
-  y2 = _MM_MUL_f32(y2, z ,gvl);
-  y2 = _MM_ADD_f32(y2, _ps_sincof_p1 ,gvl);
-  y2 = _MM_MUL_f32(y2, z ,gvl);
-  y2 = _MM_ADD_f32(y2, _ps_sincof_p2 ,gvl);
-  y2 = _MM_MUL_f32(y2, z ,gvl);
-  y2 = _MM_MUL_f32(y2, x ,gvl);
-  y2 = _MM_ADD_f32(y2, x ,gvl);
+  y2 = _MM_MUL_f32(y2, z, gvl);
+  y2 = _MM_ADD_f32(y2, _ps_sincof_p1, gvl);
+  y2 = _MM_MUL_f32(y2, z, gvl);
+  y2 = _MM_ADD_f32(y2, _ps_sincof_p2, gvl);
+  y2 = _MM_MUL_f32(y2, z, gvl);
+  y2 = _MM_MUL_f32(y2, x, gvl);
+  y2 = _MM_ADD_f32(y2, x, gvl);
 
   /* select the correct result from the two polynoms */
   xmm3 = poly_mask;
-  y2 = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(xmm3), _MM_CAST_i32_f32(y2) , gvl)); //, xmm3);
-  y = _MM_CAST_f32_i32(_MM_AND_i32(_MM_XOR_i32(_MM_CAST_i32_f32(xmm3), _MM_SET_i32(0xffffffff,gvl),gvl),_MM_CAST_i32_f32(y),gvl));
-  y = _MM_ADD_f32(y, y2 ,gvl);
+  y2 = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(xmm3),
+                                    _MM_CAST_i32_f32(y2), gvl)); //, xmm3);
+  y = _MM_CAST_f32_i32(_MM_AND_i32(
+      _MM_XOR_i32(_MM_CAST_i32_f32(xmm3), _MM_SET_i32(0xffffffff, gvl), gvl),
+      _MM_CAST_i32_f32(y), gvl));
+  y = _MM_ADD_f32(y, y2, gvl);
   /* update the sign */
-  y = _MM_CAST_f32_i32(_MM_XOR_i32(_MM_CAST_i32_f32(y), _MM_CAST_i32_f32(sign_bit) , gvl));
+  y = _MM_CAST_f32_i32(
+      _MM_XOR_i32(_MM_CAST_i32_f32(y), _MM_CAST_i32_f32(sign_bit), gvl));
 
   return y;
 }

--- a/apps/cos/kernel/cos.h
+++ b/apps/cos/kernel/cos.h
@@ -1,0 +1,273 @@
+// Modified version of:
+// "RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
+// Find details on the original version below
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+// RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
+// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+
+/*
+   AVX implementation of sin, cos, sincos, exp and log
+   Based on "sse_mathfun.h", by Julien Pommier
+   http://gruntthepeon.free.fr/ssemath/
+   Copyright (C) 2012 Giovanni Garberoglio
+   Interdisciplinary Laboratory for Computational Science (LISC)
+   Fondazione Bruno Kessler and University of Trento
+   via Sommarive, 18
+   I-38123 Trento (Italy)
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+  (this is the zlib license)
+*/
+
+#include <stdio.h>
+#include <string.h>
+
+#include "rivec/vector_defines.h"
+
+void cos_1xf64_bmark(double* angles, double* results, size_t len);
+void cos_2xf32_bmark(float* angles, float* results, size_t len);
+
+inline _MMR_f64 __cos_1xf64(_MMR_f64 x , size_t gvl) {
+
+_MMR_i64   _ps_inv_sign_mask    = _MM_SET_i64(~0x8000000000000000,gvl);
+_MMR_f64   _ps_cephes_FOPI      = _MM_SET_f64(1.27323954473516,gvl); // 4 / M_PI
+_MMR_i64   _pi32_1              = _MM_SET_i64(1,gvl);
+_MMR_i64   _pi32_inv1           = _MM_SET_i64(~0x0000000000000001,gvl);
+_MMR_i64   _pi32_2              = _MM_SET_i64(2,gvl);
+_MMR_i64   _pi32_4              = _MM_SET_i64(4,gvl);
+_MMR_i64   _Zero                = _MM_SET_i64(0,gvl);
+
+_MMR_f64   xmm2 =  _MM_SET_f64(0.0f,gvl);
+_MMR_f64   xmm1;
+_MMR_f64   xmm3;
+_MMR_f64   y;
+
+_MMR_i64   emm0;
+_MMR_i64   emm2;
+
+_MMR_MASK_i64 xMask;
+  /* take the absolute value */
+  x = _MM_CAST_f64_i64(_MM_AND_i64(_MM_CAST_i64_f64(x), _ps_inv_sign_mask, gvl));
+
+  /* scale by 4/Pi */
+  y = _MM_MUL_f64(x, _ps_cephes_FOPI, gvl);
+
+  /* store the integer part of y in mm0 */
+  emm2 = _MM_VFCVT_X_F_i64(y,gvl);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _MM_ADD_i64(emm2,_pi32_1,gvl);
+  emm2 = _MM_AND_i64(emm2, _pi32_inv1,gvl);
+  y = _MM_VFCVT_F_X_f64(emm2,gvl);
+
+  emm2 = _MM_SUB_i64(emm2, _pi32_2,gvl);
+
+  /* get the swap sign flag */
+  emm0 = _MM_XOR_i64(emm2, _MM_SET_i64(0xffffffffffffffff,gvl),gvl);
+  emm0 = _MM_AND_i64(emm0, _pi32_4,gvl);
+
+  emm0 = _MM_SLL_i64(emm0, _MM_CAST_u64_i64(_MM_SET_i64(61,gvl)),gvl);
+
+  /* get the polynom selection mask */
+  emm2 = _MM_AND_i64(emm2, _pi32_2 ,gvl);
+  xMask= _MM_VMSEQ_i64(emm2,_Zero,gvl);
+  emm2 = _MM_MERGE_i64(_Zero,_MM_SET_i64(0xffffffffffffffff,gvl), xMask,gvl);
+
+  _MMR_f64 sign_bit =  _MM_CAST_f64_i64(emm0);
+  _MMR_f64 poly_mask =  _MM_CAST_f64_i64(emm2);
+
+  /* The magic pass: "Extended precision modular arithmetic"
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+
+  _MMR_f64   _ps_minus_cephes_DP1    = _MM_SET_f64(-0.78515625,gvl);
+  _MMR_f64   _ps_minus_cephes_DP2    = _MM_SET_f64(-2.4187564849853515625E-4,gvl);
+  _MMR_f64   _ps_minus_cephes_DP3    = _MM_SET_f64(-3.77489497744594108E-8,gvl);
+
+  xmm1 = _ps_minus_cephes_DP1;
+  xmm2 = _ps_minus_cephes_DP2;
+  xmm3 = _ps_minus_cephes_DP3;
+
+  xmm1 = _MM_MUL_f64(y, xmm1,gvl);
+  xmm2 = _MM_MUL_f64(y, xmm2,gvl);
+  xmm3 = _MM_MUL_f64(y, xmm3,gvl);
+
+  x = _MM_ADD_f64(x, xmm1,gvl);
+  x = _MM_ADD_f64(x, xmm2,gvl);
+  x = _MM_ADD_f64(x, xmm3,gvl);
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  _MMR_f64   _ps_coscof_p0      = _MM_SET_f64(2.443315711809948E-005,gvl);
+  _MMR_f64   _ps_coscof_p1      = _MM_SET_f64(-1.388731625493765E-003,gvl);
+  _MMR_f64   _ps_coscof_p2      = _MM_SET_f64(4.166664568298827E-002,gvl);
+  _MMR_f64   _ps_0p5            = _MM_SET_f64(0.5f,gvl);
+
+  _MMR_f64 z;
+  _MMR_f64 tmp;
+
+  y = _ps_coscof_p0;
+  z = _MM_MUL_f64(x,x,gvl);
+
+  y = _MM_MUL_f64(y, z,gvl);
+  y = _MM_ADD_f64(y, _ps_coscof_p1,gvl);
+  y = _MM_MUL_f64(y, z,gvl);
+  y = _MM_ADD_f64(y, _ps_coscof_p2,gvl);
+  y = _MM_MUL_f64(y, z,gvl);
+  y = _MM_MUL_f64(y, z,gvl);
+  tmp = _MM_MUL_f64(z, _ps_0p5,gvl);
+  y = _MM_SUB_f64(y, tmp,gvl);
+  y = _MM_ADD_f64(y, _MM_SET_f64(1.0,gvl) ,gvl);
+
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+  _MMR_f64 _ps_sincof_p0 = _MM_SET_f64(-1.9515295891E-4,gvl);
+  FENCE();
+  _MMR_f64 _ps_sincof_p1 = _MM_SET_f64(8.3321608736E-3,gvl);
+  _MMR_f64 _ps_sincof_p2 = _MM_SET_f64(-1.6666654611E-1,gvl);
+  _MMR_f64 y2;
+
+  y2 = _ps_sincof_p0;
+  y2 = _MM_MUL_f64(y2, z ,gvl);
+  y2 = _MM_ADD_f64(y2, _ps_sincof_p1 ,gvl);
+  y2 = _MM_MUL_f64(y2, z ,gvl);
+  y2 = _MM_ADD_f64(y2, _ps_sincof_p2 ,gvl);
+  y2 = _MM_MUL_f64(y2, z ,gvl);
+  y2 = _MM_MUL_f64(y2, x ,gvl);
+  y2 = _MM_ADD_f64(y2, x ,gvl);
+
+  /* select the correct result from the two polynoms */
+  xmm3 = poly_mask;
+  y2 = _MM_CAST_f64_i64(_MM_AND_i64(_MM_CAST_i64_f64(xmm3), _MM_CAST_i64_f64(y2), gvl));
+  y = _MM_CAST_f64_i64(_MM_AND_i64(_MM_XOR_i64(_MM_CAST_i64_f64(xmm3), _MM_SET_i64(0xffffffffffffffff,gvl),gvl),_MM_CAST_i64_f64(y),gvl));
+  y = _MM_ADD_f64(y, y2 ,gvl);
+  /* update the sign */
+  y = _MM_CAST_f64_i64(_MM_XOR_i64(_MM_CAST_i64_f64(y), _MM_CAST_i64_f64(sign_bit) , gvl));
+
+  return y;
+}
+
+inline _MMR_f32 __cos_2xf32(_MMR_f32 x , size_t gvl) {
+
+_MMR_i32   _ps_inv_sign_mask    = _MM_SET_i32(~0x80000000,gvl);
+_MMR_f32   _ps_cephes_FOPI      = _MM_SET_f32(1.27323954473516,gvl); // 4 / M_PI
+_MMR_i32   _pi32_1              = _MM_SET_i32(0x00000001,gvl);
+_MMR_i32   _pi32_inv1           = _MM_SET_i32(~0x00000001,gvl);
+_MMR_i32   _pi32_2              = _MM_SET_i32(2,gvl);
+_MMR_i32   _pi32_4              = _MM_SET_i32(4,gvl);
+_MMR_i32   _Zero                = _MM_SET_i32(0,gvl);
+
+_MMR_f32   xmm2 =  _MM_SET_f32(0.0f,gvl);
+_MMR_f32   xmm1;
+_MMR_f32   xmm3;
+_MMR_f32   y;
+
+_MMR_i32   emm0;
+_MMR_i32   emm2;
+
+_MMR_MASK_i32 xMask;
+  /* take the absolute value */
+  x = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(x), _ps_inv_sign_mask,gvl));
+
+  /* scale by 4/Pi */
+  y = _MM_MUL_f32(x, _ps_cephes_FOPI,gvl);
+
+  /* store the integer part of y in mm0 */
+  emm2 = _MM_VFCVT_X_F_i32(y,gvl);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _MM_ADD_i32(emm2,_pi32_1,gvl);
+  emm2 = _MM_AND_i32(emm2, _pi32_inv1,gvl);
+  y = _MM_VFCVT_F_X_f32(emm2,gvl);
+
+  emm2 = _MM_SUB_i32(emm2, _pi32_2,gvl);
+
+  /* get the swap sign flag */
+  emm0 = _MM_XOR_i32(emm2, _MM_SET_i32(0xffffffff,gvl),gvl);
+  emm0 = _MM_AND_i32(emm0, _pi32_4,gvl);
+
+  emm0 = _MM_SLL_i32(emm0, _MM_CAST_u32_i32(_MM_SET_i32(29,gvl)),gvl);
+
+  /* get the polynom selection mask */
+  emm2 = _MM_AND_i32(emm2, _pi32_2 ,gvl);
+  xMask= _MM_VMSEQ_i32(emm2,_Zero,gvl);
+  emm2 = _MM_MERGE_i32(_Zero,_MM_SET_i32(0xffffffff,gvl), xMask,gvl);
+
+  _MMR_f32 sign_bit =  _MM_CAST_f32_i32(emm0);
+  _MMR_f32 poly_mask =  _MM_CAST_f32_i32(emm2);
+
+  /* The magic pass: "Extended precision modular arithmetic"
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+
+  _MMR_f32   _ps_minus_cephes_DP1    = _MM_SET_f32(-0.78515625,gvl);
+  _MMR_f32   _ps_minus_cephes_DP2    = _MM_SET_f32(-2.4187564849853515625E-4,gvl);
+  _MMR_f32   _ps_minus_cephes_DP3    = _MM_SET_f32(-3.77489497744594108E-8,gvl);
+
+  xmm1 = _ps_minus_cephes_DP1;
+  xmm2 = _ps_minus_cephes_DP2;
+  xmm3 = _ps_minus_cephes_DP3;
+
+  xmm1 = _MM_MUL_f32(y, xmm1,gvl);
+  xmm2 = _MM_MUL_f32(y, xmm2,gvl);
+  xmm3 = _MM_MUL_f32(y, xmm3,gvl);
+
+  x = _MM_ADD_f32(x, xmm1,gvl);
+  x = _MM_ADD_f32(x, xmm2,gvl);
+  x = _MM_ADD_f32(x, xmm3,gvl);
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  _MMR_f32   _ps_coscof_p0      = _MM_SET_f32(2.443315711809948E-005,gvl);
+  _MMR_f32   _ps_coscof_p1      = _MM_SET_f32(-1.388731625493765E-003,gvl);
+  _MMR_f32   _ps_coscof_p2      = _MM_SET_f32(4.166664568298827E-002,gvl);
+  _MMR_f32   _ps_0p5            = _MM_SET_f32(0.5f,gvl);
+
+  _MMR_f32 z;
+  _MMR_f32 tmp;
+
+  y = _ps_coscof_p0;
+  z = _MM_MUL_f32(x,x,gvl);
+
+  y = _MM_MUL_f32(y, z,gvl);
+  y = _MM_ADD_f32(y, _ps_coscof_p1,gvl);
+  y = _MM_MUL_f32(y, z,gvl);
+  y = _MM_ADD_f32(y, _ps_coscof_p2,gvl);
+  y = _MM_MUL_f32(y, z,gvl);
+  y = _MM_MUL_f32(y, z,gvl);
+  tmp = _MM_MUL_f32(z, _ps_0p5,gvl);
+  y = _MM_SUB_f32(y, tmp,gvl);
+  y = _MM_ADD_f32(y, _MM_SET_f32(1.0,gvl) ,gvl);
+
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+  _MMR_f32   _ps_sincof_p0      = _MM_SET_f32(-1.9515295891E-4,gvl);
+  _MMR_f32   _ps_sincof_p1      = _MM_SET_f32(8.3321608736E-3,gvl);
+  _MMR_f32   _ps_sincof_p2      = _MM_SET_f32(-1.6666654611E-1,gvl);
+  _MMR_f32 y2;
+
+  y2 = _ps_sincof_p0;
+  y2 = _MM_MUL_f32(y2, z ,gvl);
+  y2 = _MM_ADD_f32(y2, _ps_sincof_p1 ,gvl);
+  y2 = _MM_MUL_f32(y2, z ,gvl);
+  y2 = _MM_ADD_f32(y2, _ps_sincof_p2 ,gvl);
+  y2 = _MM_MUL_f32(y2, z ,gvl);
+  y2 = _MM_MUL_f32(y2, x ,gvl);
+  y2 = _MM_ADD_f32(y2, x ,gvl);
+
+  /* select the correct result from the two polynoms */
+  xmm3 = poly_mask;
+  y2 = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(xmm3), _MM_CAST_i32_f32(y2) , gvl)); //, xmm3);
+  y = _MM_CAST_f32_i32(_MM_AND_i32(_MM_XOR_i32(_MM_CAST_i32_f32(xmm3), _MM_SET_i32(0xffffffff,gvl),gvl),_MM_CAST_i32_f32(y),gvl));
+  y = _MM_ADD_f32(y, y2 ,gvl);
+  /* update the sign */
+  y = _MM_CAST_f32_i32(_MM_XOR_i32(_MM_CAST_i32_f32(y), _MM_CAST_i32_f32(sign_bit) , gvl));
+
+  return y;
+}

--- a/apps/cos/main.c
+++ b/apps/cos/main.c
@@ -1,0 +1,390 @@
+// Modified version of:
+// "RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
+// Find details on the original version below
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+// RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
+// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+
+/*
+   AVX implementation of sin, cos, sincos, exp and log
+   Based on "sse_mathfun.h", by Julien Pommier
+   http://gruntthepeon.free.fr/ssemath/
+   Copyright (C) 2012 Giovanni Garberoglio
+   Interdisciplinary Laboratory for Computational Science (LISC)
+   Fondazione Bruno Kessler and University of Trento
+   via Sommarive, 18
+   I-38123 Trento (Italy)
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+  (this is the zlib license)
+*/
+
+#include <stdint.h>
+#include <string.h>
+
+#include "rivec/vector_defines.h"
+#include "printf.h"
+#include "runtime.h"
+
+extern size_t N_f64;
+
+extern double angles_f64[] __attribute__((aligned(4 * NR_LANES)));
+extern double results_f64[] __attribute__((aligned(4 * NR_LANES)));
+extern double gold_results_f64[] __attribute__((aligned(4 * NR_LANES)));
+
+extern size_t N_f32;
+
+extern float angles_f32[] __attribute__((aligned(4 * NR_LANES)));
+extern float results_f32[] __attribute__((aligned(4 * NR_LANES)));
+extern float gold_results_f32[] __attribute__((aligned(4 * NR_LANES)));
+
+#define THRESHOLD 1
+#define FABS(x) ((x < 0) ? -x : x)
+
+#define CHECK
+
+inline vfloat64m1_t __cos_1xf64(vfloat64m1_t x, size_t gvl);
+inline vfloat32m1_t __cos_2xf32(vfloat32m1_t x, size_t gvl);
+void cos_1xf64_bmark(double* angles, double* results, size_t len);
+void cos_2xf32_bmark(float* angles, float* results, size_t len);
+int similarity_check(double a, double b, double threshold);
+
+int similarity_check(double a, double b, double threshold) {
+  double diff = a - b;
+  if (FABS(diff) > threshold)
+    return 0;
+  else
+    return 1;
+}
+
+void cos_1xf64_bmark(double* angles, double* results, size_t len) {
+
+  size_t avl = len;
+  vfloat64m1_t cos_vec, res_vec;
+
+  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e64m1(avl);
+    // Load vector
+    cos_vec = vle64_v_f64m1(angles, vl);
+    // Compute
+    res_vec = __cos_1xf64(cos_vec, vl);
+    // Store
+    vse64_v_f64m1(results, res_vec, vl);
+    // Bump pointers
+    angles += vl;
+    results   += vl;
+  }
+}
+
+void cos_2xf32_bmark(float* angles, float* results, size_t len) {
+
+  size_t avl = len;
+  vfloat32m1_t cos_vec, res_vec;
+
+  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e32m1(avl);
+    // Load vector
+    cos_vec = vle32_v_f32m1(angles, vl);
+    // Compute
+    res_vec = __cos_2xf32(cos_vec, vl);
+    // Store
+    vse32_v_f32m1(results, res_vec, vl);
+    // Bump pointers
+    angles += vl;
+    results   += vl;
+  }
+}
+inline _MMR_f64 __cos_1xf64(_MMR_f64 x , size_t gvl) {
+
+_MMR_i64   _ps_inv_sign_mask    = _MM_SET_i64(~0x8000000000000000,gvl);
+_MMR_f64   _ps_cephes_FOPI      = _MM_SET_f64(1.27323954473516,gvl); // 4 / M_PI
+_MMR_i64   _pi32_1              = _MM_SET_i64(1,gvl);
+_MMR_i64   _pi32_inv1           = _MM_SET_i64(~0x0000000000000001,gvl);
+_MMR_i64   _pi32_2              = _MM_SET_i64(2,gvl);
+_MMR_i64   _pi32_4              = _MM_SET_i64(4,gvl);
+_MMR_i64   _Zero                = _MM_SET_i64(0,gvl);
+
+_MMR_f64   xmm2 =  _MM_SET_f64(0.0f,gvl);
+_MMR_f64   xmm1;
+_MMR_f64   xmm3;
+_MMR_f64   y;
+
+_MMR_i64   emm0;
+_MMR_i64   emm2;
+
+_MMR_MASK_i64 xMask;
+  /* take the absolute value */
+  x = _MM_CAST_f64_i64(_MM_AND_i64(_MM_CAST_i64_f64(x), _ps_inv_sign_mask, gvl));
+
+  /* scale by 4/Pi */
+  y = _MM_MUL_f64(x, _ps_cephes_FOPI, gvl);
+
+  /* store the integer part of y in mm0 */
+  emm2 = _MM_VFCVT_X_F_i64(y,gvl);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _MM_ADD_i64(emm2,_pi32_1,gvl);
+  emm2 = _MM_AND_i64(emm2, _pi32_inv1,gvl);
+  y = _MM_VFCVT_F_X_f64(emm2,gvl);
+
+  emm2 = _MM_SUB_i64(emm2, _pi32_2,gvl);
+
+  /* get the swap sign flag */
+  emm0 = _MM_XOR_i64(emm2, _MM_SET_i64(0xffffffffffffffff,gvl),gvl);
+  emm0 = _MM_AND_i64(emm0, _pi32_4,gvl);
+
+  emm0 = _MM_SLL_i64(emm0, _MM_CAST_u64_i64(_MM_SET_i64(61,gvl)),gvl);
+
+  /* get the polynom selection mask */
+  emm2 = _MM_AND_i64(emm2, _pi32_2 ,gvl);
+  xMask= _MM_VMSEQ_i64(emm2,_Zero,gvl);
+  emm2 = _MM_MERGE_i64(_Zero,_MM_SET_i64(0xffffffffffffffff,gvl), xMask,gvl);
+
+  _MMR_f64 sign_bit =  _MM_CAST_f64_i64(emm0);
+  _MMR_f64 poly_mask =  _MM_CAST_f64_i64(emm2);
+
+  /* The magic pass: "Extended precision modular arithmetic"
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+
+  _MMR_f64   _ps_minus_cephes_DP1    = _MM_SET_f64(-0.78515625,gvl);
+  _MMR_f64   _ps_minus_cephes_DP2    = _MM_SET_f64(-2.4187564849853515625E-4,gvl);
+  _MMR_f64   _ps_minus_cephes_DP3    = _MM_SET_f64(-3.77489497744594108E-8,gvl);
+
+  xmm1 = _ps_minus_cephes_DP1;
+  xmm2 = _ps_minus_cephes_DP2;
+  xmm3 = _ps_minus_cephes_DP3;
+
+  xmm1 = _MM_MUL_f64(y, xmm1,gvl);
+  xmm2 = _MM_MUL_f64(y, xmm2,gvl);
+  xmm3 = _MM_MUL_f64(y, xmm3,gvl);
+
+  x = _MM_ADD_f64(x, xmm1,gvl);
+  x = _MM_ADD_f64(x, xmm2,gvl);
+  x = _MM_ADD_f64(x, xmm3,gvl);
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  _MMR_f64   _ps_coscof_p0      = _MM_SET_f64(2.443315711809948E-005,gvl);
+  _MMR_f64   _ps_coscof_p1      = _MM_SET_f64(-1.388731625493765E-003,gvl);
+  _MMR_f64   _ps_coscof_p2      = _MM_SET_f64(4.166664568298827E-002,gvl);
+  _MMR_f64   _ps_0p5            = _MM_SET_f64(0.5f,gvl);
+
+  _MMR_f64 z;
+  _MMR_f64 tmp;
+
+  y = _ps_coscof_p0;
+  z = _MM_MUL_f64(x,x,gvl);
+
+  y = _MM_MUL_f64(y, z,gvl);
+  y = _MM_ADD_f64(y, _ps_coscof_p1,gvl);
+  y = _MM_MUL_f64(y, z,gvl);
+  y = _MM_ADD_f64(y, _ps_coscof_p2,gvl);
+  y = _MM_MUL_f64(y, z,gvl);
+  y = _MM_MUL_f64(y, z,gvl);
+  tmp = _MM_MUL_f64(z, _ps_0p5,gvl);
+  y = _MM_SUB_f64(y, tmp,gvl);
+  y = _MM_ADD_f64(y, _MM_SET_f64(1.0,gvl) ,gvl);
+
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+  _MMR_f64 _ps_sincof_p0 = _MM_SET_f64(-1.9515295891E-4,gvl);
+  FENCE();
+  _MMR_f64 _ps_sincof_p1 = _MM_SET_f64(8.3321608736E-3,gvl);
+  _MMR_f64 _ps_sincof_p2 = _MM_SET_f64(-1.6666654611E-1,gvl);
+  _MMR_f64 y2;
+
+  y2 = _ps_sincof_p0;
+  y2 = _MM_MUL_f64(y2, z ,gvl);
+  y2 = _MM_ADD_f64(y2, _ps_sincof_p1 ,gvl);
+  y2 = _MM_MUL_f64(y2, z ,gvl);
+  y2 = _MM_ADD_f64(y2, _ps_sincof_p2 ,gvl);
+  y2 = _MM_MUL_f64(y2, z ,gvl);
+  y2 = _MM_MUL_f64(y2, x ,gvl);
+  y2 = _MM_ADD_f64(y2, x ,gvl);
+
+  /* select the correct result from the two polynoms */
+  xmm3 = poly_mask;
+  y2 = _MM_CAST_f64_i64(_MM_AND_i64(_MM_CAST_i64_f64(xmm3), _MM_CAST_i64_f64(y2), gvl));
+  y = _MM_CAST_f64_i64(_MM_AND_i64(_MM_XOR_i64(_MM_CAST_i64_f64(xmm3), _MM_SET_i64(0xffffffffffffffff,gvl),gvl),_MM_CAST_i64_f64(y),gvl));
+  y = _MM_ADD_f64(y, y2 ,gvl);
+  /* update the sign */
+  y = _MM_CAST_f64_i64(_MM_XOR_i64(_MM_CAST_i64_f64(y), _MM_CAST_i64_f64(sign_bit) , gvl));
+
+  return y;
+}
+
+inline _MMR_f32 __cos_2xf32(_MMR_f32 x , size_t gvl) {
+
+_MMR_i32   _ps_inv_sign_mask    = _MM_SET_i32(~0x80000000,gvl);
+_MMR_f32   _ps_cephes_FOPI      = _MM_SET_f32(1.27323954473516,gvl); // 4 / M_PI
+_MMR_i32   _pi32_1              = _MM_SET_i32(0x00000001,gvl);
+_MMR_i32   _pi32_inv1           = _MM_SET_i32(~0x00000001,gvl);
+_MMR_i32   _pi32_2              = _MM_SET_i32(2,gvl);
+_MMR_i32   _pi32_4              = _MM_SET_i32(4,gvl);
+_MMR_i32   _Zero                = _MM_SET_i32(0,gvl);
+
+_MMR_f32   xmm2 =  _MM_SET_f32(0.0f,gvl);
+_MMR_f32   xmm1;
+_MMR_f32   xmm3;
+_MMR_f32   y;
+
+_MMR_i32   emm0;
+_MMR_i32   emm2;
+
+_MMR_MASK_i32 xMask;
+  /* take the absolute value */
+  x = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(x), _ps_inv_sign_mask,gvl));
+
+  /* scale by 4/Pi */
+  y = _MM_MUL_f32(x, _ps_cephes_FOPI,gvl);
+
+  /* store the integer part of y in mm0 */
+  emm2 = _MM_VFCVT_X_F_i32(y,gvl);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _MM_ADD_i32(emm2,_pi32_1,gvl);
+  emm2 = _MM_AND_i32(emm2, _pi32_inv1,gvl);
+  y = _MM_VFCVT_F_X_f32(emm2,gvl);
+
+  emm2 = _MM_SUB_i32(emm2, _pi32_2,gvl);
+
+  /* get the swap sign flag */
+  emm0 = _MM_XOR_i32(emm2, _MM_SET_i32(0xffffffff,gvl),gvl);
+  emm0 = _MM_AND_i32(emm0, _pi32_4,gvl);
+
+  emm0 = _MM_SLL_i32(emm0, _MM_CAST_u32_i32(_MM_SET_i32(29,gvl)),gvl);
+
+  /* get the polynom selection mask */
+  emm2 = _MM_AND_i32(emm2, _pi32_2 ,gvl);
+  xMask= _MM_VMSEQ_i32(emm2,_Zero,gvl);
+  emm2 = _MM_MERGE_i32(_Zero,_MM_SET_i32(0xffffffff,gvl), xMask,gvl);
+
+  _MMR_f32 sign_bit =  _MM_CAST_f32_i32(emm0);
+  _MMR_f32 poly_mask =  _MM_CAST_f32_i32(emm2);
+
+  /* The magic pass: "Extended precision modular arithmetic"
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+
+  _MMR_f32   _ps_minus_cephes_DP1    = _MM_SET_f32(-0.78515625,gvl);
+  _MMR_f32   _ps_minus_cephes_DP2    = _MM_SET_f32(-2.4187564849853515625E-4,gvl);
+  _MMR_f32   _ps_minus_cephes_DP3    = _MM_SET_f32(-3.77489497744594108E-8,gvl);
+
+  xmm1 = _ps_minus_cephes_DP1;
+  xmm2 = _ps_minus_cephes_DP2;
+  xmm3 = _ps_minus_cephes_DP3;
+
+  xmm1 = _MM_MUL_f32(y, xmm1,gvl);
+  xmm2 = _MM_MUL_f32(y, xmm2,gvl);
+  xmm3 = _MM_MUL_f32(y, xmm3,gvl);
+
+  x = _MM_ADD_f32(x, xmm1,gvl);
+  x = _MM_ADD_f32(x, xmm2,gvl);
+  x = _MM_ADD_f32(x, xmm3,gvl);
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  _MMR_f32   _ps_coscof_p0      = _MM_SET_f32(2.443315711809948E-005,gvl);
+  _MMR_f32   _ps_coscof_p1      = _MM_SET_f32(-1.388731625493765E-003,gvl);
+  _MMR_f32   _ps_coscof_p2      = _MM_SET_f32(4.166664568298827E-002,gvl);
+  _MMR_f32   _ps_0p5            = _MM_SET_f32(0.5f,gvl);
+
+  _MMR_f32 z;
+  _MMR_f32 tmp;
+
+  y = _ps_coscof_p0;
+  z = _MM_MUL_f32(x,x,gvl);
+
+  y = _MM_MUL_f32(y, z,gvl);
+  y = _MM_ADD_f32(y, _ps_coscof_p1,gvl);
+  y = _MM_MUL_f32(y, z,gvl);
+  y = _MM_ADD_f32(y, _ps_coscof_p2,gvl);
+  y = _MM_MUL_f32(y, z,gvl);
+  y = _MM_MUL_f32(y, z,gvl);
+  tmp = _MM_MUL_f32(z, _ps_0p5,gvl);
+  y = _MM_SUB_f32(y, tmp,gvl);
+  y = _MM_ADD_f32(y, _MM_SET_f32(1.0,gvl) ,gvl);
+
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+  _MMR_f32   _ps_sincof_p0      = _MM_SET_f32(-1.9515295891E-4,gvl);
+  _MMR_f32   _ps_sincof_p1      = _MM_SET_f32(8.3321608736E-3,gvl);
+  _MMR_f32   _ps_sincof_p2      = _MM_SET_f32(-1.6666654611E-1,gvl);
+  _MMR_f32 y2;
+
+  y2 = _ps_sincof_p0;
+  y2 = _MM_MUL_f32(y2, z ,gvl);
+  y2 = _MM_ADD_f32(y2, _ps_sincof_p1 ,gvl);
+  y2 = _MM_MUL_f32(y2, z ,gvl);
+  y2 = _MM_ADD_f32(y2, _ps_sincof_p2 ,gvl);
+  y2 = _MM_MUL_f32(y2, z ,gvl);
+  y2 = _MM_MUL_f32(y2, x ,gvl);
+  y2 = _MM_ADD_f32(y2, x ,gvl);
+
+  /* select the correct result from the two polynoms */
+  xmm3 = poly_mask;
+  y2 = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(xmm3), _MM_CAST_i32_f32(y2) , gvl)); //, xmm3);
+  y = _MM_CAST_f32_i32(_MM_AND_i32(_MM_XOR_i32(_MM_CAST_i32_f32(xmm3), _MM_SET_i32(0xffffffff,gvl),gvl),_MM_CAST_i32_f32(y),gvl));
+  y = _MM_ADD_f32(y, y2 ,gvl);
+  /* update the sign */
+  y = _MM_CAST_f32_i32(_MM_XOR_i32(_MM_CAST_i32_f32(y), _MM_CAST_i32_f32(sign_bit) , gvl));
+
+  return y;
+}
+
+int main() {
+  printf("\n");
+  printf("==========\n");
+  printf("=  FCOS  =\n");
+  printf("==========\n");
+  printf("\n");
+  printf("\n");
+
+  int error = 0;
+  int64_t runtime;
+
+  printf("Executing cosine on %d 64-bit data...\n", N_f64);
+
+  start_timer();
+  cos_1xf64_bmark(angles_f64, results_f64, N_f64);
+  stop_timer();
+
+  runtime = get_timer();
+  printf("The execution took %d cycles.\n", runtime);
+
+  printf("Executing cosine on %d 32-bit data...\n", N_f32);
+  start_timer();
+  cos_2xf32_bmark(angles_f32, results_f32, N_f32);
+  stop_timer();
+
+  runtime = get_timer();
+  printf("The execution took %d cycles.\n", runtime);
+
+#ifdef CHECK
+  printf("Checking results:\n");
+
+  for (uint64_t i = 0; i < N_f64; ++i) {
+    if (!similarity_check(results_f64[i], gold_results_f64[i], THRESHOLD)) {
+      error = 1;
+      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i], gold_results_f64[i]);
+    }
+  }
+  for (uint64_t i = 0; i < N_f32; ++i) {
+    if (!similarity_check(results_f32[i], gold_results_f32[i], THRESHOLD)) {
+      error = 1;
+      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i], gold_results_f32[i]);
+    }
+  }
+#endif
+
+  return error;
+}

--- a/apps/cos/main.c
+++ b/apps/cos/main.c
@@ -1,345 +1,42 @@
-// Modified version of:
-// "RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
-// Find details on the original version below
+// Copyright 2022 ETH Zurich and University of Bologna.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
-
-// RISC-V VECTOR COS FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
-// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
-
-/*
-   AVX implementation of sin, cos, sincos, exp and log
-   Based on "sse_mathfun.h", by Julien Pommier
-   http://gruntthepeon.free.fr/ssemath/
-   Copyright (C) 2012 Giovanni Garberoglio
-   Interdisciplinary Laboratory for Computational Science (LISC)
-   Fondazione Bruno Kessler and University of Trento
-   via Sommarive, 18
-   I-38123 Trento (Italy)
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
-  (this is the zlib license)
-*/
 
 #include <stdint.h>
 #include <string.h>
 
-#include "rivec/vector_defines.h"
+#include "util.h"
+#include "kernel/cos.h"
 #include "printf.h"
 #include "runtime.h"
 
 extern size_t N_f64;
-
 extern double angles_f64[] __attribute__((aligned(4 * NR_LANES)));
 extern double results_f64[] __attribute__((aligned(4 * NR_LANES)));
 extern double gold_results_f64[] __attribute__((aligned(4 * NR_LANES)));
 
 extern size_t N_f32;
-
 extern float angles_f32[] __attribute__((aligned(4 * NR_LANES)));
 extern float results_f32[] __attribute__((aligned(4 * NR_LANES)));
 extern float gold_results_f32[] __attribute__((aligned(4 * NR_LANES)));
 
 #define THRESHOLD 1
-#define FABS(x) ((x < 0) ? -x : x)
 
 #define CHECK
-
-inline vfloat64m1_t __cos_1xf64(vfloat64m1_t x, size_t gvl);
-inline vfloat32m1_t __cos_2xf32(vfloat32m1_t x, size_t gvl);
-void cos_1xf64_bmark(double* angles, double* results, size_t len);
-void cos_2xf32_bmark(float* angles, float* results, size_t len);
-int similarity_check(double a, double b, double threshold);
-
-int similarity_check(double a, double b, double threshold) {
-  double diff = a - b;
-  if (FABS(diff) > threshold)
-    return 0;
-  else
-    return 1;
-}
-
-void cos_1xf64_bmark(double* angles, double* results, size_t len) {
-
-  size_t avl = len;
-  vfloat64m1_t cos_vec, res_vec;
-
-  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
-    // Strip-mine
-    vl = vsetvl_e64m1(avl);
-    // Load vector
-    cos_vec = vle64_v_f64m1(angles, vl);
-    // Compute
-    res_vec = __cos_1xf64(cos_vec, vl);
-    // Store
-    vse64_v_f64m1(results, res_vec, vl);
-    // Bump pointers
-    angles += vl;
-    results   += vl;
-  }
-}
-
-void cos_2xf32_bmark(float* angles, float* results, size_t len) {
-
-  size_t avl = len;
-  vfloat32m1_t cos_vec, res_vec;
-
-  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
-    // Strip-mine
-    vl = vsetvl_e32m1(avl);
-    // Load vector
-    cos_vec = vle32_v_f32m1(angles, vl);
-    // Compute
-    res_vec = __cos_2xf32(cos_vec, vl);
-    // Store
-    vse32_v_f32m1(results, res_vec, vl);
-    // Bump pointers
-    angles += vl;
-    results   += vl;
-  }
-}
-inline _MMR_f64 __cos_1xf64(_MMR_f64 x , size_t gvl) {
-
-_MMR_i64   _ps_inv_sign_mask    = _MM_SET_i64(~0x8000000000000000,gvl);
-_MMR_f64   _ps_cephes_FOPI      = _MM_SET_f64(1.27323954473516,gvl); // 4 / M_PI
-_MMR_i64   _pi32_1              = _MM_SET_i64(1,gvl);
-_MMR_i64   _pi32_inv1           = _MM_SET_i64(~0x0000000000000001,gvl);
-_MMR_i64   _pi32_2              = _MM_SET_i64(2,gvl);
-_MMR_i64   _pi32_4              = _MM_SET_i64(4,gvl);
-_MMR_i64   _Zero                = _MM_SET_i64(0,gvl);
-
-_MMR_f64   xmm2 =  _MM_SET_f64(0.0f,gvl);
-_MMR_f64   xmm1;
-_MMR_f64   xmm3;
-_MMR_f64   y;
-
-_MMR_i64   emm0;
-_MMR_i64   emm2;
-
-_MMR_MASK_i64 xMask;
-  /* take the absolute value */
-  x = _MM_CAST_f64_i64(_MM_AND_i64(_MM_CAST_i64_f64(x), _ps_inv_sign_mask, gvl));
-
-  /* scale by 4/Pi */
-  y = _MM_MUL_f64(x, _ps_cephes_FOPI, gvl);
-
-  /* store the integer part of y in mm0 */
-  emm2 = _MM_VFCVT_X_F_i64(y,gvl);
-
-  /* j=(j+1) & (~1) (see the cephes sources) */
-  emm2 = _MM_ADD_i64(emm2,_pi32_1,gvl);
-  emm2 = _MM_AND_i64(emm2, _pi32_inv1,gvl);
-  y = _MM_VFCVT_F_X_f64(emm2,gvl);
-
-  emm2 = _MM_SUB_i64(emm2, _pi32_2,gvl);
-
-  /* get the swap sign flag */
-  emm0 = _MM_XOR_i64(emm2, _MM_SET_i64(0xffffffffffffffff,gvl),gvl);
-  emm0 = _MM_AND_i64(emm0, _pi32_4,gvl);
-
-  emm0 = _MM_SLL_i64(emm0, _MM_CAST_u64_i64(_MM_SET_i64(61,gvl)),gvl);
-
-  /* get the polynom selection mask */
-  emm2 = _MM_AND_i64(emm2, _pi32_2 ,gvl);
-  xMask= _MM_VMSEQ_i64(emm2,_Zero,gvl);
-  emm2 = _MM_MERGE_i64(_Zero,_MM_SET_i64(0xffffffffffffffff,gvl), xMask,gvl);
-
-  _MMR_f64 sign_bit =  _MM_CAST_f64_i64(emm0);
-  _MMR_f64 poly_mask =  _MM_CAST_f64_i64(emm2);
-
-  /* The magic pass: "Extended precision modular arithmetic"
-     x = ((x - y * DP1) - y * DP2) - y * DP3; */
-
-  _MMR_f64   _ps_minus_cephes_DP1    = _MM_SET_f64(-0.78515625,gvl);
-  _MMR_f64   _ps_minus_cephes_DP2    = _MM_SET_f64(-2.4187564849853515625E-4,gvl);
-  _MMR_f64   _ps_minus_cephes_DP3    = _MM_SET_f64(-3.77489497744594108E-8,gvl);
-
-  xmm1 = _ps_minus_cephes_DP1;
-  xmm2 = _ps_minus_cephes_DP2;
-  xmm3 = _ps_minus_cephes_DP3;
-
-  xmm1 = _MM_MUL_f64(y, xmm1,gvl);
-  xmm2 = _MM_MUL_f64(y, xmm2,gvl);
-  xmm3 = _MM_MUL_f64(y, xmm3,gvl);
-
-  x = _MM_ADD_f64(x, xmm1,gvl);
-  x = _MM_ADD_f64(x, xmm2,gvl);
-  x = _MM_ADD_f64(x, xmm3,gvl);
-
-  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
-  _MMR_f64   _ps_coscof_p0      = _MM_SET_f64(2.443315711809948E-005,gvl);
-  _MMR_f64   _ps_coscof_p1      = _MM_SET_f64(-1.388731625493765E-003,gvl);
-  _MMR_f64   _ps_coscof_p2      = _MM_SET_f64(4.166664568298827E-002,gvl);
-  _MMR_f64   _ps_0p5            = _MM_SET_f64(0.5f,gvl);
-
-  _MMR_f64 z;
-  _MMR_f64 tmp;
-
-  y = _ps_coscof_p0;
-  z = _MM_MUL_f64(x,x,gvl);
-
-  y = _MM_MUL_f64(y, z,gvl);
-  y = _MM_ADD_f64(y, _ps_coscof_p1,gvl);
-  y = _MM_MUL_f64(y, z,gvl);
-  y = _MM_ADD_f64(y, _ps_coscof_p2,gvl);
-  y = _MM_MUL_f64(y, z,gvl);
-  y = _MM_MUL_f64(y, z,gvl);
-  tmp = _MM_MUL_f64(z, _ps_0p5,gvl);
-  y = _MM_SUB_f64(y, tmp,gvl);
-  y = _MM_ADD_f64(y, _MM_SET_f64(1.0,gvl) ,gvl);
-
-  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
-  _MMR_f64 _ps_sincof_p0 = _MM_SET_f64(-1.9515295891E-4,gvl);
-  FENCE();
-  _MMR_f64 _ps_sincof_p1 = _MM_SET_f64(8.3321608736E-3,gvl);
-  _MMR_f64 _ps_sincof_p2 = _MM_SET_f64(-1.6666654611E-1,gvl);
-  _MMR_f64 y2;
-
-  y2 = _ps_sincof_p0;
-  y2 = _MM_MUL_f64(y2, z ,gvl);
-  y2 = _MM_ADD_f64(y2, _ps_sincof_p1 ,gvl);
-  y2 = _MM_MUL_f64(y2, z ,gvl);
-  y2 = _MM_ADD_f64(y2, _ps_sincof_p2 ,gvl);
-  y2 = _MM_MUL_f64(y2, z ,gvl);
-  y2 = _MM_MUL_f64(y2, x ,gvl);
-  y2 = _MM_ADD_f64(y2, x ,gvl);
-
-  /* select the correct result from the two polynoms */
-  xmm3 = poly_mask;
-  y2 = _MM_CAST_f64_i64(_MM_AND_i64(_MM_CAST_i64_f64(xmm3), _MM_CAST_i64_f64(y2), gvl));
-  y = _MM_CAST_f64_i64(_MM_AND_i64(_MM_XOR_i64(_MM_CAST_i64_f64(xmm3), _MM_SET_i64(0xffffffffffffffff,gvl),gvl),_MM_CAST_i64_f64(y),gvl));
-  y = _MM_ADD_f64(y, y2 ,gvl);
-  /* update the sign */
-  y = _MM_CAST_f64_i64(_MM_XOR_i64(_MM_CAST_i64_f64(y), _MM_CAST_i64_f64(sign_bit) , gvl));
-
-  return y;
-}
-
-inline _MMR_f32 __cos_2xf32(_MMR_f32 x , size_t gvl) {
-
-_MMR_i32   _ps_inv_sign_mask    = _MM_SET_i32(~0x80000000,gvl);
-_MMR_f32   _ps_cephes_FOPI      = _MM_SET_f32(1.27323954473516,gvl); // 4 / M_PI
-_MMR_i32   _pi32_1              = _MM_SET_i32(0x00000001,gvl);
-_MMR_i32   _pi32_inv1           = _MM_SET_i32(~0x00000001,gvl);
-_MMR_i32   _pi32_2              = _MM_SET_i32(2,gvl);
-_MMR_i32   _pi32_4              = _MM_SET_i32(4,gvl);
-_MMR_i32   _Zero                = _MM_SET_i32(0,gvl);
-
-_MMR_f32   xmm2 =  _MM_SET_f32(0.0f,gvl);
-_MMR_f32   xmm1;
-_MMR_f32   xmm3;
-_MMR_f32   y;
-
-_MMR_i32   emm0;
-_MMR_i32   emm2;
-
-_MMR_MASK_i32 xMask;
-  /* take the absolute value */
-  x = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(x), _ps_inv_sign_mask,gvl));
-
-  /* scale by 4/Pi */
-  y = _MM_MUL_f32(x, _ps_cephes_FOPI,gvl);
-
-  /* store the integer part of y in mm0 */
-  emm2 = _MM_VFCVT_X_F_i32(y,gvl);
-
-  /* j=(j+1) & (~1) (see the cephes sources) */
-  emm2 = _MM_ADD_i32(emm2,_pi32_1,gvl);
-  emm2 = _MM_AND_i32(emm2, _pi32_inv1,gvl);
-  y = _MM_VFCVT_F_X_f32(emm2,gvl);
-
-  emm2 = _MM_SUB_i32(emm2, _pi32_2,gvl);
-
-  /* get the swap sign flag */
-  emm0 = _MM_XOR_i32(emm2, _MM_SET_i32(0xffffffff,gvl),gvl);
-  emm0 = _MM_AND_i32(emm0, _pi32_4,gvl);
-
-  emm0 = _MM_SLL_i32(emm0, _MM_CAST_u32_i32(_MM_SET_i32(29,gvl)),gvl);
-
-  /* get the polynom selection mask */
-  emm2 = _MM_AND_i32(emm2, _pi32_2 ,gvl);
-  xMask= _MM_VMSEQ_i32(emm2,_Zero,gvl);
-  emm2 = _MM_MERGE_i32(_Zero,_MM_SET_i32(0xffffffff,gvl), xMask,gvl);
-
-  _MMR_f32 sign_bit =  _MM_CAST_f32_i32(emm0);
-  _MMR_f32 poly_mask =  _MM_CAST_f32_i32(emm2);
-
-  /* The magic pass: "Extended precision modular arithmetic"
-     x = ((x - y * DP1) - y * DP2) - y * DP3; */
-
-  _MMR_f32   _ps_minus_cephes_DP1    = _MM_SET_f32(-0.78515625,gvl);
-  _MMR_f32   _ps_minus_cephes_DP2    = _MM_SET_f32(-2.4187564849853515625E-4,gvl);
-  _MMR_f32   _ps_minus_cephes_DP3    = _MM_SET_f32(-3.77489497744594108E-8,gvl);
-
-  xmm1 = _ps_minus_cephes_DP1;
-  xmm2 = _ps_minus_cephes_DP2;
-  xmm3 = _ps_minus_cephes_DP3;
-
-  xmm1 = _MM_MUL_f32(y, xmm1,gvl);
-  xmm2 = _MM_MUL_f32(y, xmm2,gvl);
-  xmm3 = _MM_MUL_f32(y, xmm3,gvl);
-
-  x = _MM_ADD_f32(x, xmm1,gvl);
-  x = _MM_ADD_f32(x, xmm2,gvl);
-  x = _MM_ADD_f32(x, xmm3,gvl);
-
-  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
-  _MMR_f32   _ps_coscof_p0      = _MM_SET_f32(2.443315711809948E-005,gvl);
-  _MMR_f32   _ps_coscof_p1      = _MM_SET_f32(-1.388731625493765E-003,gvl);
-  _MMR_f32   _ps_coscof_p2      = _MM_SET_f32(4.166664568298827E-002,gvl);
-  _MMR_f32   _ps_0p5            = _MM_SET_f32(0.5f,gvl);
-
-  _MMR_f32 z;
-  _MMR_f32 tmp;
-
-  y = _ps_coscof_p0;
-  z = _MM_MUL_f32(x,x,gvl);
-
-  y = _MM_MUL_f32(y, z,gvl);
-  y = _MM_ADD_f32(y, _ps_coscof_p1,gvl);
-  y = _MM_MUL_f32(y, z,gvl);
-  y = _MM_ADD_f32(y, _ps_coscof_p2,gvl);
-  y = _MM_MUL_f32(y, z,gvl);
-  y = _MM_MUL_f32(y, z,gvl);
-  tmp = _MM_MUL_f32(z, _ps_0p5,gvl);
-  y = _MM_SUB_f32(y, tmp,gvl);
-  y = _MM_ADD_f32(y, _MM_SET_f32(1.0,gvl) ,gvl);
-
-  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
-  _MMR_f32   _ps_sincof_p0      = _MM_SET_f32(-1.9515295891E-4,gvl);
-  _MMR_f32   _ps_sincof_p1      = _MM_SET_f32(8.3321608736E-3,gvl);
-  _MMR_f32   _ps_sincof_p2      = _MM_SET_f32(-1.6666654611E-1,gvl);
-  _MMR_f32 y2;
-
-  y2 = _ps_sincof_p0;
-  y2 = _MM_MUL_f32(y2, z ,gvl);
-  y2 = _MM_ADD_f32(y2, _ps_sincof_p1 ,gvl);
-  y2 = _MM_MUL_f32(y2, z ,gvl);
-  y2 = _MM_ADD_f32(y2, _ps_sincof_p2 ,gvl);
-  y2 = _MM_MUL_f32(y2, z ,gvl);
-  y2 = _MM_MUL_f32(y2, x ,gvl);
-  y2 = _MM_ADD_f32(y2, x ,gvl);
-
-  /* select the correct result from the two polynoms */
-  xmm3 = poly_mask;
-  y2 = _MM_CAST_f32_i32(_MM_AND_i32(_MM_CAST_i32_f32(xmm3), _MM_CAST_i32_f32(y2) , gvl)); //, xmm3);
-  y = _MM_CAST_f32_i32(_MM_AND_i32(_MM_XOR_i32(_MM_CAST_i32_f32(xmm3), _MM_SET_i32(0xffffffff,gvl),gvl),_MM_CAST_i32_f32(y),gvl));
-  y = _MM_ADD_f32(y, y2 ,gvl);
-  /* update the sign */
-  y = _MM_CAST_f32_i32(_MM_XOR_i32(_MM_CAST_i32_f32(y), _MM_CAST_i32_f32(sign_bit) , gvl));
-
-  return y;
-}
 
 int main() {
   printf("\n");

--- a/apps/cos/main.c
+++ b/apps/cos/main.c
@@ -19,10 +19,10 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "util.h"
 #include "kernel/cos.h"
 #include "printf.h"
 #include "runtime.h"
+#include "util.h"
 
 extern size_t N_f64;
 extern double angles_f64[] __attribute__((aligned(4 * NR_LANES)));
@@ -72,13 +72,15 @@ int main() {
   for (uint64_t i = 0; i < N_f64; ++i) {
     if (!similarity_check(results_f64[i], gold_results_f64[i], THRESHOLD)) {
       error = 1;
-      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i], gold_results_f64[i]);
+      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i],
+             gold_results_f64[i]);
     }
   }
   for (uint64_t i = 0; i < N_f32; ++i) {
     if (!similarity_check(results_f32[i], gold_results_f32[i], THRESHOLD)) {
       error = 1;
-      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i], gold_results_f32[i]);
+      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i],
+             gold_results_f32[i]);
     }
   }
 #endif

--- a/apps/cos/script/gen_data.py
+++ b/apps/cos/script/gen_data.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2021 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# arg1: vector size, arg2: filter size
+
+import random as rand
+import numpy as np
+import sys
+
+def emit(name, array, alignment='8'):
+  print(".global %s" % name)
+  print(".balign " + alignment)
+  print("%s:" % name)
+  bs = array.tobytes()
+  for i in range(0, len(bs), 4):
+    s = ""
+    for n in range(4):
+      s += "%02x" % bs[i+3-n]
+    print("    .word 0x%s" % s)
+
+def rand_matrix(N, dtype):
+  return np.random.rand(N).astype(dtype) * 3.141
+
+############
+## SCRIPT ##
+############
+
+if len(sys.argv) == 2:
+  N_f64 = int(sys.argv[1])
+  N_f32 = 2 * N_f64
+else:
+  print("Error. Give me one argument: the number of vector elements.")
+  sys.exit()
+
+# Vector of samples
+angles_f64 = rand_matrix(N_f64, np.float64).astype(np.float64)
+angles_f32 = rand_matrix(N_f32, np.float32).astype(np.float32)
+
+# Results buffer
+results_f64 = np.zeros(N_f64, dtype=np.float64)
+results_f32 = np.zeros(N_f32, dtype=np.float32)
+
+# Gold results
+gold_results_f64 = np.cos(angles_f64, dtype=np.float64)
+gold_results_f32 = np.cos(angles_f32, dtype=np.float32)
+
+# Create the file
+print(".section .data,\"aw\",@progbits")
+emit("N_f64", np.array(N_f64, dtype=np.uint64))
+emit("angles_f64", angles_f64, 'NR_LANES*4')
+emit("results_f64", results_f64, 'NR_LANES*4')
+emit("gold_results_f64", gold_results_f64, 'NR_LANES*4')
+emit("N_f32", np.array(N_f32, dtype=np.uint32))
+emit("angles_f32", angles_f32, 'NR_LANES*4')
+emit("results_f32", results_f32, 'NR_LANES*4')
+emit("gold_results_f32", gold_results_f32, 'NR_LANES*4')

--- a/apps/exp/LICENSE
+++ b/apps/exp/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2020, Barcelona Supercomputing Center
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met: redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer;
+redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution;
+neither the name of the copyright holders nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+If you use this software or a modified version of it for your research, please cite the paper:
+Cristóbal Ramírez, César Hernandez, Oscar Palomar, Osman Unsal, Marco Ramírez, and Adrián Cristal. 2020. A RISC-V Simulator and Benchmark Suite for Designing and Evaluating Vector Architectures. ACM Trans. Archit. Code Optim. 17, 4, Article 38 (October 2020), 29 pages. https://doi.org/10.1145/3422667

--- a/apps/exp/kernel/exp.c
+++ b/apps/exp/kernel/exp.c
@@ -1,0 +1,75 @@
+// Modified version of:
+// "RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
+// Find details on the original version below
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+//
+// RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
+// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+
+/*
+   AVX implementation of sin, cos, sincos, exp and log
+   Based on "sse_mathfun.h", by Julien Pommier
+   http://gruntthepeon.free.fr/ssemath/
+   Copyright (C) 2012 Giovanni Garberoglio
+   Interdisciplinary Laboratory for Computational Science (LISC)
+   Fondazione Bruno Kessler and University of Trento
+   via Sommarive, 18
+   I-38123 Trento (Italy)
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+  (this is the zlib license)
+*/
+
+#include "exp.h"
+
+void exp_1xf64_bmark(double* exponents, double* results, size_t len) {
+
+  size_t avl = len;
+  vfloat64m1_t exp_vec, res_vec;
+
+  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e64m1(avl);
+    // Load vector
+    exp_vec = vle64_v_f64m1(exponents, vl);
+    // Compute
+    res_vec = __exp_1xf64(exp_vec, vl);
+    // Store
+    vse64_v_f64m1(results, res_vec, vl);
+    // Bump pointers
+    exponents += vl;
+    results   += vl;
+  }
+}
+
+void exp_2xf32_bmark(float* exponents, float* results, size_t len) {
+
+  size_t avl = len;
+  vfloat32m1_t exp_vec, res_vec;
+
+  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e32m1(avl);
+    // Load vector
+    exp_vec = vle32_v_f32m1(exponents, vl);
+    // Compute
+    res_vec = __exp_2xf32(exp_vec, vl);
+    // Store
+    vse32_v_f32m1(results, res_vec, vl);
+    // Bump pointers
+    exponents += vl;
+    results   += vl;
+  }
+}

--- a/apps/exp/kernel/exp.c
+++ b/apps/exp/kernel/exp.c
@@ -1,11 +1,12 @@
 // Modified version of:
-// "RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
-// Find details on the original version below
-// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+// "RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona
+// 2019"" Find details on the original version below Author: Matteo Perotti
+// <mperotti@iis.ee.ethz.ch>
 
 //
-// RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
-// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+// RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona
+// 2019" This RISC-V Vector implementation is based on the original code
+// presented by Julien Pommier
 
 /*
    AVX implementation of sin, cos, sincos, exp and log
@@ -34,7 +35,7 @@
 
 #include "exp.h"
 
-void exp_1xf64_bmark(double* exponents, double* results, size_t len) {
+void exp_1xf64_bmark(double *exponents, double *results, size_t len) {
 
   size_t avl = len;
   vfloat64m1_t exp_vec, res_vec;
@@ -50,11 +51,11 @@ void exp_1xf64_bmark(double* exponents, double* results, size_t len) {
     vse64_v_f64m1(results, res_vec, vl);
     // Bump pointers
     exponents += vl;
-    results   += vl;
+    results += vl;
   }
 }
 
-void exp_2xf32_bmark(float* exponents, float* results, size_t len) {
+void exp_2xf32_bmark(float *exponents, float *results, size_t len) {
 
   size_t avl = len;
   vfloat32m1_t exp_vec, res_vec;
@@ -70,6 +71,6 @@ void exp_2xf32_bmark(float* exponents, float* results, size_t len) {
     vse32_v_f32m1(results, res_vec, vl);
     // Bump pointers
     exponents += vl;
-    results   += vl;
+    results += vl;
   }
 }

--- a/apps/exp/kernel/exp.h
+++ b/apps/exp/kernel/exp.h
@@ -21,8 +21,8 @@
 
 #include "riscv_vector.h"
 
-void exp_1xf64_bmark(double* exponents, double* results, size_t len);
-void exp_2xf32_bmark(float* exponents, float* results, size_t len);
+void exp_1xf64_bmark(double *exponents, double *results, size_t len);
+void exp_2xf32_bmark(float *exponents, float *results, size_t len);
 
 // Cannot use LMUL > 1 with this implmentation
 // Hard to hardcode assembly registers in this function
@@ -30,132 +30,132 @@ void exp_2xf32_bmark(float* exponents, float* results, size_t len);
 // the correct ones.
 inline vfloat64m1_t __exp_1xf64(vfloat64m1_t x, size_t gvl) {
 
-vfloat64m1_t   exp_hi        = vfmv_v_f_f64m1(88.3762626647949,gvl);
-vfloat64m1_t   exp_lo        = vfmv_v_f_f64m1(-88.3762626647949,gvl);
+  vfloat64m1_t exp_hi = vfmv_v_f_f64m1(88.3762626647949, gvl);
+  vfloat64m1_t exp_lo = vfmv_v_f_f64m1(-88.3762626647949, gvl);
 
-vfloat64m1_t   cephes_LOG2EF = vfmv_v_f_f64m1(1.44269504088896341,gvl);
-vfloat64m1_t   cephes_exp_C1 = vfmv_v_f_f64m1(0.693359375,gvl);
-vfloat64m1_t   cephes_exp_C2 = vfmv_v_f_f64m1(-2.12194440e-4,gvl);
+  vfloat64m1_t cephes_LOG2EF = vfmv_v_f_f64m1(1.44269504088896341, gvl);
+  vfloat64m1_t cephes_exp_C1 = vfmv_v_f_f64m1(0.693359375, gvl);
+  vfloat64m1_t cephes_exp_C2 = vfmv_v_f_f64m1(-2.12194440e-4, gvl);
 
-vfloat64m1_t   cephes_exp_p0 = vfmv_v_f_f64m1(1.9875691500E-4,gvl);
-vfloat64m1_t   cephes_exp_p1 = vfmv_v_f_f64m1(1.3981999507E-3,gvl);
-vfloat64m1_t   cephes_exp_p2 = vfmv_v_f_f64m1(8.3334519073E-3,gvl);
-vfloat64m1_t   cephes_exp_p3 = vfmv_v_f_f64m1(4.1665795894E-2,gvl);
-vfloat64m1_t   cephes_exp_p4 = vfmv_v_f_f64m1(1.6666665459E-1,gvl);
-vfloat64m1_t   cephes_exp_p5 = vfmv_v_f_f64m1(5.0000001201E-1,gvl);
-vfloat64m1_t   tmp;
-vfloat64m1_t   tmp2;
-vfloat64m1_t   tmp4;
-vfloat64m1_t   fx;
+  vfloat64m1_t cephes_exp_p0 = vfmv_v_f_f64m1(1.9875691500E-4, gvl);
+  vfloat64m1_t cephes_exp_p1 = vfmv_v_f_f64m1(1.3981999507E-3, gvl);
+  vfloat64m1_t cephes_exp_p2 = vfmv_v_f_f64m1(8.3334519073E-3, gvl);
+  vfloat64m1_t cephes_exp_p3 = vfmv_v_f_f64m1(4.1665795894E-2, gvl);
+  vfloat64m1_t cephes_exp_p4 = vfmv_v_f_f64m1(1.6666665459E-1, gvl);
+  vfloat64m1_t cephes_exp_p5 = vfmv_v_f_f64m1(5.0000001201E-1, gvl);
+  vfloat64m1_t tmp;
+  vfloat64m1_t tmp2;
+  vfloat64m1_t tmp4;
+  vfloat64m1_t fx;
 
-vfloat64m1_t   one = vfmv_v_f_f64m1(1.0,gvl);
-vfloat64m1_t   zero = vfmv_v_f_f64m1(0.0,gvl);
-vfloat64m1_t   z;
-vfloat64m1_t   y;
+  vfloat64m1_t one = vfmv_v_f_f64m1(1.0, gvl);
+  vfloat64m1_t zero = vfmv_v_f_f64m1(0.0, gvl);
+  vfloat64m1_t z;
+  vfloat64m1_t y;
 
-vbool64_t  mask;
-vint64m1_t  imm0;
-vint64m1_t  tmp3;
+  vbool64_t mask;
+  vint64m1_t imm0;
+  vint64m1_t tmp3;
 
-        x     = vfmin_vv_f64m1(x, exp_hi,gvl);
-        x     = vfmax_vv_f64m1(x, exp_lo,gvl);
+  x = vfmin_vv_f64m1(x, exp_hi, gvl);
+  x = vfmax_vv_f64m1(x, exp_lo, gvl);
 
-        fx    = vfmv_v_f_f64m1(0.5,gvl);
-        fx    = vfmacc_vv_f64m1(fx,x,cephes_LOG2EF,gvl);
+  fx = vfmv_v_f_f64m1(0.5, gvl);
+  fx = vfmacc_vv_f64m1(fx, x, cephes_LOG2EF, gvl);
 
-        tmp3  = vfcvt_x_f_v_i64m1(fx,gvl);
-        tmp   = vfcvt_f_x_v_f64m1(tmp3,gvl);
+  tmp3 = vfcvt_x_f_v_i64m1(fx, gvl);
+  tmp = vfcvt_f_x_v_f64m1(tmp3, gvl);
 
-        mask  = vmflt_vv_f64m1_b64(fx,tmp,gvl);
-        tmp2  = vmerge_vvm_f64m1(mask,zero,one, gvl);
-        fx    = vfsub_vv_f64m1(tmp,tmp2,gvl);
-        tmp   = vfmul_vv_f64m1(fx, cephes_exp_C1,gvl);
-        z     = vfmul_vv_f64m1(fx, cephes_exp_C2,gvl);
-        x     = vfsub_vv_f64m1(x,tmp,gvl);
-        x     = vfsub_vv_f64m1(x,z,gvl);
+  mask = vmflt_vv_f64m1_b64(fx, tmp, gvl);
+  tmp2 = vmerge_vvm_f64m1(mask, zero, one, gvl);
+  fx = vfsub_vv_f64m1(tmp, tmp2, gvl);
+  tmp = vfmul_vv_f64m1(fx, cephes_exp_C1, gvl);
+  z = vfmul_vv_f64m1(fx, cephes_exp_C2, gvl);
+  x = vfsub_vv_f64m1(x, tmp, gvl);
+  x = vfsub_vv_f64m1(x, z, gvl);
 
-        z     = vfmul_vv_f64m1(x,x,gvl);
+  z = vfmul_vv_f64m1(x, x, gvl);
 
-        y     = cephes_exp_p0;
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p1,gvl);
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p2,gvl);
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p3,gvl);
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p4,gvl);
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p5,gvl);
-        y     = vfmadd_vv_f64m1(y,z,x,gvl);
-        y     = vfadd_vv_f64m1(y, one,gvl);
+  y = cephes_exp_p0;
+  y = vfmadd_vv_f64m1(y, x, cephes_exp_p1, gvl);
+  y = vfmadd_vv_f64m1(y, x, cephes_exp_p2, gvl);
+  y = vfmadd_vv_f64m1(y, x, cephes_exp_p3, gvl);
+  y = vfmadd_vv_f64m1(y, x, cephes_exp_p4, gvl);
+  y = vfmadd_vv_f64m1(y, x, cephes_exp_p5, gvl);
+  y = vfmadd_vv_f64m1(y, z, x, gvl);
+  y = vfadd_vv_f64m1(y, one, gvl);
 
-        imm0  = vfcvt_x_f_v_i64m1(fx,gvl);
-        imm0  = vadd_vv_i64m1(imm0, vmv_v_x_i64m1(1023,gvl),gvl);
-        imm0  = vsll_vv_i64m1(imm0, vmv_v_x_u64m1(52,gvl),gvl);
+  imm0 = vfcvt_x_f_v_i64m1(fx, gvl);
+  imm0 = vadd_vv_i64m1(imm0, vmv_v_x_i64m1(1023, gvl), gvl);
+  imm0 = vsll_vv_i64m1(imm0, vmv_v_x_u64m1(52, gvl), gvl);
 
-        tmp4  = vreinterpret_v_i64m1_f64m1(imm0);
-        y     = vfmul_vv_f64m1(y, tmp4,gvl);
-        return y;
+  tmp4 = vreinterpret_v_i64m1_f64m1(imm0);
+  y = vfmul_vv_f64m1(y, tmp4, gvl);
+  return y;
 }
 
-inline vfloat32m1_t __exp_2xf32(vfloat32m1_t x , size_t gvl) {
+inline vfloat32m1_t __exp_2xf32(vfloat32m1_t x, size_t gvl) {
 
-vfloat32m1_t   exp_hi        = vfmv_v_f_f32m1(88.3762626647949,gvl);
-vfloat32m1_t   exp_lo        = vfmv_v_f_f32m1(-88.3762626647949,gvl);
+  vfloat32m1_t exp_hi = vfmv_v_f_f32m1(88.3762626647949, gvl);
+  vfloat32m1_t exp_lo = vfmv_v_f_f32m1(-88.3762626647949, gvl);
 
-vfloat32m1_t   cephes_LOG2EF = vfmv_v_f_f32m1(1.44269504088896341,gvl);
-vfloat32m1_t   cephes_exp_C1 = vfmv_v_f_f32m1(0.693359375,gvl);
-vfloat32m1_t   cephes_exp_C2 = vfmv_v_f_f32m1(-2.12194440e-4,gvl);
+  vfloat32m1_t cephes_LOG2EF = vfmv_v_f_f32m1(1.44269504088896341, gvl);
+  vfloat32m1_t cephes_exp_C1 = vfmv_v_f_f32m1(0.693359375, gvl);
+  vfloat32m1_t cephes_exp_C2 = vfmv_v_f_f32m1(-2.12194440e-4, gvl);
 
-vfloat32m1_t   cephes_exp_p0 = vfmv_v_f_f32m1(1.9875691500E-4,gvl);
-vfloat32m1_t   cephes_exp_p1 = vfmv_v_f_f32m1(1.3981999507E-3,gvl);
-vfloat32m1_t   cephes_exp_p2 = vfmv_v_f_f32m1(8.3334519073E-3,gvl);
-vfloat32m1_t   cephes_exp_p3 = vfmv_v_f_f32m1(4.1665795894E-2,gvl);
-vfloat32m1_t   cephes_exp_p4 = vfmv_v_f_f32m1(1.6666665459E-1,gvl);
-vfloat32m1_t   cephes_exp_p5 = vfmv_v_f_f32m1(5.0000001201E-1,gvl);
-vfloat32m1_t   tmp;
-vfloat32m1_t   tmp2;
-vfloat32m1_t   tmp4;
-vfloat32m1_t   fx;
+  vfloat32m1_t cephes_exp_p0 = vfmv_v_f_f32m1(1.9875691500E-4, gvl);
+  vfloat32m1_t cephes_exp_p1 = vfmv_v_f_f32m1(1.3981999507E-3, gvl);
+  vfloat32m1_t cephes_exp_p2 = vfmv_v_f_f32m1(8.3334519073E-3, gvl);
+  vfloat32m1_t cephes_exp_p3 = vfmv_v_f_f32m1(4.1665795894E-2, gvl);
+  vfloat32m1_t cephes_exp_p4 = vfmv_v_f_f32m1(1.6666665459E-1, gvl);
+  vfloat32m1_t cephes_exp_p5 = vfmv_v_f_f32m1(5.0000001201E-1, gvl);
+  vfloat32m1_t tmp;
+  vfloat32m1_t tmp2;
+  vfloat32m1_t tmp4;
+  vfloat32m1_t fx;
 
-vfloat32m1_t   one = vfmv_v_f_f32m1(1.0,gvl);
-vfloat32m1_t   zero = vfmv_v_f_f32m1(0.0,gvl);
-vfloat32m1_t   z;
-vfloat32m1_t   y;
+  vfloat32m1_t one = vfmv_v_f_f32m1(1.0, gvl);
+  vfloat32m1_t zero = vfmv_v_f_f32m1(0.0, gvl);
+  vfloat32m1_t z;
+  vfloat32m1_t y;
 
-vbool32_t  mask;
-vint32m1_t  imm0;
-vint32m1_t  tmp3;
+  vbool32_t mask;
+  vint32m1_t imm0;
+  vint32m1_t tmp3;
 
-        x     = vfmin_vv_f32m1(x, exp_hi,gvl);
-        x     = vfmax_vv_f32m1(x, exp_lo,gvl);
+  x = vfmin_vv_f32m1(x, exp_hi, gvl);
+  x = vfmax_vv_f32m1(x, exp_lo, gvl);
 
-        fx    = vfmv_v_f_f32m1(0.5,gvl);
-        fx    = vfmacc_vv_f32m1(fx,x,cephes_LOG2EF,gvl);
+  fx = vfmv_v_f_f32m1(0.5, gvl);
+  fx = vfmacc_vv_f32m1(fx, x, cephes_LOG2EF, gvl);
 
-        tmp3  = vfcvt_x_f_v_i32m1(fx,gvl);
-        tmp   = vfcvt_f_x_v_f32m1(tmp3,gvl);
+  tmp3 = vfcvt_x_f_v_i32m1(fx, gvl);
+  tmp = vfcvt_f_x_v_f32m1(tmp3, gvl);
 
-        mask  = vmflt_vv_f32m1_b32(fx,tmp,gvl);
-        tmp2  = vmerge_vvm_f32m1(mask,zero,one, gvl);
-        fx    = vfsub_vv_f32m1(tmp,tmp2,gvl);
-        tmp   = vfmul_vv_f32m1(fx, cephes_exp_C1,gvl);
-        z     = vfmul_vv_f32m1(fx, cephes_exp_C2,gvl);
-        x     = vfsub_vv_f32m1(x,tmp,gvl);
-        x     = vfsub_vv_f32m1(x,z,gvl);
+  mask = vmflt_vv_f32m1_b32(fx, tmp, gvl);
+  tmp2 = vmerge_vvm_f32m1(mask, zero, one, gvl);
+  fx = vfsub_vv_f32m1(tmp, tmp2, gvl);
+  tmp = vfmul_vv_f32m1(fx, cephes_exp_C1, gvl);
+  z = vfmul_vv_f32m1(fx, cephes_exp_C2, gvl);
+  x = vfsub_vv_f32m1(x, tmp, gvl);
+  x = vfsub_vv_f32m1(x, z, gvl);
 
-        z     = vfmul_vv_f32m1(x,x,gvl);
+  z = vfmul_vv_f32m1(x, x, gvl);
 
-        y     = cephes_exp_p0;
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p1,gvl);
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p2,gvl);
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p3,gvl);
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p4,gvl);
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p5,gvl);
-        y     = vfmadd_vv_f32m1(y,z,x,gvl);
-        y     = vfadd_vv_f32m1(y,one,gvl);
+  y = cephes_exp_p0;
+  y = vfmadd_vv_f32m1(y, x, cephes_exp_p1, gvl);
+  y = vfmadd_vv_f32m1(y, x, cephes_exp_p2, gvl);
+  y = vfmadd_vv_f32m1(y, x, cephes_exp_p3, gvl);
+  y = vfmadd_vv_f32m1(y, x, cephes_exp_p4, gvl);
+  y = vfmadd_vv_f32m1(y, x, cephes_exp_p5, gvl);
+  y = vfmadd_vv_f32m1(y, z, x, gvl);
+  y = vfadd_vv_f32m1(y, one, gvl);
 
-        imm0  = vfcvt_x_f_v_i32m1(fx,gvl);
-        imm0  = vadd_vv_i32m1(imm0, vmv_v_x_i32m1(0x7f,gvl),gvl);
-        imm0  = vsll_vv_i32m1(imm0, vmv_v_x_u32m1(23,gvl),gvl);
+  imm0 = vfcvt_x_f_v_i32m1(fx, gvl);
+  imm0 = vadd_vv_i32m1(imm0, vmv_v_x_i32m1(0x7f, gvl), gvl);
+  imm0 = vsll_vv_i32m1(imm0, vmv_v_x_u32m1(23, gvl), gvl);
 
-        tmp4  = vreinterpret_v_i32m1_f32m1(imm0);
-        y     = vfmul_vv_f32m1(y, tmp4, gvl);
-        return y;
+  tmp4 = vreinterpret_v_i32m1_f32m1(imm0);
+  y = vfmul_vv_f32m1(y, tmp4, gvl);
+  return y;
 }

--- a/apps/exp/kernel/exp.h
+++ b/apps/exp/kernel/exp.h
@@ -1,0 +1,161 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Matteo Perotti
+
+#include <stdint.h>
+#include <string.h>
+
+#include "riscv_vector.h"
+
+void exp_1xf64_bmark(double* exponents, double* results, size_t len);
+void exp_2xf32_bmark(float* exponents, float* results, size_t len);
+
+// Cannot use LMUL > 1 with this implmentation
+// Hard to hardcode assembly registers in this function
+// since the caller should know to spill to/from memory
+// the correct ones.
+inline vfloat64m1_t __exp_1xf64(vfloat64m1_t x, size_t gvl) {
+
+vfloat64m1_t   exp_hi        = vfmv_v_f_f64m1(88.3762626647949,gvl);
+vfloat64m1_t   exp_lo        = vfmv_v_f_f64m1(-88.3762626647949,gvl);
+
+vfloat64m1_t   cephes_LOG2EF = vfmv_v_f_f64m1(1.44269504088896341,gvl);
+vfloat64m1_t   cephes_exp_C1 = vfmv_v_f_f64m1(0.693359375,gvl);
+vfloat64m1_t   cephes_exp_C2 = vfmv_v_f_f64m1(-2.12194440e-4,gvl);
+
+vfloat64m1_t   cephes_exp_p0 = vfmv_v_f_f64m1(1.9875691500E-4,gvl);
+vfloat64m1_t   cephes_exp_p1 = vfmv_v_f_f64m1(1.3981999507E-3,gvl);
+vfloat64m1_t   cephes_exp_p2 = vfmv_v_f_f64m1(8.3334519073E-3,gvl);
+vfloat64m1_t   cephes_exp_p3 = vfmv_v_f_f64m1(4.1665795894E-2,gvl);
+vfloat64m1_t   cephes_exp_p4 = vfmv_v_f_f64m1(1.6666665459E-1,gvl);
+vfloat64m1_t   cephes_exp_p5 = vfmv_v_f_f64m1(5.0000001201E-1,gvl);
+vfloat64m1_t   tmp;
+vfloat64m1_t   tmp2;
+vfloat64m1_t   tmp4;
+vfloat64m1_t   fx;
+
+vfloat64m1_t   one = vfmv_v_f_f64m1(1.0,gvl);
+vfloat64m1_t   zero = vfmv_v_f_f64m1(0.0,gvl);
+vfloat64m1_t   z;
+vfloat64m1_t   y;
+
+vbool64_t  mask;
+vint64m1_t  imm0;
+vint64m1_t  tmp3;
+
+        x     = vfmin_vv_f64m1(x, exp_hi,gvl);
+        x     = vfmax_vv_f64m1(x, exp_lo,gvl);
+
+        fx    = vfmv_v_f_f64m1(0.5,gvl);
+        fx    = vfmacc_vv_f64m1(fx,x,cephes_LOG2EF,gvl);
+
+        tmp3  = vfcvt_x_f_v_i64m1(fx,gvl);
+        tmp   = vfcvt_f_x_v_f64m1(tmp3,gvl);
+
+        mask  = vmflt_vv_f64m1_b64(fx,tmp,gvl);
+        tmp2  = vmerge_vvm_f64m1(mask,zero,one, gvl);
+        fx    = vfsub_vv_f64m1(tmp,tmp2,gvl);
+        tmp   = vfmul_vv_f64m1(fx, cephes_exp_C1,gvl);
+        z     = vfmul_vv_f64m1(fx, cephes_exp_C2,gvl);
+        x     = vfsub_vv_f64m1(x,tmp,gvl);
+        x     = vfsub_vv_f64m1(x,z,gvl);
+
+        z     = vfmul_vv_f64m1(x,x,gvl);
+
+        y     = cephes_exp_p0;
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p1,gvl);
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p2,gvl);
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p3,gvl);
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p4,gvl);
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p5,gvl);
+        y     = vfmadd_vv_f64m1(y,z,x,gvl);
+        y     = vfadd_vv_f64m1(y, one,gvl);
+
+        imm0  = vfcvt_x_f_v_i64m1(fx,gvl);
+        imm0  = vadd_vv_i64m1(imm0, vmv_v_x_i64m1(1023,gvl),gvl);
+        imm0  = vsll_vv_i64m1(imm0, vmv_v_x_u64m1(52,gvl),gvl);
+
+        tmp4  = vreinterpret_v_i64m1_f64m1(imm0);
+        y     = vfmul_vv_f64m1(y, tmp4,gvl);
+        return y;
+}
+
+inline vfloat32m1_t __exp_2xf32(vfloat32m1_t x , size_t gvl) {
+
+vfloat32m1_t   exp_hi        = vfmv_v_f_f32m1(88.3762626647949,gvl);
+vfloat32m1_t   exp_lo        = vfmv_v_f_f32m1(-88.3762626647949,gvl);
+
+vfloat32m1_t   cephes_LOG2EF = vfmv_v_f_f32m1(1.44269504088896341,gvl);
+vfloat32m1_t   cephes_exp_C1 = vfmv_v_f_f32m1(0.693359375,gvl);
+vfloat32m1_t   cephes_exp_C2 = vfmv_v_f_f32m1(-2.12194440e-4,gvl);
+
+vfloat32m1_t   cephes_exp_p0 = vfmv_v_f_f32m1(1.9875691500E-4,gvl);
+vfloat32m1_t   cephes_exp_p1 = vfmv_v_f_f32m1(1.3981999507E-3,gvl);
+vfloat32m1_t   cephes_exp_p2 = vfmv_v_f_f32m1(8.3334519073E-3,gvl);
+vfloat32m1_t   cephes_exp_p3 = vfmv_v_f_f32m1(4.1665795894E-2,gvl);
+vfloat32m1_t   cephes_exp_p4 = vfmv_v_f_f32m1(1.6666665459E-1,gvl);
+vfloat32m1_t   cephes_exp_p5 = vfmv_v_f_f32m1(5.0000001201E-1,gvl);
+vfloat32m1_t   tmp;
+vfloat32m1_t   tmp2;
+vfloat32m1_t   tmp4;
+vfloat32m1_t   fx;
+
+vfloat32m1_t   one = vfmv_v_f_f32m1(1.0,gvl);
+vfloat32m1_t   zero = vfmv_v_f_f32m1(0.0,gvl);
+vfloat32m1_t   z;
+vfloat32m1_t   y;
+
+vbool32_t  mask;
+vint32m1_t  imm0;
+vint32m1_t  tmp3;
+
+        x     = vfmin_vv_f32m1(x, exp_hi,gvl);
+        x     = vfmax_vv_f32m1(x, exp_lo,gvl);
+
+        fx    = vfmv_v_f_f32m1(0.5,gvl);
+        fx    = vfmacc_vv_f32m1(fx,x,cephes_LOG2EF,gvl);
+
+        tmp3  = vfcvt_x_f_v_i32m1(fx,gvl);
+        tmp   = vfcvt_f_x_v_f32m1(tmp3,gvl);
+
+        mask  = vmflt_vv_f32m1_b32(fx,tmp,gvl);
+        tmp2  = vmerge_vvm_f32m1(mask,zero,one, gvl);
+        fx    = vfsub_vv_f32m1(tmp,tmp2,gvl);
+        tmp   = vfmul_vv_f32m1(fx, cephes_exp_C1,gvl);
+        z     = vfmul_vv_f32m1(fx, cephes_exp_C2,gvl);
+        x     = vfsub_vv_f32m1(x,tmp,gvl);
+        x     = vfsub_vv_f32m1(x,z,gvl);
+
+        z     = vfmul_vv_f32m1(x,x,gvl);
+
+        y     = cephes_exp_p0;
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p1,gvl);
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p2,gvl);
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p3,gvl);
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p4,gvl);
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p5,gvl);
+        y     = vfmadd_vv_f32m1(y,z,x,gvl);
+        y     = vfadd_vv_f32m1(y,one,gvl);
+
+        imm0  = vfcvt_x_f_v_i32m1(fx,gvl);
+        imm0  = vadd_vv_i32m1(imm0, vmv_v_x_i32m1(0x7f,gvl),gvl);
+        imm0  = vsll_vv_i32m1(imm0, vmv_v_x_u32m1(23,gvl),gvl);
+
+        tmp4  = vreinterpret_v_i32m1_f32m1(imm0);
+        y     = vfmul_vv_f32m1(y, tmp4, gvl);
+        return y;
+}

--- a/apps/exp/main.c
+++ b/apps/exp/main.c
@@ -1,0 +1,295 @@
+// Modified version of:
+// "RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
+// Find details on the original version below
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+//
+// RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
+// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+
+/*
+   AVX implementation of sin, cos, sincos, exp and log
+   Based on "sse_mathfun.h", by Julien Pommier
+   http://gruntthepeon.free.fr/ssemath/
+   Copyright (C) 2012 Giovanni Garberoglio
+   Interdisciplinary Laboratory for Computational Science (LISC)
+   Fondazione Bruno Kessler and University of Trento
+   via Sommarive, 18
+   I-38123 Trento (Italy)
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+  (this is the zlib license)
+*/
+
+#include <stdint.h>
+#include <string.h>
+
+#include <riscv_vector.h>
+#include "printf.h"
+#include "runtime.h"
+
+extern size_t N_f64;
+
+extern double exponents_f64[] __attribute__((aligned(4 * NR_LANES)));
+extern double results_f64[] __attribute__((aligned(4 * NR_LANES)));
+extern double gold_results_f64[] __attribute__((aligned(4 * NR_LANES)));
+
+extern size_t N_f32;
+
+extern float exponents_f32[] __attribute__((aligned(4 * NR_LANES)));
+extern float results_f32[] __attribute__((aligned(4 * NR_LANES)));
+extern float gold_results_f32[] __attribute__((aligned(4 * NR_LANES)));
+
+#define THRESHOLD 1
+#define FABS(x) ((x < 0) ? -x : x)
+
+#define CHECK
+
+inline vfloat64m1_t __exp_1xf64(vfloat64m1_t x, size_t gvl);
+inline vfloat32m1_t __exp_2xf32(vfloat32m1_t x, size_t gvl);
+void exp_1xf64_bmark(double* exponents, double* results, size_t len);
+void exp_2xf32_bmark(float* exponents, float* results, size_t len);
+int similarity_check(double a, double b, double threshold);
+
+int similarity_check(double a, double b, double threshold) {
+  double diff = a - b;
+  if (FABS(diff) > threshold)
+    return 0;
+  else
+    return 1;
+}
+
+void exp_1xf64_bmark(double* exponents, double* results, size_t len) {
+
+  size_t avl = len;
+  vfloat64m1_t exp_vec, res_vec;
+
+  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e64m1(avl);
+    // Load vector
+    exp_vec = vle64_v_f64m1(exponents, vl);
+    // Compute
+    res_vec = __exp_1xf64(exp_vec, vl);
+    // Store
+    vse64_v_f64m1(results, res_vec, vl);
+    // Bump pointers
+    exponents += vl;
+    results   += vl;
+  }
+}
+
+void exp_2xf32_bmark(float* exponents, float* results, size_t len) {
+
+  size_t avl = len;
+  vfloat32m1_t exp_vec, res_vec;
+
+  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e32m1(avl);
+    // Load vector
+    exp_vec = vle32_v_f32m1(exponents, vl);
+    // Compute
+    res_vec = __exp_2xf32(exp_vec, vl);
+    // Store
+    vse32_v_f32m1(results, res_vec, vl);
+    // Bump pointers
+    exponents += vl;
+    results   += vl;
+  }
+}
+
+// Cannot use LMUL > 1 with this implmentation
+// Hard to hardcode assembly registers in this function
+// since the caller should know to spill to/from memory
+// the correct ones.
+inline vfloat64m1_t __exp_1xf64(vfloat64m1_t x, size_t gvl) {
+
+vfloat64m1_t   exp_hi        = vfmv_v_f_f64m1(88.3762626647949,gvl);
+vfloat64m1_t   exp_lo        = vfmv_v_f_f64m1(-88.3762626647949,gvl);
+
+vfloat64m1_t   cephes_LOG2EF = vfmv_v_f_f64m1(1.44269504088896341,gvl);
+vfloat64m1_t   cephes_exp_C1 = vfmv_v_f_f64m1(0.693359375,gvl);
+vfloat64m1_t   cephes_exp_C2 = vfmv_v_f_f64m1(-2.12194440e-4,gvl);
+
+vfloat64m1_t   cephes_exp_p0 = vfmv_v_f_f64m1(1.9875691500E-4,gvl);
+vfloat64m1_t   cephes_exp_p1 = vfmv_v_f_f64m1(1.3981999507E-3,gvl);
+vfloat64m1_t   cephes_exp_p2 = vfmv_v_f_f64m1(8.3334519073E-3,gvl);
+vfloat64m1_t   cephes_exp_p3 = vfmv_v_f_f64m1(4.1665795894E-2,gvl);
+vfloat64m1_t   cephes_exp_p4 = vfmv_v_f_f64m1(1.6666665459E-1,gvl);
+vfloat64m1_t   cephes_exp_p5 = vfmv_v_f_f64m1(5.0000001201E-1,gvl);
+vfloat64m1_t   tmp;
+vfloat64m1_t   tmp2;
+vfloat64m1_t   tmp4;
+vfloat64m1_t   fx;
+
+vfloat64m1_t   one = vfmv_v_f_f64m1(1.0,gvl);
+vfloat64m1_t   zero = vfmv_v_f_f64m1(0.0,gvl);
+vfloat64m1_t   z;
+vfloat64m1_t   y;
+
+vbool64_t  mask;
+vint64m1_t  imm0;
+vint64m1_t  tmp3;
+
+        x     = vfmin_vv_f64m1(x, exp_hi,gvl);
+        x     = vfmax_vv_f64m1(x, exp_lo,gvl);
+
+        fx    = vfmv_v_f_f64m1(0.5,gvl);
+        fx    = vfmacc_vv_f64m1(fx,x,cephes_LOG2EF,gvl);
+
+        tmp3  = vfcvt_x_f_v_i64m1(fx,gvl);
+        tmp   = vfcvt_f_x_v_f64m1(tmp3,gvl);
+
+        mask  = vmflt_vv_f64m1_b64(fx,tmp,gvl);
+        tmp2  = vmerge_vvm_f64m1(mask,zero,one, gvl);
+        fx    = vfsub_vv_f64m1(tmp,tmp2,gvl);
+        tmp   = vfmul_vv_f64m1(fx, cephes_exp_C1,gvl);
+        z     = vfmul_vv_f64m1(fx, cephes_exp_C2,gvl);
+        x     = vfsub_vv_f64m1(x,tmp,gvl);
+        x     = vfsub_vv_f64m1(x,z,gvl);
+
+        z     = vfmul_vv_f64m1(x,x,gvl);
+
+        y     = cephes_exp_p0;
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p1,gvl);
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p2,gvl);
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p3,gvl);
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p4,gvl);
+        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p5,gvl);
+        y     = vfmadd_vv_f64m1(y,z,x,gvl);
+        y     = vfadd_vv_f64m1(y, one,gvl);
+
+        imm0  = vfcvt_x_f_v_i64m1(fx,gvl);
+        imm0  = vadd_vv_i64m1(imm0, vmv_v_x_i64m1(1023,gvl),gvl);
+        imm0  = vsll_vv_i64m1(imm0, vmv_v_x_u64m1(52,gvl),gvl);
+
+        tmp4  = vreinterpret_v_i64m1_f64m1(imm0);
+        y     = vfmul_vv_f64m1(y, tmp4,gvl);
+        return y;
+}
+
+inline vfloat32m1_t __exp_2xf32(vfloat32m1_t x , size_t gvl) {
+
+vfloat32m1_t   exp_hi        = vfmv_v_f_f32m1(88.3762626647949,gvl);
+vfloat32m1_t   exp_lo        = vfmv_v_f_f32m1(-88.3762626647949,gvl);
+
+vfloat32m1_t   cephes_LOG2EF = vfmv_v_f_f32m1(1.44269504088896341,gvl);
+vfloat32m1_t   cephes_exp_C1 = vfmv_v_f_f32m1(0.693359375,gvl);
+vfloat32m1_t   cephes_exp_C2 = vfmv_v_f_f32m1(-2.12194440e-4,gvl);
+
+vfloat32m1_t   cephes_exp_p0 = vfmv_v_f_f32m1(1.9875691500E-4,gvl);
+vfloat32m1_t   cephes_exp_p1 = vfmv_v_f_f32m1(1.3981999507E-3,gvl);
+vfloat32m1_t   cephes_exp_p2 = vfmv_v_f_f32m1(8.3334519073E-3,gvl);
+vfloat32m1_t   cephes_exp_p3 = vfmv_v_f_f32m1(4.1665795894E-2,gvl);
+vfloat32m1_t   cephes_exp_p4 = vfmv_v_f_f32m1(1.6666665459E-1,gvl);
+vfloat32m1_t   cephes_exp_p5 = vfmv_v_f_f32m1(5.0000001201E-1,gvl);
+vfloat32m1_t   tmp;
+vfloat32m1_t   tmp2;
+vfloat32m1_t   tmp4;
+vfloat32m1_t   fx;
+
+vfloat32m1_t   one = vfmv_v_f_f32m1(1.0,gvl);
+vfloat32m1_t   zero = vfmv_v_f_f32m1(0.0,gvl);
+vfloat32m1_t   z;
+vfloat32m1_t   y;
+
+vbool32_t  mask;
+vint32m1_t  imm0;
+vint32m1_t  tmp3;
+
+        x     = vfmin_vv_f32m1(x, exp_hi,gvl);
+        x     = vfmax_vv_f32m1(x, exp_lo,gvl);
+
+        fx    = vfmv_v_f_f32m1(0.5,gvl);
+        fx    = vfmacc_vv_f32m1(fx,x,cephes_LOG2EF,gvl);
+
+        tmp3  = vfcvt_x_f_v_i32m1(fx,gvl);
+        tmp   = vfcvt_f_x_v_f32m1(tmp3,gvl);
+
+        mask  = vmflt_vv_f32m1_b32(fx,tmp,gvl);
+        tmp2  = vmerge_vvm_f32m1(mask,zero,one, gvl);
+        fx    = vfsub_vv_f32m1(tmp,tmp2,gvl);
+        tmp   = vfmul_vv_f32m1(fx, cephes_exp_C1,gvl);
+        z     = vfmul_vv_f32m1(fx, cephes_exp_C2,gvl);
+        x     = vfsub_vv_f32m1(x,tmp,gvl);
+        x     = vfsub_vv_f32m1(x,z,gvl);
+
+        z     = vfmul_vv_f32m1(x,x,gvl);
+
+        y     = cephes_exp_p0;
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p1,gvl);
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p2,gvl);
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p3,gvl);
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p4,gvl);
+        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p5,gvl);
+        y     = vfmadd_vv_f32m1(y,z,x,gvl);
+        y     = vfadd_vv_f32m1(y,one,gvl);
+
+        imm0  = vfcvt_x_f_v_i32m1(fx,gvl);
+        imm0  = vadd_vv_i32m1(imm0, vmv_v_x_i32m1(0x7f,gvl),gvl);
+        imm0  = vsll_vv_i32m1(imm0, vmv_v_x_u32m1(23,gvl),gvl);
+
+        tmp4  = vreinterpret_v_i32m1_f32m1(imm0);
+        y     = vfmul_vv_f32m1(y, tmp4, gvl);
+        return y;
+}
+
+int main() {
+  printf("\n");
+  printf("==========\n");
+  printf("=  FEXP  =\n");
+  printf("==========\n");
+  printf("\n");
+  printf("\n");
+
+  int error = 0;
+  int64_t runtime;
+
+  printf("Executing exponential on %d 64-bit data...\n", N_f64);
+
+  start_timer();
+  exp_1xf64_bmark(exponents_f64, results_f64, N_f64);
+  stop_timer();
+
+  runtime = get_timer();
+  printf("The execution took %d cycles.\n", runtime);
+
+  printf("Executing exponential on %d 32-bit data...\n", N_f32);
+  start_timer();
+  exp_2xf32_bmark(exponents_f32, results_f32, N_f32);
+  stop_timer();
+
+  runtime = get_timer();
+  printf("The execution took %d cycles.\n", runtime);
+
+#ifdef CHECK
+  printf("Checking results:\n");
+
+  for (uint64_t i = 0; i < N_f64; ++i) {
+    if (!similarity_check(results_f64[i], gold_results_f64[i], THRESHOLD)) {
+      error = 1;
+      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i], gold_results_f64[i]);
+    }
+  }
+  for (uint64_t i = 0; i < N_f32; ++i) {
+    if (!similarity_check(results_f32[i], gold_results_f32[i], THRESHOLD)) {
+      error = 1;
+      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i], gold_results_f32[i]);
+    }
+  }
+#endif
+
+  return error;
+}

--- a/apps/exp/main.c
+++ b/apps/exp/main.c
@@ -20,9 +20,14 @@
 #include <string.h>
 
 #include "kernel/exp.h"
-#include "util.h"
-#include "printf.h"
 #include "runtime.h"
+#include "util.h"
+
+#ifndef SPIKE
+#include "printf.h"
+#else
+#include <stdio.h>
+#endif
 
 extern size_t N_f64;
 extern double exponents_f64[] __attribute__((aligned(4 * NR_LANES)));
@@ -72,15 +77,19 @@ int main() {
   for (uint64_t i = 0; i < N_f64; ++i) {
     if (!similarity_check(results_f64[i], gold_results_f64[i], THRESHOLD)) {
       error = 1;
-      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i], gold_results_f64[i]);
+      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i],
+             gold_results_f64[i]);
     }
   }
   for (uint64_t i = 0; i < N_f32; ++i) {
     if (!similarity_check(results_f32[i], gold_results_f32[i], THRESHOLD)) {
       error = 1;
-      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i], gold_results_f32[i]);
+      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i],
+             gold_results_f32[i]);
     }
   }
+  if (!error)
+    printf("Test result: PASS. No errors found.\n");
 #endif
 
   return error;

--- a/apps/exp/main.c
+++ b/apps/exp/main.c
@@ -1,250 +1,42 @@
-// Modified version of:
-// "RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
-// Find details on the original version below
-// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
-
+// Copyright 2022 ETH Zurich and University of Bologna.
 //
-// RISC-V VECTOR EXP FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
-// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
-
-/*
-   AVX implementation of sin, cos, sincos, exp and log
-   Based on "sse_mathfun.h", by Julien Pommier
-   http://gruntthepeon.free.fr/ssemath/
-   Copyright (C) 2012 Giovanni Garberoglio
-   Interdisciplinary Laboratory for Computational Science (LISC)
-   Fondazione Bruno Kessler and University of Trento
-   via Sommarive, 18
-   I-38123 Trento (Italy)
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
-  (this is the zlib license)
-*/
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Matteo Perotti
 
 #include <stdint.h>
 #include <string.h>
 
-#include <riscv_vector.h>
+#include "kernel/exp.h"
+#include "util.h"
 #include "printf.h"
 #include "runtime.h"
 
 extern size_t N_f64;
-
 extern double exponents_f64[] __attribute__((aligned(4 * NR_LANES)));
 extern double results_f64[] __attribute__((aligned(4 * NR_LANES)));
 extern double gold_results_f64[] __attribute__((aligned(4 * NR_LANES)));
 
 extern size_t N_f32;
-
 extern float exponents_f32[] __attribute__((aligned(4 * NR_LANES)));
 extern float results_f32[] __attribute__((aligned(4 * NR_LANES)));
 extern float gold_results_f32[] __attribute__((aligned(4 * NR_LANES)));
 
 #define THRESHOLD 1
-#define FABS(x) ((x < 0) ? -x : x)
 
 #define CHECK
-
-inline vfloat64m1_t __exp_1xf64(vfloat64m1_t x, size_t gvl);
-inline vfloat32m1_t __exp_2xf32(vfloat32m1_t x, size_t gvl);
-void exp_1xf64_bmark(double* exponents, double* results, size_t len);
-void exp_2xf32_bmark(float* exponents, float* results, size_t len);
-int similarity_check(double a, double b, double threshold);
-
-int similarity_check(double a, double b, double threshold) {
-  double diff = a - b;
-  if (FABS(diff) > threshold)
-    return 0;
-  else
-    return 1;
-}
-
-void exp_1xf64_bmark(double* exponents, double* results, size_t len) {
-
-  size_t avl = len;
-  vfloat64m1_t exp_vec, res_vec;
-
-  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
-    // Strip-mine
-    vl = vsetvl_e64m1(avl);
-    // Load vector
-    exp_vec = vle64_v_f64m1(exponents, vl);
-    // Compute
-    res_vec = __exp_1xf64(exp_vec, vl);
-    // Store
-    vse64_v_f64m1(results, res_vec, vl);
-    // Bump pointers
-    exponents += vl;
-    results   += vl;
-  }
-}
-
-void exp_2xf32_bmark(float* exponents, float* results, size_t len) {
-
-  size_t avl = len;
-  vfloat32m1_t exp_vec, res_vec;
-
-  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
-    // Strip-mine
-    vl = vsetvl_e32m1(avl);
-    // Load vector
-    exp_vec = vle32_v_f32m1(exponents, vl);
-    // Compute
-    res_vec = __exp_2xf32(exp_vec, vl);
-    // Store
-    vse32_v_f32m1(results, res_vec, vl);
-    // Bump pointers
-    exponents += vl;
-    results   += vl;
-  }
-}
-
-// Cannot use LMUL > 1 with this implmentation
-// Hard to hardcode assembly registers in this function
-// since the caller should know to spill to/from memory
-// the correct ones.
-inline vfloat64m1_t __exp_1xf64(vfloat64m1_t x, size_t gvl) {
-
-vfloat64m1_t   exp_hi        = vfmv_v_f_f64m1(88.3762626647949,gvl);
-vfloat64m1_t   exp_lo        = vfmv_v_f_f64m1(-88.3762626647949,gvl);
-
-vfloat64m1_t   cephes_LOG2EF = vfmv_v_f_f64m1(1.44269504088896341,gvl);
-vfloat64m1_t   cephes_exp_C1 = vfmv_v_f_f64m1(0.693359375,gvl);
-vfloat64m1_t   cephes_exp_C2 = vfmv_v_f_f64m1(-2.12194440e-4,gvl);
-
-vfloat64m1_t   cephes_exp_p0 = vfmv_v_f_f64m1(1.9875691500E-4,gvl);
-vfloat64m1_t   cephes_exp_p1 = vfmv_v_f_f64m1(1.3981999507E-3,gvl);
-vfloat64m1_t   cephes_exp_p2 = vfmv_v_f_f64m1(8.3334519073E-3,gvl);
-vfloat64m1_t   cephes_exp_p3 = vfmv_v_f_f64m1(4.1665795894E-2,gvl);
-vfloat64m1_t   cephes_exp_p4 = vfmv_v_f_f64m1(1.6666665459E-1,gvl);
-vfloat64m1_t   cephes_exp_p5 = vfmv_v_f_f64m1(5.0000001201E-1,gvl);
-vfloat64m1_t   tmp;
-vfloat64m1_t   tmp2;
-vfloat64m1_t   tmp4;
-vfloat64m1_t   fx;
-
-vfloat64m1_t   one = vfmv_v_f_f64m1(1.0,gvl);
-vfloat64m1_t   zero = vfmv_v_f_f64m1(0.0,gvl);
-vfloat64m1_t   z;
-vfloat64m1_t   y;
-
-vbool64_t  mask;
-vint64m1_t  imm0;
-vint64m1_t  tmp3;
-
-        x     = vfmin_vv_f64m1(x, exp_hi,gvl);
-        x     = vfmax_vv_f64m1(x, exp_lo,gvl);
-
-        fx    = vfmv_v_f_f64m1(0.5,gvl);
-        fx    = vfmacc_vv_f64m1(fx,x,cephes_LOG2EF,gvl);
-
-        tmp3  = vfcvt_x_f_v_i64m1(fx,gvl);
-        tmp   = vfcvt_f_x_v_f64m1(tmp3,gvl);
-
-        mask  = vmflt_vv_f64m1_b64(fx,tmp,gvl);
-        tmp2  = vmerge_vvm_f64m1(mask,zero,one, gvl);
-        fx    = vfsub_vv_f64m1(tmp,tmp2,gvl);
-        tmp   = vfmul_vv_f64m1(fx, cephes_exp_C1,gvl);
-        z     = vfmul_vv_f64m1(fx, cephes_exp_C2,gvl);
-        x     = vfsub_vv_f64m1(x,tmp,gvl);
-        x     = vfsub_vv_f64m1(x,z,gvl);
-
-        z     = vfmul_vv_f64m1(x,x,gvl);
-
-        y     = cephes_exp_p0;
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p1,gvl);
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p2,gvl);
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p3,gvl);
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p4,gvl);
-        y     = vfmadd_vv_f64m1(y,x,cephes_exp_p5,gvl);
-        y     = vfmadd_vv_f64m1(y,z,x,gvl);
-        y     = vfadd_vv_f64m1(y, one,gvl);
-
-        imm0  = vfcvt_x_f_v_i64m1(fx,gvl);
-        imm0  = vadd_vv_i64m1(imm0, vmv_v_x_i64m1(1023,gvl),gvl);
-        imm0  = vsll_vv_i64m1(imm0, vmv_v_x_u64m1(52,gvl),gvl);
-
-        tmp4  = vreinterpret_v_i64m1_f64m1(imm0);
-        y     = vfmul_vv_f64m1(y, tmp4,gvl);
-        return y;
-}
-
-inline vfloat32m1_t __exp_2xf32(vfloat32m1_t x , size_t gvl) {
-
-vfloat32m1_t   exp_hi        = vfmv_v_f_f32m1(88.3762626647949,gvl);
-vfloat32m1_t   exp_lo        = vfmv_v_f_f32m1(-88.3762626647949,gvl);
-
-vfloat32m1_t   cephes_LOG2EF = vfmv_v_f_f32m1(1.44269504088896341,gvl);
-vfloat32m1_t   cephes_exp_C1 = vfmv_v_f_f32m1(0.693359375,gvl);
-vfloat32m1_t   cephes_exp_C2 = vfmv_v_f_f32m1(-2.12194440e-4,gvl);
-
-vfloat32m1_t   cephes_exp_p0 = vfmv_v_f_f32m1(1.9875691500E-4,gvl);
-vfloat32m1_t   cephes_exp_p1 = vfmv_v_f_f32m1(1.3981999507E-3,gvl);
-vfloat32m1_t   cephes_exp_p2 = vfmv_v_f_f32m1(8.3334519073E-3,gvl);
-vfloat32m1_t   cephes_exp_p3 = vfmv_v_f_f32m1(4.1665795894E-2,gvl);
-vfloat32m1_t   cephes_exp_p4 = vfmv_v_f_f32m1(1.6666665459E-1,gvl);
-vfloat32m1_t   cephes_exp_p5 = vfmv_v_f_f32m1(5.0000001201E-1,gvl);
-vfloat32m1_t   tmp;
-vfloat32m1_t   tmp2;
-vfloat32m1_t   tmp4;
-vfloat32m1_t   fx;
-
-vfloat32m1_t   one = vfmv_v_f_f32m1(1.0,gvl);
-vfloat32m1_t   zero = vfmv_v_f_f32m1(0.0,gvl);
-vfloat32m1_t   z;
-vfloat32m1_t   y;
-
-vbool32_t  mask;
-vint32m1_t  imm0;
-vint32m1_t  tmp3;
-
-        x     = vfmin_vv_f32m1(x, exp_hi,gvl);
-        x     = vfmax_vv_f32m1(x, exp_lo,gvl);
-
-        fx    = vfmv_v_f_f32m1(0.5,gvl);
-        fx    = vfmacc_vv_f32m1(fx,x,cephes_LOG2EF,gvl);
-
-        tmp3  = vfcvt_x_f_v_i32m1(fx,gvl);
-        tmp   = vfcvt_f_x_v_f32m1(tmp3,gvl);
-
-        mask  = vmflt_vv_f32m1_b32(fx,tmp,gvl);
-        tmp2  = vmerge_vvm_f32m1(mask,zero,one, gvl);
-        fx    = vfsub_vv_f32m1(tmp,tmp2,gvl);
-        tmp   = vfmul_vv_f32m1(fx, cephes_exp_C1,gvl);
-        z     = vfmul_vv_f32m1(fx, cephes_exp_C2,gvl);
-        x     = vfsub_vv_f32m1(x,tmp,gvl);
-        x     = vfsub_vv_f32m1(x,z,gvl);
-
-        z     = vfmul_vv_f32m1(x,x,gvl);
-
-        y     = cephes_exp_p0;
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p1,gvl);
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p2,gvl);
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p3,gvl);
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p4,gvl);
-        y     = vfmadd_vv_f32m1(y,x,cephes_exp_p5,gvl);
-        y     = vfmadd_vv_f32m1(y,z,x,gvl);
-        y     = vfadd_vv_f32m1(y,one,gvl);
-
-        imm0  = vfcvt_x_f_v_i32m1(fx,gvl);
-        imm0  = vadd_vv_i32m1(imm0, vmv_v_x_i32m1(0x7f,gvl),gvl);
-        imm0  = vsll_vv_i32m1(imm0, vmv_v_x_u32m1(23,gvl),gvl);
-
-        tmp4  = vreinterpret_v_i32m1_f32m1(imm0);
-        y     = vfmul_vv_f32m1(y, tmp4, gvl);
-        return y;
-}
 
 int main() {
   printf("\n");

--- a/apps/exp/script/gen_data.py
+++ b/apps/exp/script/gen_data.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2021 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# arg1: vector size, arg2: filter size
+
+import random as rand
+import numpy as np
+import sys
+
+def emit(name, array, alignment='8'):
+  print(".global %s" % name)
+  print(".balign " + alignment)
+  print("%s:" % name)
+  bs = array.tobytes()
+  for i in range(0, len(bs), 4):
+    s = ""
+    for n in range(4):
+      s += "%02x" % bs[i+3-n]
+    print("    .word 0x%s" % s)
+
+def rand_matrix(N, dtype):
+  return np.random.rand(N).astype(dtype) * 3.141
+
+############
+## SCRIPT ##
+############
+
+if len(sys.argv) == 2:
+  N_f64 = int(sys.argv[1])
+  N_f32 = 2 * N_f64
+else:
+  print("Error. Give me one argument: the number of vector elements.")
+  sys.exit()
+
+# Vector of samples
+exponents_f64 = rand_matrix(N_f64, np.float64).astype(np.float64)
+exponents_f32 = rand_matrix(N_f32, np.float32).astype(np.float32)
+
+# Results buffer
+results_f64 = np.zeros(N_f64, dtype=np.float64)
+results_f32 = np.zeros(N_f32, dtype=np.float32)
+
+# Gold results
+gold_results_f64 = np.exp(exponents_f64, dtype=np.float64)
+gold_results_f32 = np.exp(exponents_f32, dtype=np.float32)
+
+# Create the file
+print(".section .data,\"aw\",@progbits")
+emit("N_f64", np.array(N_f64, dtype=np.uint64))
+emit("exponents_f64", exponents_f64, 'NR_LANES*4')
+emit("results_f64", results_f64, 'NR_LANES*4')
+emit("gold_results_f64", gold_results_f64, 'NR_LANES*4')
+emit("N_f32", np.array(N_f32, dtype=np.uint32))
+emit("exponents_f32", exponents_f32, 'NR_LANES*4')
+emit("results_f32", results_f32, 'NR_LANES*4')
+emit("gold_results_f32", gold_results_f32, 'NR_LANES*4')

--- a/apps/ideal_dispatcher/scripts/dump_vtrace.py
+++ b/apps/ideal_dispatcher/scripts/dump_vtrace.py
@@ -123,11 +123,11 @@ def updateRf(regline, reg_width, rf):
 def addRs2(disasm, args):
   rs2 = ''
   if (disasm == 'vsetvl'):
-    #rs2 =
-    print('ERROR: vsetvl found, implement addRs2 function!')
-  if ('vlse' in disasm or 'vsse' in disasm):
-    #rs2 =
     print('ERROR: vlse or vsse found, implement addRs2 function!')
+  if ('vlse' in disasm or 'vsse' in disasm):
+    for reg in xrf:
+      if (reg == args[-1]):
+        rs2 = "{}".format(xrf[reg])
   return rs2
 
 # If an instruction needs a register value, fetch it from the next XRF/FRF state
@@ -150,7 +150,13 @@ with open(infile, "r") as fin, open(outfile, "w") as fout:
       for row in range(RegRows):
         regline = fin.readline()
         frf = updateRf(regline, RegWidth, frf)
-      # Fetch the values to be forwarded to Ara
+      # Check for Rs2 and delete its entry if present
+      rs2 = addRs2(insn['name'], insn['regs'])
+      if rs2 != '':
+        del insn['regs'][-1]
+      else:
+        rs2 = '0000000000000000'
+      # Fetch the rs1 value to be forwarded to Ara
       for reg in xrf:
         if (reg in insn['regs']):
           insn['vals'] = "{}".format(xrf[reg])
@@ -158,4 +164,4 @@ with open(infile, "r") as fin, open(outfile, "w") as fout:
         if (reg in insn['regs']):
           insn['vals'] = "{}".format(frf[reg])
     insn_out = ''
-    fout.write(insn_out.join([insn['asm'], insn['vals'], addRs2(insn['name'], insn['regs'])]) + '\n')
+    fout.write(insn_out.join([insn['asm'], insn['vals'], rs2]) + '\n')

--- a/apps/log/LICENSE
+++ b/apps/log/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2020, Barcelona Supercomputing Center
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met: redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer;
+redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution;
+neither the name of the copyright holders nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+If you use this software or a modified version of it for your research, please cite the paper:
+Cristóbal Ramírez, César Hernandez, Oscar Palomar, Osman Unsal, Marco Ramírez, and Adrián Cristal. 2020. A RISC-V Simulator and Benchmark Suite for Designing and Evaluating Vector Architectures. ACM Trans. Archit. Code Optim. 17, 4, Article 38 (October 2020), 29 pages. https://doi.org/10.1145/3422667

--- a/apps/log/kernel/log.c
+++ b/apps/log/kernel/log.c
@@ -16,8 +16,9 @@
 //
 // Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 
-void log_1xf64_bmark(double* args, double* results, size_t len) {
 #include "log.h"
+
+void log_1xf64_bmark(double *args, double *results, size_t len) {
 
   size_t avl = len;
   vfloat64m1_t log_vec, res_vec;
@@ -33,11 +34,11 @@ void log_1xf64_bmark(double* args, double* results, size_t len) {
     vse64_v_f64m1(results, res_vec, vl);
     // Bump pointers
     args += vl;
-    results   += vl;
+    results += vl;
   }
 }
 
-void log_2xf32_bmark(float* args, float* results, size_t len) {
+void log_2xf32_bmark(float *args, float *results, size_t len) {
 
   size_t avl = len;
   vfloat32m1_t log_vec, res_vec;
@@ -53,6 +54,6 @@ void log_2xf32_bmark(float* args, float* results, size_t len) {
     vse32_v_f32m1(results, res_vec, vl);
     // Bump pointers
     args += vl;
-    results   += vl;
+    results += vl;
   }
 }

--- a/apps/log/kernel/log.c
+++ b/apps/log/kernel/log.c
@@ -1,0 +1,58 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+void log_1xf64_bmark(double* args, double* results, size_t len) {
+#include "log.h"
+
+  size_t avl = len;
+  vfloat64m1_t log_vec, res_vec;
+
+  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e64m1(avl);
+    // Load vector
+    log_vec = vle64_v_f64m1(args, vl);
+    // Compute
+    res_vec = __log_1xf64(log_vec, vl);
+    // Store
+    vse64_v_f64m1(results, res_vec, vl);
+    // Bump pointers
+    args += vl;
+    results   += vl;
+  }
+}
+
+void log_2xf32_bmark(float* args, float* results, size_t len) {
+
+  size_t avl = len;
+  vfloat32m1_t log_vec, res_vec;
+
+  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e32m1(avl);
+    // Load vector
+    log_vec = vle32_v_f32m1(args, vl);
+    // Compute
+    res_vec = __log_2xf32(log_vec, vl);
+    // Store
+    vse32_v_f32m1(results, res_vec, vl);
+    // Bump pointers
+    args += vl;
+    results   += vl;
+  }
+}

--- a/apps/log/kernel/log.h
+++ b/apps/log/kernel/log.h
@@ -1,10 +1,11 @@
 // Modified version of:
-// "RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
-// Find details on the original version below
-// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+// "RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona
+// 2019"" Find details on the original version below Author: Matteo Perotti
+// <mperotti@iis.ee.ethz.ch>
 
-// RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
-// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+// RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona
+// 2019" This RISC-V Vector implementation is based on the original code
+// presented by Julien Pommier
 
 /*
    AVX implementation of sin, cos, sincos, exp and log
@@ -36,104 +37,121 @@
 
 #include "rivec/vector_defines.h"
 
-void log_1xf64_bmark(double* args, double* results, size_t len);
-void log_2xf32_bmark(float* args, float* results, size_t len);
+void log_1xf64_bmark(double *args, double *results, size_t len);
+void log_2xf32_bmark(float *args, float *results, size_t len);
 
-inline _MMR_f64 __log_1xf64(_MMR_f64 x , unsigned long int gvl) {
+inline _MMR_f64 __log_1xf64(_MMR_f64 x, unsigned long int gvl) {
 
-_MMR_i64   _x_i;
-_MMR_u64   imm0_u;
-_MMR_i64   imm0;
-_MMR_f64  e;
-_MMR_MASK_i64 invalid_mask = _MM_VFLE_f64(x,_MM_SET_f64(0.0f,gvl),gvl);
+  _MMR_i64 _x_i;
+  _MMR_u64 imm0_u;
+  _MMR_i64 imm0;
+  _MMR_f64 e;
+  _MMR_MASK_i64 invalid_mask = _MM_VFLE_f64(x, _MM_SET_f64(0.0f, gvl), gvl);
 
-  x = _MM_MAX_f64(x, _MM_CAST_f64_i64(_MM_SET_i64(0x0010000000000000,gvl)), gvl);  /* cut off denormalized stuff */
-  imm0_u = _MM_SRL_i64(_MM_CAST_u64_f64(x), _MM_CAST_u64_i64(_MM_SET_i64(52,gvl)), gvl);
+  x = _MM_MAX_f64(x, _MM_CAST_f64_i64(_MM_SET_i64(0x0010000000000000, gvl)),
+                  gvl); /* cut off denormalized stuff */
+  imm0_u = _MM_SRL_i64(_MM_CAST_u64_f64(x),
+                       _MM_CAST_u64_i64(_MM_SET_i64(52, gvl)), gvl);
   imm0 = _MM_CAST_i64_u64(imm0_u);
   /* keep only the fractional part */
-  _x_i = _MM_AND_i64(_MM_CAST_i64_f64(x), _MM_SET_i64(~0x7ff0000000000000,gvl), gvl);
-  _x_i = _MM_OR_i64(_x_i, _MM_CAST_i64_f64(_MM_SET_f64(0.5f,gvl)), gvl);
-  x= _MM_CAST_f64_i64(_x_i);
-  imm0 = _MM_SUB_i64(imm0 ,_MM_SET_i64(1023,gvl) , gvl);
-  e = _MM_VFCVT_F_X_f64(imm0,gvl);
-  e = _MM_ADD_f64(e, _MM_SET_f64(1.0f,gvl) ,gvl);
+  _x_i = _MM_AND_i64(_MM_CAST_i64_f64(x), _MM_SET_i64(~0x7ff0000000000000, gvl),
+                     gvl);
+  _x_i = _MM_OR_i64(_x_i, _MM_CAST_i64_f64(_MM_SET_f64(0.5f, gvl)), gvl);
+  x = _MM_CAST_f64_i64(_x_i);
+  imm0 = _MM_SUB_i64(imm0, _MM_SET_i64(1023, gvl), gvl);
+  e = _MM_VFCVT_F_X_f64(imm0, gvl);
+  e = _MM_ADD_f64(e, _MM_SET_f64(1.0f, gvl), gvl);
 
-_MMR_MASK_i64 mask = _MM_VFLT_f64(x, _MM_SET_f64(0.707106781186547524,gvl) , gvl);
-_MMR_f64 tmp  = _MM_MERGE_f64(_MM_SET_f64(0.0f,gvl),x, mask,gvl);
+  _MMR_MASK_i64 mask =
+      _MM_VFLT_f64(x, _MM_SET_f64(0.707106781186547524, gvl), gvl);
+  _MMR_f64 tmp = _MM_MERGE_f64(_MM_SET_f64(0.0f, gvl), x, mask, gvl);
 
-  x = _MM_SUB_f64(x, _MM_SET_f64(1.0f,gvl),gvl);
-  e = _MM_SUB_f64(e, _MM_MERGE_f64(_MM_SET_f64(0.0f,gvl),_MM_SET_f64(1.0f,gvl), mask,gvl),gvl);
-  x = _MM_ADD_f64(x, tmp,gvl);
+  x = _MM_SUB_f64(x, _MM_SET_f64(1.0f, gvl), gvl);
+  e = _MM_SUB_f64(
+      e,
+      _MM_MERGE_f64(_MM_SET_f64(0.0f, gvl), _MM_SET_f64(1.0f, gvl), mask, gvl),
+      gvl);
+  x = _MM_ADD_f64(x, tmp, gvl);
 
-_MMR_f64 z = _MM_MUL_f64(x,x,gvl);
-_MMR_f64 y;
+  _MMR_f64 z = _MM_MUL_f64(x, x, gvl);
+  _MMR_f64 y;
 
-  y = _MM_MADD_f64(_MM_SET_f64(7.0376836292E-2,gvl),x,_MM_SET_f64(-1.1514610310E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(1.1676998740E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(-1.2420140846E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(1.4249322787E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(-1.6668057665E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(2.0000714765E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(-2.4999993993E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(3.3333331174E-1,gvl),gvl);
-  y = _MM_MUL_f64(y, z,gvl);
-  y = _MM_MACC_f64(y,e,_MM_SET_f64(-2.12194440e-4,gvl),gvl);
-  tmp = _MM_MUL_f64(z, _MM_SET_f64(0.5f,gvl),gvl);
-  y = _MM_SUB_f64(y, tmp,gvl);
-  tmp = _MM_MUL_f64(e, _MM_SET_f64(0.693359375,gvl),gvl);
-  x = _MM_ADD_f64(x, y,gvl);
-  x = _MM_ADD_f64(x, tmp,gvl);
-  x = _MM_MERGE_f64(x,_MM_CAST_f64_i64(_MM_SET_i64(0xffffffffffffffff,gvl)), invalid_mask,gvl);
+  y = _MM_MADD_f64(_MM_SET_f64(7.0376836292E-2, gvl), x,
+                   _MM_SET_f64(-1.1514610310E-1, gvl), gvl);
+  y = _MM_MADD_f64(y, x, _MM_SET_f64(1.1676998740E-1, gvl), gvl);
+  y = _MM_MADD_f64(y, x, _MM_SET_f64(-1.2420140846E-1, gvl), gvl);
+  y = _MM_MADD_f64(y, x, _MM_SET_f64(1.4249322787E-1, gvl), gvl);
+  y = _MM_MADD_f64(y, x, _MM_SET_f64(-1.6668057665E-1, gvl), gvl);
+  y = _MM_MADD_f64(y, x, _MM_SET_f64(2.0000714765E-1, gvl), gvl);
+  y = _MM_MADD_f64(y, x, _MM_SET_f64(-2.4999993993E-1, gvl), gvl);
+  y = _MM_MADD_f64(y, x, _MM_SET_f64(3.3333331174E-1, gvl), gvl);
+  y = _MM_MUL_f64(y, z, gvl);
+  y = _MM_MACC_f64(y, e, _MM_SET_f64(-2.12194440e-4, gvl), gvl);
+  tmp = _MM_MUL_f64(z, _MM_SET_f64(0.5f, gvl), gvl);
+  y = _MM_SUB_f64(y, tmp, gvl);
+  tmp = _MM_MUL_f64(e, _MM_SET_f64(0.693359375, gvl), gvl);
+  x = _MM_ADD_f64(x, y, gvl);
+  x = _MM_ADD_f64(x, tmp, gvl);
+  x = _MM_MERGE_f64(x, _MM_CAST_f64_i64(_MM_SET_i64(0xffffffffffffffff, gvl)),
+                    invalid_mask, gvl);
 
   return x;
 }
 
-inline _MMR_f32 __log_2xf32(_MMR_f32 x , unsigned long int gvl) {
+inline _MMR_f32 __log_2xf32(_MMR_f32 x, unsigned long int gvl) {
 
-_MMR_i32   _x_i;
-_MMR_u32   imm0_u;
-_MMR_i32   imm0;
-_MMR_f32  e;
+  _MMR_i32 _x_i;
+  _MMR_u32 imm0_u;
+  _MMR_i32 imm0;
+  _MMR_f32 e;
 
-_MMR_MASK_i32 invalid_mask = _MM_VFLE_f32(x,_MM_SET_f32(0.0f,gvl),gvl);
+  _MMR_MASK_i32 invalid_mask = _MM_VFLE_f32(x, _MM_SET_f32(0.0f, gvl), gvl);
 
-  x = _MM_MAX_f32(x, _MM_CAST_f32_i32(_MM_SET_i32(0x00800000,gvl)), gvl);  /* cut off denormalized stuff */
-  imm0_u = _MM_SRL_i32(_MM_CAST_u32_f32(x), _MM_CAST_u32_i32(_MM_SET_i32(23,gvl)), gvl);
+  x = _MM_MAX_f32(x, _MM_CAST_f32_i32(_MM_SET_i32(0x00800000, gvl)),
+                  gvl); /* cut off denormalized stuff */
+  imm0_u = _MM_SRL_i32(_MM_CAST_u32_f32(x),
+                       _MM_CAST_u32_i32(_MM_SET_i32(23, gvl)), gvl);
   imm0 = _MM_CAST_i32_u32(imm0_u);
   /* keep only the fractional part */
-  _x_i = _MM_AND_i32(_MM_CAST_i32_f32(x), _MM_SET_i32(~0x7f800000,gvl), gvl);
-  _x_i = _MM_OR_i32(_x_i, _MM_CAST_i32_f32(_MM_SET_f32(0.5f,gvl)), gvl);
-  x= _MM_CAST_f32_i32(_x_i);
-  imm0 = _MM_SUB_i32(imm0 ,_MM_SET_i32(0x7f,gvl) , gvl);
-  e = _MM_VFCVT_F_X_f32(imm0,gvl);
-  e = _MM_ADD_f32(e, _MM_SET_f32(1.0f,gvl) ,gvl);
+  _x_i = _MM_AND_i32(_MM_CAST_i32_f32(x), _MM_SET_i32(~0x7f800000, gvl), gvl);
+  _x_i = _MM_OR_i32(_x_i, _MM_CAST_i32_f32(_MM_SET_f32(0.5f, gvl)), gvl);
+  x = _MM_CAST_f32_i32(_x_i);
+  imm0 = _MM_SUB_i32(imm0, _MM_SET_i32(0x7f, gvl), gvl);
+  e = _MM_VFCVT_F_X_f32(imm0, gvl);
+  e = _MM_ADD_f32(e, _MM_SET_f32(1.0f, gvl), gvl);
 
-_MMR_MASK_i32 mask = _MM_VFLT_f32(x, _MM_SET_f32(0.707106781186547524,gvl) , gvl);
-_MMR_f32 tmp  = _MM_MERGE_f32(_MM_SET_f32(0.0f,gvl),x, mask,gvl);
+  _MMR_MASK_i32 mask =
+      _MM_VFLT_f32(x, _MM_SET_f32(0.707106781186547524, gvl), gvl);
+  _MMR_f32 tmp = _MM_MERGE_f32(_MM_SET_f32(0.0f, gvl), x, mask, gvl);
 
-  x = _MM_SUB_f32(x, _MM_SET_f32(1.0f,gvl),gvl);
-  e = _MM_SUB_f32(e, _MM_MERGE_f32(_MM_SET_f32(0.0f,gvl),_MM_SET_f32(1.0f,gvl), mask,gvl),gvl);
-  x = _MM_ADD_f32(x, tmp,gvl);
+  x = _MM_SUB_f32(x, _MM_SET_f32(1.0f, gvl), gvl);
+  e = _MM_SUB_f32(
+      e,
+      _MM_MERGE_f32(_MM_SET_f32(0.0f, gvl), _MM_SET_f32(1.0f, gvl), mask, gvl),
+      gvl);
+  x = _MM_ADD_f32(x, tmp, gvl);
 
-_MMR_f32 z = _MM_MUL_f32(x,x,gvl);
-_MMR_f32 y;
+  _MMR_f32 z = _MM_MUL_f32(x, x, gvl);
+  _MMR_f32 y;
 
-  y = _MM_MADD_f32(_MM_SET_f32(7.0376836292E-2,gvl),x,_MM_SET_f32(-1.1514610310E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(1.1676998740E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(-1.2420140846E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(1.4249322787E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(-1.6668057665E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(2.0000714765E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(-2.4999993993E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(3.3333331174E-1,gvl),gvl);
-  y = _MM_MUL_f32(y, z,gvl);
-  y = _MM_MACC_f32(y,e,_MM_SET_f32(-2.12194440e-4,gvl),gvl);
-  tmp = _MM_MUL_f32(z, _MM_SET_f32(0.5f,gvl),gvl);
-  y = _MM_SUB_f32(y, tmp,gvl);
-  tmp = _MM_MUL_f32(e, _MM_SET_f32(0.693359375,gvl),gvl);
-  x = _MM_ADD_f32(x, y,gvl);
-  x = _MM_ADD_f32(x, tmp,gvl);
-  x = _MM_MERGE_f32(x,_MM_CAST_f32_i32(_MM_SET_i32(0xffffffff,gvl)), invalid_mask,gvl);
+  y = _MM_MADD_f32(_MM_SET_f32(7.0376836292E-2, gvl), x,
+                   _MM_SET_f32(-1.1514610310E-1, gvl), gvl);
+  y = _MM_MADD_f32(y, x, _MM_SET_f32(1.1676998740E-1, gvl), gvl);
+  y = _MM_MADD_f32(y, x, _MM_SET_f32(-1.2420140846E-1, gvl), gvl);
+  y = _MM_MADD_f32(y, x, _MM_SET_f32(1.4249322787E-1, gvl), gvl);
+  y = _MM_MADD_f32(y, x, _MM_SET_f32(-1.6668057665E-1, gvl), gvl);
+  y = _MM_MADD_f32(y, x, _MM_SET_f32(2.0000714765E-1, gvl), gvl);
+  y = _MM_MADD_f32(y, x, _MM_SET_f32(-2.4999993993E-1, gvl), gvl);
+  y = _MM_MADD_f32(y, x, _MM_SET_f32(3.3333331174E-1, gvl), gvl);
+  y = _MM_MUL_f32(y, z, gvl);
+  y = _MM_MACC_f32(y, e, _MM_SET_f32(-2.12194440e-4, gvl), gvl);
+  tmp = _MM_MUL_f32(z, _MM_SET_f32(0.5f, gvl), gvl);
+  y = _MM_SUB_f32(y, tmp, gvl);
+  tmp = _MM_MUL_f32(e, _MM_SET_f32(0.693359375, gvl), gvl);
+  x = _MM_ADD_f32(x, y, gvl);
+  x = _MM_ADD_f32(x, tmp, gvl);
+  x = _MM_MERGE_f32(x, _MM_CAST_f32_i32(_MM_SET_i32(0xffffffff, gvl)),
+                    invalid_mask, gvl);
 
   return x;
 }

--- a/apps/log/kernel/log.h
+++ b/apps/log/kernel/log.h
@@ -1,0 +1,139 @@
+// Modified version of:
+// "RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
+// Find details on the original version below
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+// RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
+// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+
+/*
+   AVX implementation of sin, cos, sincos, exp and log
+   Based on "sse_mathfun.h", by Julien Pommier
+   http://gruntthepeon.free.fr/ssemath/
+   Copyright (C) 2012 Giovanni Garberoglio
+   Interdisciplinary Laboratory for Computational Science (LISC)
+   Fondazione Bruno Kessler and University of Trento
+   via Sommarive, 18
+   I-38123 Trento (Italy)
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+  (this is the zlib license)
+*/
+
+#include <stdio.h>
+#include <string.h>
+
+#include "rivec/vector_defines.h"
+
+void log_1xf64_bmark(double* args, double* results, size_t len);
+void log_2xf32_bmark(float* args, float* results, size_t len);
+
+inline _MMR_f64 __log_1xf64(_MMR_f64 x , unsigned long int gvl) {
+
+_MMR_i64   _x_i;
+_MMR_u64   imm0_u;
+_MMR_i64   imm0;
+_MMR_f64  e;
+_MMR_MASK_i64 invalid_mask = _MM_VFLE_f64(x,_MM_SET_f64(0.0f,gvl),gvl);
+
+  x = _MM_MAX_f64(x, _MM_CAST_f64_i64(_MM_SET_i64(0x0010000000000000,gvl)), gvl);  /* cut off denormalized stuff */
+  imm0_u = _MM_SRL_i64(_MM_CAST_u64_f64(x), _MM_CAST_u64_i64(_MM_SET_i64(52,gvl)), gvl);
+  imm0 = _MM_CAST_i64_u64(imm0_u);
+  /* keep only the fractional part */
+  _x_i = _MM_AND_i64(_MM_CAST_i64_f64(x), _MM_SET_i64(~0x7ff0000000000000,gvl), gvl);
+  _x_i = _MM_OR_i64(_x_i, _MM_CAST_i64_f64(_MM_SET_f64(0.5f,gvl)), gvl);
+  x= _MM_CAST_f64_i64(_x_i);
+  imm0 = _MM_SUB_i64(imm0 ,_MM_SET_i64(1023,gvl) , gvl);
+  e = _MM_VFCVT_F_X_f64(imm0,gvl);
+  e = _MM_ADD_f64(e, _MM_SET_f64(1.0f,gvl) ,gvl);
+
+_MMR_MASK_i64 mask = _MM_VFLT_f64(x, _MM_SET_f64(0.707106781186547524,gvl) , gvl);
+_MMR_f64 tmp  = _MM_MERGE_f64(_MM_SET_f64(0.0f,gvl),x, mask,gvl);
+
+  x = _MM_SUB_f64(x, _MM_SET_f64(1.0f,gvl),gvl);
+  e = _MM_SUB_f64(e, _MM_MERGE_f64(_MM_SET_f64(0.0f,gvl),_MM_SET_f64(1.0f,gvl), mask,gvl),gvl);
+  x = _MM_ADD_f64(x, tmp,gvl);
+
+_MMR_f64 z = _MM_MUL_f64(x,x,gvl);
+_MMR_f64 y;
+
+  y = _MM_MADD_f64(_MM_SET_f64(7.0376836292E-2,gvl),x,_MM_SET_f64(-1.1514610310E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(1.1676998740E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(-1.2420140846E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(1.4249322787E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(-1.6668057665E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(2.0000714765E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(-2.4999993993E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(3.3333331174E-1,gvl),gvl);
+  y = _MM_MUL_f64(y, z,gvl);
+  y = _MM_MACC_f64(y,e,_MM_SET_f64(-2.12194440e-4,gvl),gvl);
+  tmp = _MM_MUL_f64(z, _MM_SET_f64(0.5f,gvl),gvl);
+  y = _MM_SUB_f64(y, tmp,gvl);
+  tmp = _MM_MUL_f64(e, _MM_SET_f64(0.693359375,gvl),gvl);
+  x = _MM_ADD_f64(x, y,gvl);
+  x = _MM_ADD_f64(x, tmp,gvl);
+  x = _MM_MERGE_f64(x,_MM_CAST_f64_i64(_MM_SET_i64(0xffffffffffffffff,gvl)), invalid_mask,gvl);
+
+  return x;
+}
+
+inline _MMR_f32 __log_2xf32(_MMR_f32 x , unsigned long int gvl) {
+
+_MMR_i32   _x_i;
+_MMR_u32   imm0_u;
+_MMR_i32   imm0;
+_MMR_f32  e;
+
+_MMR_MASK_i32 invalid_mask = _MM_VFLE_f32(x,_MM_SET_f32(0.0f,gvl),gvl);
+
+  x = _MM_MAX_f32(x, _MM_CAST_f32_i32(_MM_SET_i32(0x00800000,gvl)), gvl);  /* cut off denormalized stuff */
+  imm0_u = _MM_SRL_i32(_MM_CAST_u32_f32(x), _MM_CAST_u32_i32(_MM_SET_i32(23,gvl)), gvl);
+  imm0 = _MM_CAST_i32_u32(imm0_u);
+  /* keep only the fractional part */
+  _x_i = _MM_AND_i32(_MM_CAST_i32_f32(x), _MM_SET_i32(~0x7f800000,gvl), gvl);
+  _x_i = _MM_OR_i32(_x_i, _MM_CAST_i32_f32(_MM_SET_f32(0.5f,gvl)), gvl);
+  x= _MM_CAST_f32_i32(_x_i);
+  imm0 = _MM_SUB_i32(imm0 ,_MM_SET_i32(0x7f,gvl) , gvl);
+  e = _MM_VFCVT_F_X_f32(imm0,gvl);
+  e = _MM_ADD_f32(e, _MM_SET_f32(1.0f,gvl) ,gvl);
+
+_MMR_MASK_i32 mask = _MM_VFLT_f32(x, _MM_SET_f32(0.707106781186547524,gvl) , gvl);
+_MMR_f32 tmp  = _MM_MERGE_f32(_MM_SET_f32(0.0f,gvl),x, mask,gvl);
+
+  x = _MM_SUB_f32(x, _MM_SET_f32(1.0f,gvl),gvl);
+  e = _MM_SUB_f32(e, _MM_MERGE_f32(_MM_SET_f32(0.0f,gvl),_MM_SET_f32(1.0f,gvl), mask,gvl),gvl);
+  x = _MM_ADD_f32(x, tmp,gvl);
+
+_MMR_f32 z = _MM_MUL_f32(x,x,gvl);
+_MMR_f32 y;
+
+  y = _MM_MADD_f32(_MM_SET_f32(7.0376836292E-2,gvl),x,_MM_SET_f32(-1.1514610310E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(1.1676998740E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(-1.2420140846E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(1.4249322787E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(-1.6668057665E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(2.0000714765E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(-2.4999993993E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(3.3333331174E-1,gvl),gvl);
+  y = _MM_MUL_f32(y, z,gvl);
+  y = _MM_MACC_f32(y,e,_MM_SET_f32(-2.12194440e-4,gvl),gvl);
+  tmp = _MM_MUL_f32(z, _MM_SET_f32(0.5f,gvl),gvl);
+  y = _MM_SUB_f32(y, tmp,gvl);
+  tmp = _MM_MUL_f32(e, _MM_SET_f32(0.693359375,gvl),gvl);
+  x = _MM_ADD_f32(x, y,gvl);
+  x = _MM_ADD_f32(x, tmp,gvl);
+  x = _MM_MERGE_f32(x,_MM_CAST_f32_i32(_MM_SET_i32(0xffffffff,gvl)), invalid_mask,gvl);
+
+  return x;
+}

--- a/apps/log/main.c
+++ b/apps/log/main.c
@@ -1,0 +1,260 @@
+// Modified version of:
+// "RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
+// Find details on the original version below
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+
+// RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
+// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
+
+/*
+   AVX implementation of sin, cos, sincos, exp and log
+   Based on "sse_mathfun.h", by Julien Pommier
+   http://gruntthepeon.free.fr/ssemath/
+   Copyright (C) 2012 Giovanni Garberoglio
+   Interdisciplinary Laboratory for Computational Science (LISC)
+   Fondazione Bruno Kessler and University of Trento
+   via Sommarive, 18
+   I-38123 Trento (Italy)
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+  (this is the zlib license)
+*/
+
+#include <stdint.h>
+#include <string.h>
+
+#include "rivec/vector_defines.h"
+#include "printf.h"
+#include "runtime.h"
+
+extern size_t N_f64;
+
+extern double args_f64[] __attribute__((aligned(4 * NR_LANES)));
+extern double results_f64[] __attribute__((aligned(4 * NR_LANES)));
+extern double gold_results_f64[] __attribute__((aligned(4 * NR_LANES)));
+
+extern size_t N_f32;
+
+extern float args_f32[] __attribute__((aligned(4 * NR_LANES)));
+extern float results_f32[] __attribute__((aligned(4 * NR_LANES)));
+extern float gold_results_f32[] __attribute__((aligned(4 * NR_LANES)));
+
+#define THRESHOLD 1
+#define FABS(x) ((x < 0) ? -x : x)
+
+#define CHECK
+
+inline vfloat64m1_t __log_1xf64(vfloat64m1_t x, size_t gvl);
+inline vfloat32m1_t __log_2xf32(vfloat32m1_t x, size_t gvl);
+void log_1xf64_bmark(double* args, double* results, size_t len);
+void log_2xf32_bmark(float* args, float* results, size_t len);
+int similarity_check(double a, double b, double threshold);
+
+int similarity_check(double a, double b, double threshold) {
+  double diff = a - b;
+  if (FABS(diff) > threshold)
+    return 0;
+  else
+    return 1;
+}
+
+void log_1xf64_bmark(double* args, double* results, size_t len) {
+
+  size_t avl = len;
+  vfloat64m1_t log_vec, res_vec;
+
+  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e64m1(avl);
+    // Load vector
+    log_vec = vle64_v_f64m1(args, vl);
+    // Compute
+    res_vec = __log_1xf64(log_vec, vl);
+    // Store
+    vse64_v_f64m1(results, res_vec, vl);
+    // Bump pointers
+    args += vl;
+    results   += vl;
+  }
+}
+
+void log_2xf32_bmark(float* args, float* results, size_t len) {
+
+  size_t avl = len;
+  vfloat32m1_t log_vec, res_vec;
+
+  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
+    // Strip-mine
+    vl = vsetvl_e32m1(avl);
+    // Load vector
+    log_vec = vle32_v_f32m1(args, vl);
+    // Compute
+    res_vec = __log_2xf32(log_vec, vl);
+    // Store
+    vse32_v_f32m1(results, res_vec, vl);
+    // Bump pointers
+    args += vl;
+    results   += vl;
+  }
+}
+
+inline _MMR_f64 __log_1xf64(_MMR_f64 x , unsigned long int gvl) {
+
+_MMR_i64   _x_i;
+_MMR_u64   imm0_u;
+_MMR_i64   imm0;
+_MMR_f64  e;
+_MMR_MASK_i64 invalid_mask = _MM_VFLE_f64(x,_MM_SET_f64(0.0f,gvl),gvl);
+
+  x = _MM_MAX_f64(x, _MM_CAST_f64_i64(_MM_SET_i64(0x0010000000000000,gvl)), gvl);  /* cut off denormalized stuff */
+  imm0_u = _MM_SRL_i64(_MM_CAST_u64_f64(x), _MM_CAST_u64_i64(_MM_SET_i64(52,gvl)), gvl);
+  imm0 = _MM_CAST_i64_u64(imm0_u);
+  /* keep only the fractional part */
+  _x_i = _MM_AND_i64(_MM_CAST_i64_f64(x), _MM_SET_i64(~0x7ff0000000000000,gvl), gvl);
+  _x_i = _MM_OR_i64(_x_i, _MM_CAST_i64_f64(_MM_SET_f64(0.5f,gvl)), gvl);
+  x= _MM_CAST_f64_i64(_x_i);
+  imm0 = _MM_SUB_i64(imm0 ,_MM_SET_i64(1023,gvl) , gvl);
+  e = _MM_VFCVT_F_X_f64(imm0,gvl);
+  e = _MM_ADD_f64(e, _MM_SET_f64(1.0f,gvl) ,gvl);
+
+_MMR_MASK_i64 mask = _MM_VFLT_f64(x, _MM_SET_f64(0.707106781186547524,gvl) , gvl);
+_MMR_f64 tmp  = _MM_MERGE_f64(_MM_SET_f64(0.0f,gvl),x, mask,gvl);
+
+  x = _MM_SUB_f64(x, _MM_SET_f64(1.0f,gvl),gvl);
+  e = _MM_SUB_f64(e, _MM_MERGE_f64(_MM_SET_f64(0.0f,gvl),_MM_SET_f64(1.0f,gvl), mask,gvl),gvl);
+  x = _MM_ADD_f64(x, tmp,gvl);
+
+_MMR_f64 z = _MM_MUL_f64(x,x,gvl);
+_MMR_f64 y;
+
+  y = _MM_MADD_f64(_MM_SET_f64(7.0376836292E-2,gvl),x,_MM_SET_f64(-1.1514610310E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(1.1676998740E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(-1.2420140846E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(1.4249322787E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(-1.6668057665E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(2.0000714765E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(-2.4999993993E-1,gvl),gvl);
+  y = _MM_MADD_f64(y,x,_MM_SET_f64(3.3333331174E-1,gvl),gvl);
+  y = _MM_MUL_f64(y, z,gvl);
+  y = _MM_MACC_f64(y,e,_MM_SET_f64(-2.12194440e-4,gvl),gvl);
+  tmp = _MM_MUL_f64(z, _MM_SET_f64(0.5f,gvl),gvl);
+  y = _MM_SUB_f64(y, tmp,gvl);
+  tmp = _MM_MUL_f64(e, _MM_SET_f64(0.693359375,gvl),gvl);
+  x = _MM_ADD_f64(x, y,gvl);
+  x = _MM_ADD_f64(x, tmp,gvl);
+  x = _MM_MERGE_f64(x,_MM_CAST_f64_i64(_MM_SET_i64(0xffffffffffffffff,gvl)), invalid_mask,gvl);
+
+  return x;
+}
+
+inline _MMR_f32 __log_2xf32(_MMR_f32 x , unsigned long int gvl) {
+
+_MMR_i32   _x_i;
+_MMR_u32   imm0_u;
+_MMR_i32   imm0;
+_MMR_f32  e;
+
+_MMR_MASK_i32 invalid_mask = _MM_VFLE_f32(x,_MM_SET_f32(0.0f,gvl),gvl);
+
+  x = _MM_MAX_f32(x, _MM_CAST_f32_i32(_MM_SET_i32(0x00800000,gvl)), gvl);  /* cut off denormalized stuff */
+  imm0_u = _MM_SRL_i32(_MM_CAST_u32_f32(x), _MM_CAST_u32_i32(_MM_SET_i32(23,gvl)), gvl);
+  imm0 = _MM_CAST_i32_u32(imm0_u);
+  /* keep only the fractional part */
+  _x_i = _MM_AND_i32(_MM_CAST_i32_f32(x), _MM_SET_i32(~0x7f800000,gvl), gvl);
+  _x_i = _MM_OR_i32(_x_i, _MM_CAST_i32_f32(_MM_SET_f32(0.5f,gvl)), gvl);
+  x= _MM_CAST_f32_i32(_x_i);
+  imm0 = _MM_SUB_i32(imm0 ,_MM_SET_i32(0x7f,gvl) , gvl);
+  e = _MM_VFCVT_F_X_f32(imm0,gvl);
+  e = _MM_ADD_f32(e, _MM_SET_f32(1.0f,gvl) ,gvl);
+
+_MMR_MASK_i32 mask = _MM_VFLT_f32(x, _MM_SET_f32(0.707106781186547524,gvl) , gvl);
+_MMR_f32 tmp  = _MM_MERGE_f32(_MM_SET_f32(0.0f,gvl),x, mask,gvl);
+
+  x = _MM_SUB_f32(x, _MM_SET_f32(1.0f,gvl),gvl);
+  e = _MM_SUB_f32(e, _MM_MERGE_f32(_MM_SET_f32(0.0f,gvl),_MM_SET_f32(1.0f,gvl), mask,gvl),gvl);
+  x = _MM_ADD_f32(x, tmp,gvl);
+
+_MMR_f32 z = _MM_MUL_f32(x,x,gvl);
+_MMR_f32 y;
+
+  y = _MM_MADD_f32(_MM_SET_f32(7.0376836292E-2,gvl),x,_MM_SET_f32(-1.1514610310E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(1.1676998740E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(-1.2420140846E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(1.4249322787E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(-1.6668057665E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(2.0000714765E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(-2.4999993993E-1,gvl),gvl);
+  y = _MM_MADD_f32(y,x,_MM_SET_f32(3.3333331174E-1,gvl),gvl);
+  y = _MM_MUL_f32(y, z,gvl);
+  y = _MM_MACC_f32(y,e,_MM_SET_f32(-2.12194440e-4,gvl),gvl);
+  tmp = _MM_MUL_f32(z, _MM_SET_f32(0.5f,gvl),gvl);
+  y = _MM_SUB_f32(y, tmp,gvl);
+  tmp = _MM_MUL_f32(e, _MM_SET_f32(0.693359375,gvl),gvl);
+  x = _MM_ADD_f32(x, y,gvl);
+  x = _MM_ADD_f32(x, tmp,gvl);
+  x = _MM_MERGE_f32(x,_MM_CAST_f32_i32(_MM_SET_i32(0xffffffff,gvl)), invalid_mask,gvl);
+
+  return x;
+}
+
+// Natural logarithm (base e)
+int main() {
+  printf("\n");
+  printf("==========\n");
+  printf("=  FLOG  =\n");
+  printf("==========\n");
+  printf("\n");
+  printf("\n");
+
+  int error = 0;
+  int64_t runtime;
+
+  printf("Executing natural log (base e) on %d 64-bit data...\n", N_f64);
+
+  start_timer();
+  log_1xf64_bmark(args_f64, results_f64, N_f64);
+  stop_timer();
+
+  runtime = get_timer();
+  printf("The execution took %d cycles.\n", runtime);
+
+  printf("Executing natural log (base e) on %d 32-bit data...\n", N_f32);
+  start_timer();
+  log_2xf32_bmark(args_f32, results_f32, N_f32);
+  stop_timer();
+
+  runtime = get_timer();
+  printf("The execution took %d cycles.\n", runtime);
+
+  printf("log(%f) = %f\n", args_f64[0], results_f64[0]);
+
+#ifdef CHECK
+  printf("Checking results:\n");
+
+  for (uint64_t i = 0; i < N_f64; ++i) {
+    if (!similarity_check(results_f64[i], gold_results_f64[i], THRESHOLD)) {
+      error = 1;
+      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i], gold_results_f64[i]);
+    }
+  }
+  for (uint64_t i = 0; i < N_f32; ++i) {
+    if (!similarity_check(results_f32[i], gold_results_f32[i], THRESHOLD)) {
+      error = 1;
+      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i], gold_results_f32[i]);
+    }
+  }
+#endif
+
+  return error;
+}

--- a/apps/log/main.c
+++ b/apps/log/main.c
@@ -19,10 +19,10 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "util.h"
 #include "kernel/log.h"
 #include "printf.h"
 #include "runtime.h"
+#include "util.h"
 
 #define THRESHOLD 1
 
@@ -75,13 +75,15 @@ int main() {
   for (uint64_t i = 0; i < N_f64; ++i) {
     if (!similarity_check(results_f64[i], gold_results_f64[i], THRESHOLD)) {
       error = 1;
-      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i], gold_results_f64[i]);
+      printf("64-bit error at index %d. %f != %f\n", i, results_f64[i],
+             gold_results_f64[i]);
     }
   }
   for (uint64_t i = 0; i < N_f32; ++i) {
     if (!similarity_check(results_f32[i], gold_results_f32[i], THRESHOLD)) {
       error = 1;
-      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i], gold_results_f32[i]);
+      printf("32-bit error at index %d. %f != %f\n", i, results_f32[i],
+             gold_results_f32[i]);
     }
   }
 #endif

--- a/apps/log/main.c
+++ b/apps/log/main.c
@@ -1,212 +1,42 @@
-// Modified version of:
-// "RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019""
-// Find details on the original version below
+// Copyright 2022 ETH Zurich and University of Bologna.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
-
-// RISC-V VECTOR LOG FUNCTION Version by Cristóbal Ramírez Lazo, "Barcelona 2019"
-// This RISC-V Vector implementation is based on the original code presented by Julien Pommier
-
-/*
-   AVX implementation of sin, cos, sincos, exp and log
-   Based on "sse_mathfun.h", by Julien Pommier
-   http://gruntthepeon.free.fr/ssemath/
-   Copyright (C) 2012 Giovanni Garberoglio
-   Interdisciplinary Laboratory for Computational Science (LISC)
-   Fondazione Bruno Kessler and University of Trento
-   via Sommarive, 18
-   I-38123 Trento (Italy)
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
-  (this is the zlib license)
-*/
 
 #include <stdint.h>
 #include <string.h>
 
-#include "rivec/vector_defines.h"
+#include "util.h"
+#include "kernel/log.h"
 #include "printf.h"
 #include "runtime.h"
 
-extern size_t N_f64;
+#define THRESHOLD 1
 
+#define CHECK
+
+extern size_t N_f64;
 extern double args_f64[] __attribute__((aligned(4 * NR_LANES)));
 extern double results_f64[] __attribute__((aligned(4 * NR_LANES)));
 extern double gold_results_f64[] __attribute__((aligned(4 * NR_LANES)));
 
 extern size_t N_f32;
-
 extern float args_f32[] __attribute__((aligned(4 * NR_LANES)));
 extern float results_f32[] __attribute__((aligned(4 * NR_LANES)));
 extern float gold_results_f32[] __attribute__((aligned(4 * NR_LANES)));
-
-#define THRESHOLD 1
-#define FABS(x) ((x < 0) ? -x : x)
-
-#define CHECK
-
-inline vfloat64m1_t __log_1xf64(vfloat64m1_t x, size_t gvl);
-inline vfloat32m1_t __log_2xf32(vfloat32m1_t x, size_t gvl);
-void log_1xf64_bmark(double* args, double* results, size_t len);
-void log_2xf32_bmark(float* args, float* results, size_t len);
-int similarity_check(double a, double b, double threshold);
-
-int similarity_check(double a, double b, double threshold) {
-  double diff = a - b;
-  if (FABS(diff) > threshold)
-    return 0;
-  else
-    return 1;
-}
-
-void log_1xf64_bmark(double* args, double* results, size_t len) {
-
-  size_t avl = len;
-  vfloat64m1_t log_vec, res_vec;
-
-  for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
-    // Strip-mine
-    vl = vsetvl_e64m1(avl);
-    // Load vector
-    log_vec = vle64_v_f64m1(args, vl);
-    // Compute
-    res_vec = __log_1xf64(log_vec, vl);
-    // Store
-    vse64_v_f64m1(results, res_vec, vl);
-    // Bump pointers
-    args += vl;
-    results   += vl;
-  }
-}
-
-void log_2xf32_bmark(float* args, float* results, size_t len) {
-
-  size_t avl = len;
-  vfloat32m1_t log_vec, res_vec;
-
-  for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
-    // Strip-mine
-    vl = vsetvl_e32m1(avl);
-    // Load vector
-    log_vec = vle32_v_f32m1(args, vl);
-    // Compute
-    res_vec = __log_2xf32(log_vec, vl);
-    // Store
-    vse32_v_f32m1(results, res_vec, vl);
-    // Bump pointers
-    args += vl;
-    results   += vl;
-  }
-}
-
-inline _MMR_f64 __log_1xf64(_MMR_f64 x , unsigned long int gvl) {
-
-_MMR_i64   _x_i;
-_MMR_u64   imm0_u;
-_MMR_i64   imm0;
-_MMR_f64  e;
-_MMR_MASK_i64 invalid_mask = _MM_VFLE_f64(x,_MM_SET_f64(0.0f,gvl),gvl);
-
-  x = _MM_MAX_f64(x, _MM_CAST_f64_i64(_MM_SET_i64(0x0010000000000000,gvl)), gvl);  /* cut off denormalized stuff */
-  imm0_u = _MM_SRL_i64(_MM_CAST_u64_f64(x), _MM_CAST_u64_i64(_MM_SET_i64(52,gvl)), gvl);
-  imm0 = _MM_CAST_i64_u64(imm0_u);
-  /* keep only the fractional part */
-  _x_i = _MM_AND_i64(_MM_CAST_i64_f64(x), _MM_SET_i64(~0x7ff0000000000000,gvl), gvl);
-  _x_i = _MM_OR_i64(_x_i, _MM_CAST_i64_f64(_MM_SET_f64(0.5f,gvl)), gvl);
-  x= _MM_CAST_f64_i64(_x_i);
-  imm0 = _MM_SUB_i64(imm0 ,_MM_SET_i64(1023,gvl) , gvl);
-  e = _MM_VFCVT_F_X_f64(imm0,gvl);
-  e = _MM_ADD_f64(e, _MM_SET_f64(1.0f,gvl) ,gvl);
-
-_MMR_MASK_i64 mask = _MM_VFLT_f64(x, _MM_SET_f64(0.707106781186547524,gvl) , gvl);
-_MMR_f64 tmp  = _MM_MERGE_f64(_MM_SET_f64(0.0f,gvl),x, mask,gvl);
-
-  x = _MM_SUB_f64(x, _MM_SET_f64(1.0f,gvl),gvl);
-  e = _MM_SUB_f64(e, _MM_MERGE_f64(_MM_SET_f64(0.0f,gvl),_MM_SET_f64(1.0f,gvl), mask,gvl),gvl);
-  x = _MM_ADD_f64(x, tmp,gvl);
-
-_MMR_f64 z = _MM_MUL_f64(x,x,gvl);
-_MMR_f64 y;
-
-  y = _MM_MADD_f64(_MM_SET_f64(7.0376836292E-2,gvl),x,_MM_SET_f64(-1.1514610310E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(1.1676998740E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(-1.2420140846E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(1.4249322787E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(-1.6668057665E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(2.0000714765E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(-2.4999993993E-1,gvl),gvl);
-  y = _MM_MADD_f64(y,x,_MM_SET_f64(3.3333331174E-1,gvl),gvl);
-  y = _MM_MUL_f64(y, z,gvl);
-  y = _MM_MACC_f64(y,e,_MM_SET_f64(-2.12194440e-4,gvl),gvl);
-  tmp = _MM_MUL_f64(z, _MM_SET_f64(0.5f,gvl),gvl);
-  y = _MM_SUB_f64(y, tmp,gvl);
-  tmp = _MM_MUL_f64(e, _MM_SET_f64(0.693359375,gvl),gvl);
-  x = _MM_ADD_f64(x, y,gvl);
-  x = _MM_ADD_f64(x, tmp,gvl);
-  x = _MM_MERGE_f64(x,_MM_CAST_f64_i64(_MM_SET_i64(0xffffffffffffffff,gvl)), invalid_mask,gvl);
-
-  return x;
-}
-
-inline _MMR_f32 __log_2xf32(_MMR_f32 x , unsigned long int gvl) {
-
-_MMR_i32   _x_i;
-_MMR_u32   imm0_u;
-_MMR_i32   imm0;
-_MMR_f32  e;
-
-_MMR_MASK_i32 invalid_mask = _MM_VFLE_f32(x,_MM_SET_f32(0.0f,gvl),gvl);
-
-  x = _MM_MAX_f32(x, _MM_CAST_f32_i32(_MM_SET_i32(0x00800000,gvl)), gvl);  /* cut off denormalized stuff */
-  imm0_u = _MM_SRL_i32(_MM_CAST_u32_f32(x), _MM_CAST_u32_i32(_MM_SET_i32(23,gvl)), gvl);
-  imm0 = _MM_CAST_i32_u32(imm0_u);
-  /* keep only the fractional part */
-  _x_i = _MM_AND_i32(_MM_CAST_i32_f32(x), _MM_SET_i32(~0x7f800000,gvl), gvl);
-  _x_i = _MM_OR_i32(_x_i, _MM_CAST_i32_f32(_MM_SET_f32(0.5f,gvl)), gvl);
-  x= _MM_CAST_f32_i32(_x_i);
-  imm0 = _MM_SUB_i32(imm0 ,_MM_SET_i32(0x7f,gvl) , gvl);
-  e = _MM_VFCVT_F_X_f32(imm0,gvl);
-  e = _MM_ADD_f32(e, _MM_SET_f32(1.0f,gvl) ,gvl);
-
-_MMR_MASK_i32 mask = _MM_VFLT_f32(x, _MM_SET_f32(0.707106781186547524,gvl) , gvl);
-_MMR_f32 tmp  = _MM_MERGE_f32(_MM_SET_f32(0.0f,gvl),x, mask,gvl);
-
-  x = _MM_SUB_f32(x, _MM_SET_f32(1.0f,gvl),gvl);
-  e = _MM_SUB_f32(e, _MM_MERGE_f32(_MM_SET_f32(0.0f,gvl),_MM_SET_f32(1.0f,gvl), mask,gvl),gvl);
-  x = _MM_ADD_f32(x, tmp,gvl);
-
-_MMR_f32 z = _MM_MUL_f32(x,x,gvl);
-_MMR_f32 y;
-
-  y = _MM_MADD_f32(_MM_SET_f32(7.0376836292E-2,gvl),x,_MM_SET_f32(-1.1514610310E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(1.1676998740E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(-1.2420140846E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(1.4249322787E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(-1.6668057665E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(2.0000714765E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(-2.4999993993E-1,gvl),gvl);
-  y = _MM_MADD_f32(y,x,_MM_SET_f32(3.3333331174E-1,gvl),gvl);
-  y = _MM_MUL_f32(y, z,gvl);
-  y = _MM_MACC_f32(y,e,_MM_SET_f32(-2.12194440e-4,gvl),gvl);
-  tmp = _MM_MUL_f32(z, _MM_SET_f32(0.5f,gvl),gvl);
-  y = _MM_SUB_f32(y, tmp,gvl);
-  tmp = _MM_MUL_f32(e, _MM_SET_f32(0.693359375,gvl),gvl);
-  x = _MM_ADD_f32(x, y,gvl);
-  x = _MM_ADD_f32(x, tmp,gvl);
-  x = _MM_MERGE_f32(x,_MM_CAST_f32_i32(_MM_SET_i32(0xffffffff,gvl)), invalid_mask,gvl);
-
-  return x;
-}
 
 // Natural logarithm (base e)
 int main() {

--- a/apps/log/script/gen_data.py
+++ b/apps/log/script/gen_data.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2021 ETH Zurich and University of Bologna.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# arg1: vector size, arg2: filter size
+
+import random as rand
+import numpy as np
+import sys
+
+def emit(name, array, alignment='8'):
+  print(".global %s" % name)
+  print(".balign " + alignment)
+  print("%s:" % name)
+  bs = array.tobytes()
+  for i in range(0, len(bs), 4):
+    s = ""
+    for n in range(4):
+      s += "%02x" % bs[i+3-n]
+    print("    .word 0x%s" % s)
+
+def rand_matrix(N, dtype):
+  return np.random.rand(N).astype(dtype) * 3.141
+
+############
+## SCRIPT ##
+############
+
+if len(sys.argv) == 2:
+  N_f64 = int(sys.argv[1])
+  N_f32 = 2 * N_f64
+else:
+  print("Error. Give me one argument: the number of vector elements.")
+  sys.exit()
+
+# Vector of samples
+args_f64 = rand_matrix(N_f64, np.float64).astype(np.float64)
+args_f32 = rand_matrix(N_f32, np.float32).astype(np.float32)
+
+# Results buffer
+results_f64 = np.zeros(N_f64, dtype=np.float64)
+results_f32 = np.zeros(N_f32, dtype=np.float32)
+
+# Gold results
+gold_results_f64 = np.log(args_f64, dtype=np.float64)
+gold_results_f32 = np.log(args_f32, dtype=np.float32)
+
+# Create the file
+print(".section .data,\"aw\",@progbits")
+emit("N_f64", np.array(N_f64, dtype=np.uint64))
+emit("args_f64", args_f64, 'NR_LANES*4')
+emit("results_f64", results_f64, 'NR_LANES*4')
+emit("gold_results_f64", gold_results_f64, 'NR_LANES*4')
+emit("N_f32", np.array(N_f32, dtype=np.uint32))
+emit("args_f32", args_f32, 'NR_LANES*4')
+emit("results_f32", results_f32, 'NR_LANES*4')
+emit("gold_results_f32", gold_results_f32, 'NR_LANES*4')

--- a/hardware/src/accel_dispatcher_ideal.sv
+++ b/hardware/src/accel_dispatcher_ideal.sv
@@ -39,12 +39,13 @@ module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; (
   //////////
 
   // Width and number of vector instructions in the ideal dispatcher
-  localparam integer unsigned DATA_WIDTH  = 32 + 64; // vinsn + scalar reg
+  localparam integer unsigned DATA_WIDTH  = 32 + 64 + 64; // vinsn + scalar reg + scalar reg
   localparam integer unsigned N_VINSN   = `N_VINSN;
 
   typedef struct packed {
     riscv::instruction_t insn;
     riscv::xlen_t rs1;
+    riscv::xlen_t rs2;
   } fifo_payload_t;
 
   logic [DATA_WIDTH-1:0] fifo_data_raw;
@@ -102,6 +103,7 @@ module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; (
   assign acc_req_o = '{
     insn    : fifo_data.insn,
     rs1     : fifo_data.rs1,
+    rs2     : fifo_data.rs2,
     default : '0
   };
 

--- a/scripts/benchmark.gnuplot
+++ b/scripts/benchmark.gnuplot
@@ -277,13 +277,6 @@ set yrange [0.125:50]
 
 # Title
 set title "dwt performance, (vector of size #elements)"
-
-# Set axis labels
-set xlabel 'Vector size (#elements)'
-set ylabel 'Performance (OP/cycle)'
-
-# Output png
-set term png
 set out "dwt.png"
 
 # Plot the rooflines
@@ -303,3 +296,32 @@ plot roof_cpu(x, 1.7, 1.7) w l lw 2 lc 1 t '2 Lanes',     \
      roof_cpu(x, 11, 11) w l lw 2 lc 7 t '16 Lanes',      \
      'dwt_16.benchmark'       w p lw 2 lc 7 pt 5 notitle, \
      'dwt_16_ideal.benchmark' w p lw 2 lc 7 pt 4 notitle
+
+#########
+## EXP ##
+#########
+
+# Title
+set title "exp performance, (Vector of size #elements)"
+
+# Set axis labels
+set xlabel 'Vector size (#elements)'
+set ylabel 'Performance (OP/cycle)'
+
+# Output png
+set term png
+set out "exp.png"
+
+# Plot the rooflines for 64-bit data
+plot roof_cpu(x, 1,  1.3*2) w l lw 2 lc 1 t  '2 Lanes',   \
+     'exp_2.benchmark'       w p lw 2 lc 1 pt 5 notitle,  \
+     'exp_2_ideal.benchmark' w p lw 2 lc 1 pt 4 notitle,  \
+     roof_cpu(x, 2,  1.3*4) w l lw 2 lc 2 t  '4 Lanes',   \
+     'exp_4.benchmark'       w p lw 2 lc 2 pt 5 notitle,  \
+     'exp_4_ideal.benchmark' w p lw 2 lc 2 pt 4 notitle,  \
+     roof_cpu(x, 4, 1.3*8) w l lw 2 lc 3 t  '8 Lanes',    \
+     'exp_8.benchmark'       w p lw 2 lc 3 pt 5 notitle,  \
+     'exp_8_ideal.benchmark' w p lw 2 lc 3 pt 4 notitle,  \
+     roof_cpu(x, 8, 1.3*16) w l lw 2 lc 7 t '16 Lanes',   \
+     'exp_16.benchmark'       w p lw 2 lc 7 pt 5 notitle, \
+     'exp_16_ideal.benchmark' w p lw 2 lc 7 pt 4 notitle

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -325,3 +325,42 @@ for kernel in dwt; do
         fi
     done
 done
+
+#########
+## EXP ##
+#########
+
+# Measure the runtime of the following kernels
+for kernel in exp; do
+
+    # Log the performance results
+    > ${kernel}_${nr_lanes}.benchmark
+    > ${kernel}_${nr_lanes}_ideal.benchmark
+
+    for vsize in 8 16 32 64 128 256 512; do
+        tempfile=`mktemp`
+
+        # Clean
+        make -C apps/ clean
+
+        mkdir -p apps/benchmarks/data
+        ${PYTHON} apps/$kernel/script/gen_data.py $vsize > apps/benchmarks/data/data.S
+        ENV_DEFINES="-D${kernel^^}=1" \
+               make -C apps/ bin/benchmarks
+        make -C hardware/ simv app=benchmarks > $tempfile || exit
+        # Extract the performance
+        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
+
+        if [ "$ci" == 0 ]; then
+          # System with ideal dispatcher
+          ENV_DEFINES="-D${kernel^^}=1 -DSAMPLES=${vsize}" \
+                 make -C apps/ bin/benchmarks.ideal
+          touch -a hardware/build
+          make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
+          # Extract the performance
+           cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+          ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+       fi
+    done
+done

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# benchmark.sh [ci] [$app]
+# Pass the option "ci" if there is no QuestaSim installed
+# Pass the name of the app to benchmark
+# If no app is passed, all the apps are benchmarked
+
 
 # Python in use
 PYTHON=python3
@@ -7,6 +12,8 @@ PYTHON=python3
 if [ "$1" == "ci" ]
 then
     ci=1
+    # If there is a program
+    shift
 else
     ci=0
 fi
@@ -28,8 +35,9 @@ source ${tmpscript}
 ## MATMUL ##
 ############
 
-# Measure the runtime of the following kernels
-for kernel in imatmul fmatmul; do
+matmul() {
+  # Measure the runtime of the following kernels
+  for kernel in imatmul fmatmul; do
 
     # Log the performance results
     > ${kernel}_${nr_lanes}.benchmark
@@ -38,38 +46,40 @@ for kernel in imatmul fmatmul; do
     # Measure the following matrix sizes
     for size in 4 8 16 32 64 128; do
 
-        tempfile=`mktemp`
+      tempfile=`mktemp`
 
-        # Clean, and then generate the correct matrix and filter
-		make -C apps/ clean
+      # Clean, and then generate the correct matrix and filter
+      make -C apps/ clean
 
-        # Standard system
+      # Standard system
+      config=${config} ENV_DEFINES="-DSIZE=$size -D${kernel^^}=1" \
+             make -C apps/ bin/benchmarks
+      make -C hardware/ simv app=benchmarks > $tempfile || exit
+      # Extract the cycle count and calculate performance
+      cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+      ./scripts/performance.py $kernel "$size" $cycles >> ${kernel}_${nr_lanes}.benchmark
+
+      if [ "$ci" == 0 ]; then
+        # System with ideal dispatcher
         config=${config} ENV_DEFINES="-DSIZE=$size -D${kernel^^}=1" \
-               make -C apps/ bin/benchmarks
-        make -C hardware/ simv app=benchmarks > $tempfile || exit
+               make -C apps/ bin/benchmarks.ideal
+        touch -a hardware/build
+        config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
         # Extract the cycle count and calculate performance
-	    cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-        ./scripts/performance.py $kernel "$size" $cycles >> ${kernel}_${nr_lanes}.benchmark
-
-        if [ "$ci" == 0 ]; then
-          # System with ideal dispatcher
-          config=${config} ENV_DEFINES="-DSIZE=$size -D${kernel^^}=1" \
-                 make -C apps/ bin/benchmarks.ideal
-          touch -a hardware/build
-          config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-          # Extract the cycle count and calculate performance
-	      cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-          ./scripts/performance.py $kernel "$size" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
-        fi
+        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+        ./scripts/performance.py $kernel "$size" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+      fi
     done
-done
+  done
+}
 
 ################
 ## CONV2D 3x3 ##
 ################
 
-# Measure the runtime of the following kernels
-for kernel in iconv2d fconv2d; do
+conv2d() {
+  # Measure the runtime of the following kernels
+  for kernel in iconv2d fconv2d; do
 
     # Log the performance results
     > ${kernel}_${nr_lanes}.benchmark
@@ -80,43 +90,45 @@ for kernel in iconv2d fconv2d; do
     # MAXVL_M2_64b - F_MAX + 1 = 128 - 7 + 1 = 122 is the max number of elements
     # Actually 120, since it must be divible by 4
     for msize in 4 8 16 32 64 112; do
-        for fsize in 3; do
-            tempfile=`mktemp`
+      for fsize in 3; do
+        tempfile=`mktemp`
 
-            # Clean, and then generate the correct matrix and filter
-			make -C apps/ clean
+        # Clean, and then generate the correct matrix and filter
+        make -C apps/ clean
 
-			mkdir -p apps/benchmarks/data
-			${PYTHON} apps/$kernel/script/gen_data.py $msize $fsize > apps/benchmarks/data/data.S
+        mkdir -p apps/benchmarks/data
+        ${PYTHON} apps/$kernel/script/gen_data.py $msize $fsize > apps/benchmarks/data/data.S
 
-            # Standard System
-            config=${config} ENV_DEFINES="-D${kernel^^}=1" \
-                   make -C apps/ bin/benchmarks
-            make -C hardware/ simv app=benchmarks > $tempfile || exit
-            # Extract the performance
-	        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-            ./scripts/performance.py $kernel "$msize $fsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
+        # Standard System
+        config=${config} ENV_DEFINES="-D${kernel^^}=1" \
+               make -C apps/ bin/benchmarks
+        make -C hardware/ simv app=benchmarks > $tempfile || exit
+        # Extract the performance
+        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+        ./scripts/performance.py $kernel "$msize $fsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
 
-            if [ "$ci" == 0 ]; then
-              # System with ideal dispatcher
-              config=${config} ENV_DEFINES="-D${kernel^^}=1" \
-                     make -C apps/ bin/benchmarks.ideal
-              touch -a hardware/build
-              config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-              # Extract the performance
-	          cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-              ./scripts/performance.py $kernel "$msize $fsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
-            fi
-        done
+        if [ "$ci" == 0 ]; then
+          # System with ideal dispatcher
+          config=${config} ENV_DEFINES="-D${kernel^^}=1" \
+                 make -C apps/ bin/benchmarks.ideal
+          touch -a hardware/build
+          config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
+          # Extract the performance
+          cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+          ./scripts/performance.py $kernel "$msize $fsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+        fi
+      done
     done
-done
+  done
+}
 
 ################
 ## CONV3D 7x7 ##
 ################
 
-# Measure the runtime of the following kernels
-for kernel in fconv3d; do
+conv3d() {
+  # Measure the runtime of the following kernels
+  for kernel in fconv3d; do
 
     # Log the performance results
     > ${kernel}_${nr_lanes}.benchmark
@@ -127,43 +139,45 @@ for kernel in fconv3d; do
     # MAXVL_M2_64b - F_MAX + 1 = 128 - 7 + 1 = 122 is the max number of elements
     # Actually 120, since it must be divible by 4
     for msize in 4 8 16 32 64 112; do
-        for fsize in 7; do
-            tempfile=`mktemp`
+      for fsize in 7; do
+        tempfile=`mktemp`
 
-            # Clean, and then generate the correct matrix and filter
-			make -C apps/ clean
+        # Clean, and then generate the correct matrix and filter
+        make -C apps/ clean
 
-			mkdir -p apps/benchmarks/data
-            ${PYTHON} apps/$kernel/script/gen_data.py $msize $fsize > apps/benchmarks/data/data.S
+        mkdir -p apps/benchmarks/data
+        ${PYTHON} apps/$kernel/script/gen_data.py $msize $fsize > apps/benchmarks/data/data.S
 
-            # Standard System
-            config=${config} ENV_DEFINES="-D${kernel^^}=1" \
-                   make -C apps/ bin/benchmarks
-            make -C hardware/ simv app=benchmarks > $tempfile || exit
-            # Extract the performance
-	        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-            ./scripts/performance.py $kernel "$msize $fsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
+        # Standard System
+        config=${config} ENV_DEFINES="-D${kernel^^}=1" \
+               make -C apps/ bin/benchmarks
+        make -C hardware/ simv app=benchmarks > $tempfile || exit
+        # Extract the performance
+        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+        ./scripts/performance.py $kernel "$msize $fsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
 
-            if [ "$ci" == 0 ]; then
-              # System with ideal dispatcher
-              config=${config} ENV_DEFINES="-D${kernel^^}=1" \
-                     make -C apps/ bin/benchmarks.ideal
-              touch -a hardware/build
-              config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-              # Extract the performance
-	          cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-              ./scripts/performance.py $kernel "$msize $fsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
-            fi
-        done
+        if [ "$ci" == 0 ]; then
+          # System with ideal dispatcher
+          config=${config} ENV_DEFINES="-D${kernel^^}=1" \
+                 make -C apps/ bin/benchmarks.ideal
+          touch -a hardware/build
+          config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
+          # Extract the performance
+          cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+          ./scripts/performance.py $kernel "$msize $fsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+        fi
+      done
     done
-done
+  done
+}
 
 ##############
 ## Jacobi2d ##
 ##############
 
-# Measure the runtime of the following kernels
-for kernel in jacobi2d; do
+jacobi2d() {
+  # Measure the runtime of the following kernels
+  for kernel in jacobi2d; do
     OnlyVec=1
 
     # Log the performance results
@@ -171,83 +185,86 @@ for kernel in jacobi2d; do
     > ${kernel}_${nr_lanes}_ideal.benchmark
 
     for vsize_unpadded in 4 8 16 32 64 128 238; do
-        vsize=$(($vsize_unpadded + 2))
+      vsize=$(($vsize_unpadded + 2))
 
-        tempfile=`mktemp`
+      tempfile=`mktemp`
 
-        # Clean, and then generate the correct matrix and filter
-        make -C apps/ clean
+      # Clean, and then generate the correct data
+      make -C apps/ clean
 
-        mkdir -p apps/benchmarks/data
+      mkdir -p apps/benchmarks/data
+      ${PYTHON} apps/$kernel/script/gen_data.py $vsize $vsize $OnlyVec > apps/benchmarks/data/data.S
+      config=${config} ENV_DEFINES="-D${kernel^^}=1" \
+             make -C apps/ bin/benchmarks
+      make -C hardware/ simv app=benchmarks > $tempfile || exit
+      # Extract the performance
+         cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+      ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
 
-        ${PYTHON} apps/$kernel/script/gen_data.py $vsize $vsize $OnlyVec > apps/benchmarks/data/data.S
+      if [ "$ci" == 0 ]; then
+        # System with ideal dispatcher
         config=${config} ENV_DEFINES="-D${kernel^^}=1" \
-               make -C apps/ bin/benchmarks
-        make -C hardware/ simv app=benchmarks > $tempfile || exit
+               make -C apps/ bin/benchmarks.ideal
+        touch -a hardware/build
+        config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
         # Extract the performance
            cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
-
-        if [ "$ci" == 0 ]; then
-          # System with ideal dispatcher
-          config=${config} ENV_DEFINES="-D${kernel^^}=1" \
-                 make -C apps/ bin/benchmarks.ideal
-          touch -a hardware/build
-          config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-          # Extract the performance
-             cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-          ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
-        fi
+        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+      fi
     done
-done
+  done
+}
 
 #############
 ## DROPOUT ##
 #############
 
-# Measure the runtime of the following kernels
-for kernel in dropout; do
+dropout() {
+  # Measure the runtime of the following kernels
+  for kernel in dropout; do
 
     # Log the performance results
     > ${kernel}_${nr_lanes}.benchmark
     > ${kernel}_${nr_lanes}_ideal.benchmark
 
     for vsize in 4 8 16 32 64 128 256 512 1024 2048; do
-        tempfile=`mktemp`
+      tempfile=`mktemp`
 
-        # Clean, and then generate the correct matrix and filter
-        make -C apps/ clean
+      # Clean
+      make -C apps/ clean
 
-        mkdir -p apps/benchmarks/data
-        ${PYTHON} apps/$kernel/script/gen_data.py $vsize > apps/benchmarks/data/data.S
+      mkdir -p apps/benchmarks/data
+      ${PYTHON} apps/$kernel/script/gen_data.py $vsize > apps/benchmarks/data/data.S
 
-        # Standard System
+      # Standard System
+      config=${config} ENV_DEFINES="-D${kernel^^}=1" \
+             make -C apps/ bin/benchmarks
+      make -C hardware/ simv app=benchmarks > $tempfile || exit
+      # Extract the performance
+         cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+      ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
+
+      if [ "$ci" == 0 ]; then
+        # System with ideal dispatcher
         config=${config} ENV_DEFINES="-D${kernel^^}=1" \
-               make -C apps/ bin/benchmarks
-        make -C hardware/ simv app=benchmarks > $tempfile || exit
+               make -C apps/ bin/benchmarks.ideal
+        touch -a hardware/build
+        config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
         # Extract the performance
            cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
-
-        if [ "$ci" == 0 ]; then
-          # System with ideal dispatcher
-          config=${config} ENV_DEFINES="-D${kernel^^}=1" \
-                 make -C apps/ bin/benchmarks.ideal
-          touch -a hardware/build
-          config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-          # Extract the performance
-             cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-          ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
-        fi
+        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+      fi
     done
-done
+  done
+}
 
 #########
 ## FFT ##
 #########
 
-# Measure the runtime of the following kernels
-for kernel in fft; do
+fft() {
+  # Measure the runtime of the following kernels
+  for kernel in fft; do
 
     # Log the performance results
     > ${kernel}_${nr_lanes}.benchmark
@@ -259,39 +276,42 @@ for kernel in fft; do
 
     # 2-lanes and vlen == 4096 cannot contain 256 float32 elements
     for vsize in 4 8 16 32 64 128 $(test $vlen -ge $(( 256 * ${dtype:5:2} )) && echo 256); do
-        tempfile=`mktemp`
+      tempfile=`mktemp`
 
-        # Clean, and then generate the correct matrix and filter
-        make -C apps/ clean
+      # Clean, and then generate the correct matrix and filter
+      make -C apps/ clean
 
-        mkdir -p apps/benchmarks/data
-        ${PYTHON} apps/$kernel/script/gen_data.py $vsize $dtype > apps/benchmarks/data/data.S
+      mkdir -p apps/benchmarks/data
+      ${PYTHON} apps/$kernel/script/gen_data.py $vsize $dtype > apps/benchmarks/data/data.S
+
+      config=${config} ENV_DEFINES="-D${kernel^^}=1 -DFFT_SAMPLES=${vsize}" \
+             make -C apps/ bin/benchmarks
+      make -C hardware/ simv app=benchmarks > $tempfile || exit
+      # Extract the performance
+      cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+      ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
+
+      if [ "$ci" == 0 ]; then
+        # System with ideal dispatcher
         config=${config} ENV_DEFINES="-D${kernel^^}=1 -DFFT_SAMPLES=${vsize}" \
-               make -C apps/ bin/benchmarks
-        make -C hardware/ simv app=benchmarks > $tempfile || exit
+               make -C apps/ bin/benchmarks.ideal
+        touch -a hardware/build
+        config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
         # Extract the performance
-        cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
-
-        if [ "$ci" == 0 ]; then
-          # System with ideal dispatcher
-          config=${config} ENV_DEFINES="-D${kernel^^}=1 -DFFT_SAMPLES=${vsize}" \
-                 make -C apps/ bin/benchmarks.ideal
-          touch -a hardware/build
-          config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-          # Extract the performance
-             cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-          ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
-        fi
+           cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+      fi
     done
-done
+  done
+}
 
 #########
 ## DWT ##
 #########
 
-# Measure the runtime of the following kernels
-for kernel in dwt; do
+dwt() {
+  # Measure the runtime of the following kernels
+  for kernel in dwt; do
 
     # Log the performance results
     > ${kernel}_${nr_lanes}.benchmark
@@ -299,68 +319,117 @@ for kernel in dwt; do
 
     for vsize in 4 8 16 32 64 128 256 512; do
 
-        tempfile=`mktemp`
+      tempfile=`mktemp`
 
-        # Clean
-		make -C apps/ clean
+      # Clean
+      make -C apps/ clean
 
-        mkdir -p apps/benchmarks/data
-        ${PYTHON} apps/$kernel/script/gen_data.py $vsize > apps/benchmarks/data/data.S
+      mkdir -p apps/benchmarks/data
+      ${PYTHON} apps/$kernel/script/gen_data.py $vsize > apps/benchmarks/data/data.S
+      config=${config} ENV_DEFINES="-D${kernel^^}=1 -DSAMPLES=${vsize}" \
+             make -C apps/ bin/benchmarks
+      make -C hardware/ simv app=benchmarks > $tempfile || exit
+      # Extract the performance
+      cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+      ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
+
+      if [ "$ci" == 0 ]; then
+        # System with ideal dispatcher
         config=${config} ENV_DEFINES="-D${kernel^^}=1 -DSAMPLES=${vsize}" \
-               make -C apps/ bin/benchmarks
-        make -C hardware/ simv app=benchmarks > $tempfile || exit
+               make -C apps/ bin/benchmarks.ideal
+        touch -a hardware/build
+        config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
         # Extract the performance
         cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
-
-        if [ "$ci" == 0 ]; then
-          # System with ideal dispatcher
-          config=${config} ENV_DEFINES="-D${kernel^^}=1 -DSAMPLES=${vsize}" \
-                 make -C apps/ bin/benchmarks.ideal
-          touch -a hardware/build
-          config=${config} make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-          # Extract the performance
-          cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-          ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
-        fi
+        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+      fi
     done
-done
+  done
+}
 
 #########
 ## EXP ##
 #########
 
-# Measure the runtime of the following kernels
-for kernel in exp; do
+exp() {
+  # Measure the runtime of the following kernels
+  for kernel in exp; do
 
     # Log the performance results
     > ${kernel}_${nr_lanes}.benchmark
     > ${kernel}_${nr_lanes}_ideal.benchmark
 
     for vsize in 8 16 32 64 128 256 512; do
-        tempfile=`mktemp`
+      tempfile=`mktemp`
 
-        # Clean
-        make -C apps/ clean
+      # Clean
+      make -C apps/ clean
 
-        mkdir -p apps/benchmarks/data
-        ${PYTHON} apps/$kernel/script/gen_data.py $vsize > apps/benchmarks/data/data.S
-        ENV_DEFINES="-D${kernel^^}=1" \
-               make -C apps/ bin/benchmarks
-        make -C hardware/ simv app=benchmarks > $tempfile || exit
+      mkdir -p apps/benchmarks/data
+      ${PYTHON} apps/$kernel/script/gen_data.py $vsize > apps/benchmarks/data/data.S
+      ENV_DEFINES="-D${kernel^^}=1" \
+             make -C apps/ bin/benchmarks
+      make -C hardware/ simv app=benchmarks > $tempfile || exit
+      # Extract the performance
+      cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
+      ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
+
+      if [ "$ci" == 0 ]; then
+        # System with ideal dispatcher
+        ENV_DEFINES="-D${kernel^^}=1 -DSAMPLES=${vsize}" \
+               make -C apps/ bin/benchmarks.ideal
+        touch -a hardware/build
+        make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
         # Extract the performance
         cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}.benchmark
-
-        if [ "$ci" == 0 ]; then
-          # System with ideal dispatcher
-          ENV_DEFINES="-D${kernel^^}=1 -DSAMPLES=${vsize}" \
-                 make -C apps/ bin/benchmarks.ideal
-          touch -a hardware/build
-          make -C hardware/ -B simc app=benchmarks ideal_dispatcher=1 > $tempfile || exit
-          # Extract the performance
-           cycles=$(cat $tempfile | grep "\[cycles\]" | cut -d: -f2)
-          ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
-       fi
+        ./scripts/performance.py $kernel "$vsize" $cycles >> ${kernel}_${nr_lanes}_ideal.benchmark
+      fi
     done
-done
+  done
+}
+
+case $1 in
+  "matmul")
+    matmul
+    ;;
+
+  "conv2d")
+    conv2d
+    ;;
+
+  "conv3d")
+    conv3d
+    ;;
+
+  "jacobi2d")
+    jacobi2d
+    ;;
+
+  "dropout")
+    dropout
+    ;;
+
+  "fft")
+    fft
+    ;;
+
+  "dwt")
+    dwt
+    ;;
+
+  "exp")
+    exp
+    ;;
+
+  *)
+    echo "Benchmarking all the apps."
+    matmul
+    conv2d
+    conv3d
+    jacobi2d
+    dropout
+    fft
+    dwt
+    exp
+    ;;
+esac

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -66,6 +66,10 @@ def dwt(args, cycles):
     k += 1/(2**den)
   performance = 3 * k * size / cycles
   return [size, performance]
+def exp(args, cycles):
+  size        = int(args[0])
+  performance = 30 * size / cycles
+  return [size, performance]
 
 perfExtr = {
   'imatmul' : imatmul,
@@ -77,6 +81,7 @@ perfExtr = {
   'dropout' : dropout,
   'fft'     : fft,
   'dwt'     : dwt,
+  'exp'     : exp,
 }
 
 def main():


### PR DESCRIPTION
Implement floating-point exp-cos-log from the `RiVEC Benchmark Suite`: 
[RALC](https://github.com/RALC88/riscv-vectorized-benchmark-suite/tree/rvv-1.0) 

## Changelog

### Added

- Add fp-exp, fp-cos, fp-log benchmarks from `RiVEC Benchmark Suite` and print performance
- Ideal Dispatcher tracer now supports strided memory operations

### Changed

- `benchmark.sh` can now also benchmark just one app at a time via an input argument

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
