### PR TITLE
[HW] Cut problematic adder path in addrgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Replace `apps/common/script/datagen.sh` with new input data source-of-truth (`apps/common/default_arguments.mk`) during app compilation
  - benchmark.sh can now also benchmark just one app at a time via an input argument
  - Adapt `fdotproduct` to `dotproduct` structure
+ - Pre-calculate next-cycle `aligned_start_address` in `addrgen` for timing reasons
 
 ## 2.2.0 - 2021-11-02
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ If you want to use Ara, you can cite us:
 ```
 @INPROCEEDINGS{9912071,
   author={Perotti, Matteo and Cavalcante, Matheus and Wistoff, Nils and Andri, Renzo and Cavigelli, Lukas and Benini, Luca},
-  booktitle={2022 IEEE 33rd International Conference on Application-specific Systems, Architectures and Processors (ASAP)}, 
-  title={A “New Ara” for Vector Computing: An Open Source Highly Efficient RISC-V V 1.0 Vector Processor Design}, 
+  booktitle={2022 IEEE 33rd International Conference on Application-specific Systems, Architectures and Processors (ASAP)},
+  title={A “New Ara” for Vector Computing: An Open Source Highly Efficient RISC-V V 1.0 Vector Processor Design},
   year={2022},
   volume={},
   number={},


### PR DESCRIPTION
Currently, the `addrgen` calculates the next aligned start address by adding +1 to the current aligned end address. 
This is redundant since, when calculating the next aligned end address, we also implicitly calculate the next start address, which can be buffered for the next cycle avoiding the expensive addition on 64 address bits.
Unluckily, the 4 KiB page checks require some additional operations. 

## Changelog

### Changed

- Buffer the next aligned start address in the `addrgen`, avoiding redundant addition on a possibly critical path.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
