### PR TITLE
[HW] Hotfix to run roi-align and lavaMD correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix `eew_vs1` for widening instructions
  - Fix cleaning of the accumulator after partial reduction in `valu`
  - De-parametrize FFT on the data-type
+ - New reductions should start only when the previous operation is over
+ - Prevent VMFPU from acknowledging the opqueues when their issue is over
+ - Operand requesters sanitize partial operands during a reduction
+ - Fix load/store-complete signals to CVA6
 
 ### Added
 
@@ -116,6 +120,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - benchmark.sh can now also benchmark just one app at a time via an input argument
  - Adapt `fdotproduct` to `dotproduct` structure
  - Pre-calculate next-cycle `aligned_start_address` in `addrgen` for timing reasons
+ - Add `is_reduct` signal to the operand queues, to gate the neutral value filling
 
 ## 2.2.0 - 2021-11-02
 

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -175,9 +175,7 @@ package ara_pkg;
     OpQueueConversionZExt8,
     OpQueueConversionSExt8,
     OpQueueConversionWideFP2,
-    OpQueueIntReductionZExt,
-    OpQueueFloatReductionZExt,
-    OpQueueFloatReductionWideZExt,
+    OpQueueReductionZExt,
     OpQueueAdjustFPCvt
   } opqueue_conversion_e;
   // OpQueueAdjustFPCvt is introduced to support widening FP conversions, to comply with the
@@ -858,8 +856,8 @@ package ara_pkg;
 
   // Differenciate between SLDU and ADDRGEN operands from opqueue
   typedef enum logic {
-    SLDU    = 1'b0,
-    ADDRGEN = 1'b1
+    ALU_SLDU     = 1'b0,
+    MFPU_ADDRGEN = 1'b1
   } target_fu_e;
 
   // This is the interface between the lane's sequencer and the operand request stage, which
@@ -872,6 +870,8 @@ package ara_pkg;
     logic scale_vl; // Rescale vl taking into account the new and old EEW
 
     resize_e cvt_resize;    // Resizing of FP conversions
+
+    logic is_reduct; // Is this a reduction?
 
     rvv_pkg::vew_e eew;        // Effective element width
     opqueue_conversion_e conv; // Type conversion
@@ -892,6 +892,7 @@ package ara_pkg;
     vlen_t vl;                 // Vector length
     opqueue_conversion_e conv; // Type conversion
     logic [1:0] ntr_red;       // Neutral type for reductions
+    logic is_reduct;           // Is this a reduction?
     target_fu_e target_fu;     // Target FU of the opqueue (if it is not clear)
   } operand_queue_cmd_t;
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -2935,6 +2935,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       load_zero_vl     = is_vload;
       store_zero_vl    = is_vstore;
     end
+
+    acc_resp_o.load_complete  = load_zero_vl  | load_complete_q;
+    acc_resp_o.store_complete = store_zero_vl | store_complete_q;
   end: p_decoder
 
 endmodule : ara_dispatcher

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -590,7 +590,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.emul           = next_lmul(vtype_q.vlmul);
                     ara_req_d.eew_vs1        = vtype_q.vsew.next();
                     ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.conversion_vs2 = OpQueueConversionZExt2;
                     ara_req_d.cvt_resize     = CVT_WIDE;
                   end
@@ -599,7 +599,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     ara_req_d.emul           = next_lmul(vtype_q.vlmul);
                     ara_req_d.eew_vs1        = vtype_q.vsew.next();
                     ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.conversion_vs2 = OpQueueConversionSExt2;
                     ara_req_d.cvt_resize     = CVT_WIDE;
                   end
@@ -1036,42 +1036,42 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   // value of each operation
                   6'b000000: begin
                     ara_req_d.op             = ara_pkg::VREDSUM;
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b00);
                   end
                   6'b000001: begin
                     ara_req_d.op             = ara_pkg::VREDAND;
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b11);
                   end
                   6'b000010: begin
                     ara_req_d.op             = ara_pkg::VREDOR;
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b00);
                   end
                   6'b000011: begin
                     ara_req_d.op             = ara_pkg::VREDXOR;
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b00);
                   end
                   6'b000100: begin
                     ara_req_d.op             = ara_pkg::VREDMINU;
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b11);
                   end
                   6'b000101: begin
                     ara_req_d.op             = ara_pkg::VREDMIN;
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b01);
                   end
                   6'b000110: begin
                     ara_req_d.op             = ara_pkg::VREDMAXU;
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b00);
                   end
                   6'b000111: begin
                     ara_req_d.op             = ara_pkg::VREDMAX;
-                    ara_req_d.conversion_vs1 = OpQueueIntReductionZExt;
+                    ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                     ara_req_d.cvt_resize     = resize_e'(2'b10);
                   end
                   6'b010000: begin // VWXUNARY0
@@ -1654,7 +1654,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     end
                     6'b000001: begin
                       ara_req_d.op             = ara_pkg::VFREDUSUM;
-                      ara_req_d.conversion_vs1 = OpQueueFloatReductionZExt;
+                      ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                       ara_req_d.swap_vs2_vd_op = 1'b1;
                       ara_req_d.cvt_resize     = resize_e'(2'b00);
                     end
@@ -1664,20 +1664,20 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     end
                     6'b000011: begin
                       ara_req_d.op             = ara_pkg::VFREDOSUM;
-                      ara_req_d.conversion_vs1 = OpQueueFloatReductionZExt;
+                      ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                       ara_req_d.swap_vs2_vd_op = 1'b1;
                       ara_req_d.cvt_resize     = resize_e'(2'b00);
                     end
                     6'b000100: ara_req_d.op = ara_pkg::VFMIN;
                     6'b000101: begin
                       ara_req_d.op             = ara_pkg::VFREDMIN;
-                      ara_req_d.conversion_vs1 = OpQueueFloatReductionZExt;
+                      ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                       ara_req_d.cvt_resize     = resize_e'(2'b01);
                     end
                     6'b000110: ara_req_d.op = ara_pkg::VFMAX;
                     6'b000111: begin
                       ara_req_d.op             = ara_pkg::VFREDMAX;
-                      ara_req_d.conversion_vs1 = OpQueueFloatReductionZExt;
+                      ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                       ara_req_d.cvt_resize     = resize_e'(2'b10);
                     end
                     6'b001000: ara_req_d.op = ara_pkg::VFSGNJ;
@@ -1890,7 +1890,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       ara_req_d.swap_vs2_vd_op = 1'b1;
                       ara_req_d.emul           = next_lmul(vtype_q.vlmul);
                       ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                      ara_req_d.conversion_vs1 = OpQueueFloatReductionWideZExt;
+                      ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                       ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
                       ara_req_d.eew_vs1        = vtype_q.vsew.next();
                       ara_req_d.cvt_resize     = resize_e'(2'b00);
@@ -1908,7 +1908,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       ara_req_d.swap_vs2_vd_op = 1'b1;
                       ara_req_d.emul           = next_lmul(vtype_q.vlmul);
                       ara_req_d.vtype.vsew     = vtype_q.vsew.next();
-                      ara_req_d.conversion_vs1 = OpQueueFloatReductionWideZExt;
+                      ara_req_d.conversion_vs1 = OpQueueReductionZExt;
                       ara_req_d.conversion_vs2 = OpQueueConversionWideFP2;
                       ara_req_d.eew_vs1        = vtype_q.vsew.next();
                       ara_req_d.cvt_resize     = resize_e'(2'b00);

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -242,7 +242,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vs         : pe_req.vs1,
             eew        : pe_req.eew_vs1,
             // If reductions and vl == 0, we must replace with neutral values
-            conv       : (vfu_operation_d.vl == '0) ? OpQueueIntReductionZExt : pe_req.conversion_vs1,
+            conv       : (vfu_operation_d.vl == '0) ? OpQueueReductionZExt : pe_req.conversion_vs1,
             scale_vl   : pe_req.scale_vl,
             cvt_resize : pe_req.cvt_resize,
             vtype      : pe_req.vtype,
@@ -250,6 +250,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vl         : (pe_req.op inside {[VREDSUM:VWREDSUM]}) ? 1 : vfu_operation_d.vl,
             vstart     : vfu_operation_d.vstart,
             hazard     : pe_req.hazard_vs1 | pe_req.hazard_vd,
+            is_reduct  : pe_req.op inside {[VREDSUM:VWREDSUM]} ? 1'b1 : 0,
+            target_fu  : ALU_SLDU,
             default    : '0
           };
           operand_request_push[AluA] = pe_req.use_vs1;
@@ -259,7 +261,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vs         : pe_req.vs2,
             eew        : pe_req.eew_vs2,
             // If reductions and vl == 0, we must replace with neutral values
-            conv       : (vfu_operation_d.vl == '0) ? OpQueueIntReductionZExt : pe_req.conversion_vs2,
+            conv       : (vfu_operation_d.vl == '0) ? OpQueueReductionZExt : pe_req.conversion_vs2,
             scale_vl   : pe_req.scale_vl,
             cvt_resize : pe_req.cvt_resize,
             vtype      : pe_req.vtype,
@@ -269,6 +271,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
                          ? 1 : vfu_operation_d.vl,
             vstart     : vfu_operation_d.vstart,
             hazard     : pe_req.hazard_vs2 | pe_req.hazard_vd,
+            is_reduct  : pe_req.op inside {[VREDSUM:VWREDSUM]} ? 1'b1 : 0,
+            target_fu  : ALU_SLDU,
             default    : '0
           };
           operand_request_push[AluB] = pe_req.use_vs2;
@@ -305,6 +309,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vl         : (pe_req.op inside {[VFREDUSUM:VFWREDOSUM]}) ? 1 : vfu_operation_d.vl,
             vstart     : vfu_operation_d.vstart,
             hazard     : pe_req.hazard_vs1 | pe_req.hazard_vd,
+            is_reduct  : pe_req.op inside {[VFREDUSUM:VFWREDOSUM]} ? 1'b1 : 0,
+            target_fu  : MFPU_ADDRGEN,
             default    : '0
           };
           operand_request_push[MulFPUA] = pe_req.use_vs1;
@@ -325,6 +331,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vstart     : vfu_operation_d.vstart,
             hazard     : (pe_req.swap_vs2_vd_op ?
             pe_req.hazard_vd : (pe_req.hazard_vs2 | pe_req.hazard_vd)),
+            is_reduct  : pe_req.op inside {[VFREDUSUM:VFWREDOSUM]} ? 1'b1 : 0,
+            target_fu  : MFPU_ADDRGEN,
             default: '0
           };
           operand_request_push[MulFPUB] = pe_req.swap_vs2_vd_op ?
@@ -345,6 +353,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vtype      : pe_req.vtype,
             hazard     : pe_req.swap_vs2_vd_op ?
             (pe_req.hazard_vs2 | pe_req.hazard_vd) : pe_req.hazard_vd,
+            is_reduct  : pe_req.op inside {[VFREDUSUM:VFWREDOSUM]} ? 1'b1 : 0,
+            target_fu  : MFPU_ADDRGEN,
             default : '0
           };
           operand_request_push[MulFPUC] = pe_req.swap_vs2_vd_op ?
@@ -391,7 +401,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vs       : pe_req_i.vs2,
             eew      : pe_req_i.eew_vs2,
             conv     : pe_req_i.conversion_vs2,
-            target_fu: ADDRGEN,
+            target_fu: MFPU_ADDRGEN,
             vl       : pe_req_i.vl / NrLanes,
             scale_vl : pe_req_i.scale_vl,
             vstart   : vfu_operation_d.vstart,
@@ -447,7 +457,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vs       : pe_req_i.vs2,
             eew      : pe_req_i.eew_vs2,
             conv     : pe_req_i.conversion_vs2,
-            target_fu: ADDRGEN,
+            target_fu: MFPU_ADDRGEN,
             vl       : pe_req_i.vl / NrLanes,
             scale_vl : pe_req_i.scale_vl,
             vstart   : vfu_operation_d.vstart,
@@ -468,7 +478,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             vs       : pe_req.vs2,
             eew      : pe_req.eew_vs2,
             conv     : pe_req.conversion_vs2,
-            target_fu: SLDU,
+            target_fu: ALU_SLDU,
             scale_vl : pe_req.scale_vl,
             vtype    : pe_req.vtype,
             vstart   : vfu_operation_d.vstart,

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -57,7 +57,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .NrLanes       (NrLanes   ),
     .SupportIntExt2(1'b1      ),
     .SupportIntExt4(1'b1      ),
-    .SupportIntExt8(1'b1      )
+    .SupportIntExt8(1'b1      ),
+    .SupportReduct (1'b1      ),
+    .SupportNtrVal (1'b0      )
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -80,7 +82,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .NrLanes       (NrLanes   ),
     .SupportIntExt2(1'b1      ),
     .SupportIntExt4(1'b1      ),
-    .SupportIntExt8(1'b1      )
+    .SupportIntExt8(1'b1      ),
+    .SupportReduct (1'b1      ),
+    .SupportNtrVal (1'b1      )
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -105,7 +109,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .BufferDepth   (5         ),
     .FPUSupport    (FPUSupport),
     .NrLanes       (NrLanes   ),
-    .SupportIntExt2(1'b1      )
+    .SupportIntExt2(1'b1      ),
+    .SupportReduct (1'b1      ),
+    .SupportNtrVal (1'b0      )
   ) i_operand_queue_mfpu_a (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -126,7 +132,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .BufferDepth   (5         ),
     .FPUSupport    (FPUSupport),
     .NrLanes       (NrLanes   ),
-    .SupportIntExt2(1'b1      )
+    .SupportIntExt2(1'b1      ),
+    .SupportReduct (1'b1      ),
+    .SupportNtrVal (1'b1      )
   ) i_operand_queue_mfpu_b (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -147,7 +155,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .BufferDepth   (5         ),
     .FPUSupport    (FPUSupport),
     .NrLanes       (NrLanes   ),
-    .SupportIntExt2(1'b1      )
+    .SupportIntExt2(1'b1      ),
+    .SupportReduct (1'b1      ),
+    .SupportNtrVal (1'b1      )
   ) i_operand_queue_mfpu_c (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),

--- a/hardware/src/lane/operand_requester.sv
+++ b/hardware/src/lane/operand_requester.sv
@@ -302,7 +302,8 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
                            operand_request_i[requester].vl,
               conv     : operand_request_i[requester].conv,
               ntr_red  : operand_request_i[requester].cvt_resize,
-              target_fu: operand_request_i[requester].target_fu
+              target_fu: operand_request_i[requester].target_fu,
+              is_reduct: operand_request_i[requester].is_reduct
             };
             // The length should be at least one after the rescaling
             if (operand_queue_cmd_o[requester].vl == '0)
@@ -390,7 +391,8 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
                                operand_request_i[requester].vl,
                   conv     : operand_request_i[requester].conv,
                   ntr_red  : operand_request_i[requester].cvt_resize,
-                  target_fu: operand_request_i[requester].target_fu
+                  target_fu: operand_request_i[requester].target_fu,
+                  is_reduct: operand_request_i[requester].is_reduct
                 };
                 operand_queue_cmd_valid_o[requester] = 1'b1;
                 // The length should be at least one after the rescaling

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -1325,7 +1325,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
               operands_valid = 1'b0;
             end
           end else if (ntr_filling_q) begin
-            if (((vinsn_issue_q.swap_vs2_vd_op ? mfpu_operand_valid_i[2] : mfpu_operand_valid_i[1]) && intra_op_rx_cnt_q != vinsn_issue_q.vl) &&
+            if (((vinsn_issue_q.swap_vs2_vd_op ? mfpu_operand_valid_i[2] : mfpu_operand_valid_i[1]) && intra_op_rx_cnt_q < vinsn_issue_q.vl) &&
                 (mask_valid_i || vinsn_issue_q.vm)) begin
               intra_op_rx_cnt_en   = 1'b1;
               vfpu_tag_in          = strb_t'(1);
@@ -1341,7 +1341,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
             // The second operand is the result of the previous operation
             // In case there is no data from the operand queue, first check if there are two valid results,
             // if not, stop issuing.
-            if (((vinsn_issue_q.swap_vs2_vd_op ? mfpu_operand_valid_i[2] : mfpu_operand_valid_i[1]) && intra_op_rx_cnt_q != vinsn_issue_q.vl) &&
+            if (((vinsn_issue_q.swap_vs2_vd_op ? mfpu_operand_valid_i[2] : mfpu_operand_valid_i[1]) && intra_op_rx_cnt_q < vinsn_issue_q.vl) &&
                (mask_valid_i || vinsn_issue_q.vm)) begin
               // Take result_queue_q first
               if (first_result_op_valid_q) begin

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -315,7 +315,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
         // Are we ready?
         // During a reduction (vinsn_issue_q.vfu == VFU_Alu/VFU_MFPU) don't wait for mask bits
         if ((&sldu_operand_valid_i || (((vinsn_issue_q.stride >> vinsn_issue_q.vtype.vsew) >= vinsn_issue_q.vl) && (state_q == SLIDE_RUN_VSLIDE1UP_FIRST_WORD))) &&
-          (sldu_operand_target_fu_i[0] == SLDU || is_issue_reduction) && !result_queue_full && (vinsn_issue_q.vm || vinsn_issue_q.vfu inside {VFU_Alu, VFU_MFpu} || (|mask_valid_i)))
+          (sldu_operand_target_fu_i[0] == ALU_SLDU || is_issue_reduction) && !result_queue_full && (vinsn_issue_q.vm || vinsn_issue_q.vfu inside {VFU_Alu, VFU_MFpu} || (|mask_valid_i)))
         begin
           // How many bytes are we copying from the operand to the destination, in this cycle?
           automatic int in_byte_count = NrLanes * 8 - in_pnt_q;

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -278,7 +278,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
         // Handle handshake and data between VRF and spill register
         // We accept all the incoming data, without any checks
         // since Ara stalls on an indexed memory operation
-        if (&addrgen_operand_valid_i & addrgen_operand_target_fu_i[0] == ADDRGEN) begin
+        if (&addrgen_operand_valid_i & addrgen_operand_target_fu_i[0] == MFPU_ADDRGEN) begin
 
           // Valid data for the spill register
           idx_addr_valid_d = 1'b1;


### PR DESCRIPTION
Various hotfixes, especially around the FPU reductions.

## Changelog

### Fixed

- New reductions should start only when previous operation is over
- Prevent VMFPU from ack the opqueues when their issue is over
- Operand requesters sanitize the partial operands
- Fix load/store-complete signals to CVA6

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

