### PR TITLE
Keep the ratio `VRF_SIZE`/`NR_LANES` constant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Increase addrgen queue depth to four, to better hide memory latency
  - The RESHUFFLE state is now iterative and reshuffles all the vector registers that need this operation
  - Performance metrics are now calculated by an external performance.py script, instead of during the program simulation, which just prints out the cycle count
+ - 7x7 kernel 2dconvs now support arbitrary vector lengths
+ - Default con vlen in the config files is now NR_LANES*1024
 
 ## 2.2.0 - 2021-11-02
 

--- a/apps/fconv2d/fconv2d.h
+++ b/apps/fconv2d/fconv2d.h
@@ -31,8 +31,11 @@ void fconv2d_vec_4xC_3x3(double *o, double *i, double *f, int64_t C, int64_t F);
 
 void fconv2d_7x7(double *o, double *i, double *f, int64_t R, int64_t C,
                  int64_t F);
+void fconv2d_7x7_block(double *o, double *i, double *f, int64_t R, int64_t C,
+                       int64_t n_, int64_t F);
 
 #define FABS(x) ((x < 0) ? -x : x)
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 // Threshold for FP numbers comparison during the final check
 #define THRESHOLD 0.000000000001

--- a/apps/fconv2d/fconv2d_3x3.c
+++ b/apps/fconv2d/fconv2d_3x3.c
@@ -18,8 +18,6 @@
 
 #include "fconv2d.h"
 
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-
 void fconv2d_3x3(double *o, double *i, double *f, int64_t R, int64_t C,
                  int64_t F) {
   // We work on 4 rows of the output matrix at once

--- a/apps/iconv2d/iconv2d.h
+++ b/apps/iconv2d/iconv2d.h
@@ -37,7 +37,11 @@ void iconv2d_vec_4xC_slice_move_5x5(int64_t C, int64_t F);
 void iconv2d_vec_4xC_5x5(int64_t *o, int64_t *i, int64_t *f, int64_t C,
                          int64_t F);
 
-void iconv2d_7x7(int64_t *o, int64_t *i, int64_t *f, int64_t R, int64_t C,
+void iconv2d_7x7(int64_t *o, int64_t *i, int64_t *f, int64_t M, int64_t N,
                  int64_t F);
+void iconv2d_7x7_block(int64_t *o, int64_t *i, int64_t *f, int64_t R, int64_t C,
+                       int64_t n_, int64_t F);
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 #endif

--- a/config/16_lanes.mk
+++ b/config/16_lanes.mk
@@ -22,4 +22,4 @@ nr_lanes ?= 16
 
 # Length of each vector register (in bits)
 # Constraints: VLEN > 128
-vlen ?= 4096
+vlen ?= 16384

--- a/config/2_lanes.mk
+++ b/config/2_lanes.mk
@@ -22,4 +22,4 @@ nr_lanes ?= 2
 
 # Length of each vector register (in bits)
 # Constraints: VLEN > 128
-vlen ?= 4096
+vlen ?= 2048

--- a/config/8_lanes.mk
+++ b/config/8_lanes.mk
@@ -22,4 +22,4 @@ nr_lanes ?= 8
 
 # Length of each vector register (in bits)
 # Constraints: VLEN > 128
-vlen ?= 4096
+vlen ?= 8192


### PR DESCRIPTION
The default configuration files have a constant `VLEN`. This means that, the more the lanes, the less the buffering capability of each lane. 
Now, the default is to keep this capability constant.
Note: if the application vector length byte size is always lower than a `size_threshold`, increasing the `VLEN` above this threshold is useless.

## Changelog

### Changed

- 7x7 kernel `2dconv`s now support arbitrary vector lengths
- Default con `vlen` in the config files is now `NR_LANES*1024`

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
