### PR TITLE
[HW] Add support for vcpop and vfirst instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add Pathfinder `app` and `benchmark`, and plot its performance
  - Add Roi-Align `app` and `benchmark`, and plot its performance
  - Support for vector mask instructions: `vmsbf`, `vmsof`, `vmsif`, `viota`, `vid`
+ - Add support for vector mask population count and find first set bit instructions: `vcpop.m`, `vfirst.m`
 
 ### Changed
 

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -66,6 +66,7 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 
 - Vector mask-register logical instructions: `vmand`, `vmnand`, `vmandnot`, `vmxor`, `vmor`, `vmnor`, `vmornot`, `vmxnor`
 - Vector mask instructions: `vmsbf`, `vmsof`, `vmsif`, `viota`, `vid`
+- Vector mask population count and find first set bit instructions: `vcpop.m`, `vfirst.m`
 
 ## Vector permutation instructions
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -150,7 +150,9 @@ rv64uv_sc_tests = vadd \
                   vmsof \
                   vmsif \
                   viota \
-                  vid
+                  vid \
+                  vcpop \
+                  vfirst
 
 #rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfirst vid viota vl vlff vl_nocheck vlx vmsbf vmsif vmsof vpopc_m vrgather vsadd vsaddu vsetvl vsetivli vsetvli vsmul vssra vssrl vssub vssubu vsux vsx
 

--- a/apps/riscv-tests/isa/rv64uv/vcpop.c
+++ b/apps/riscv-tests/isa/rv64uv/vcpop.c
@@ -1,0 +1,45 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "vector_macros.h"
+
+// masked
+void TEST_CASE1(void) {
+  VSET(4, e32, m1);
+  VCLEAR(v2);
+  VLOAD_32(v2, 7, 0, 0, 0);
+  VLOAD_32(v0, 5, 0, 0, 0);
+  volatile uint32_t scalar = 1337;
+  volatile uint32_t OUP[] = {0, 0, 0, 0};
+  __asm__ volatile("vpopc.m %[A], v2, v0.t \n"
+                   "sw %[A], (%1) \n"
+                   :
+                   : [A] "r"(scalar), "r"(OUP));
+  XCMP(1, OUP[0], 2);
+}
+
+// unmasked
+void TEST_CASE2(void) {
+  VSET(4, e32, m1);
+  VLOAD_32(v2, 0xF, 0, 0, 0);
+  volatile uint32_t scalar = 1337;
+  volatile uint32_t OUP[] = {0, 0, 0, 0};
+  __asm__ volatile("vpopc.m %[A], v2 \n"
+                   "sw %[A], (%1) \n"
+                   :
+                   : [A] "r"(scalar), "r"(OUP));
+  XCMP(2, OUP[0], 4);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  enable_fp();
+  TEST_CASE1();
+  TEST_CASE2();
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vfirst.c
+++ b/apps/riscv-tests/isa/rv64uv/vfirst.c
@@ -9,8 +9,8 @@
 
 void TEST_CASE1() {
   VSET(4, e32, m1);
-  VLOAD_U32(v2, 3);
-  VLOAD_U32(v0, 2, 0, 0, 0);
+  VLOAD_32(v2, 3);
+  VLOAD_32(v0, 2, 0, 0, 0);
   volatile uint32_t scalar = 1337;
   volatile uint32_t OUP[] = {0};
   __asm__ volatile("vfirst.m %[A], v2, v0.t \n"
@@ -22,8 +22,8 @@ void TEST_CASE1() {
 
 void TEST_CASE2() {
   VSET(4, e32, m1);
-  VLOAD_U32(v2, 1, 2, 3, 4);
-  VLOAD_U32(v0, 0, 0, 0, 0);
+  VLOAD_32(v2, 1, 2, 3, 4);
+  VLOAD_32(v0, 0, 0, 0, 0);
   volatile int32_t scalar = 1337;
   volatile int32_t OUP[] = {0};
   __asm__ volatile("vfirst.m %[A], v2, v0.t \n"

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -122,7 +122,7 @@ package ara_pkg;
     // Floating-point comparison instructions
     VMFEQ, VMFLE, VMFLT, VMFNE, VMFGT, VMFGE,
     // Integer comparison instructions
-    VMSEQ, VMSNE, VMSLTU, VMSLT, VMSLEU, VMSLE, VMSGTU, VMSBF, VMSOF, VMSIF, VIOTA, VID, VMSGT,
+    VMSEQ, VMSNE, VMSLTU, VMSLT, VMSLEU, VMSLE, VMSGTU, VMSBF, VMSOF, VMSIF, VIOTA, VID, VCPOP, VFIRST, VMSGT,
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
     // Mask operations
@@ -146,6 +146,11 @@ package ara_pkg;
   function automatic is_store(ara_op_e op);
     is_store = op inside {[VSE:VSXE]};
   endfunction : is_store
+
+  // Return true of op is either VCPOP or VFIRST
+  function automatic vd_scalar(ara_op_e op);
+    vd_scalar = op inside {[VCPOP:VFIRST]};
+  endfunction : vd_scalar
 
   typedef enum logic [1:0] {
     NO_RED,

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -141,6 +141,10 @@ module ara import ara_pkg::*; #(
   logic                                        mask_valid_lane;
   logic      [NrLanes-1:0]                     lane_mask_ready;
 
+  // Mask unit scalar result variables
+  elen_t     result_scalar;
+  logic      result_scalar_valid;
+
   ara_sequencer #(.NrLanes(NrLanes)) i_sequencer (
     .clk_i                 (clk_i                    ),
     .rst_ni                (rst_ni                   ),
@@ -162,8 +166,8 @@ module ara import ara_pkg::*; #(
     // Interface with the operand requesters
     .global_hazard_table_o (global_hazard_table      ),
     // Interface with the lane 0
-    .pe_scalar_resp_i      (masku_operand[0][1]      ), // MaskB OpQueue
-    .pe_scalar_resp_valid_i(masku_operand_valid[0][1]), // MaskB OpQueue Valid
+    .pe_scalar_resp_i      (pe_req.op inside{[VCPOP:VFIRST]} ? result_scalar : masku_operand[0][1]), // MaskB OpQueue
+    .pe_scalar_resp_valid_i(pe_req.op inside{[VCPOP:VFIRST]} ? result_scalar_valid : masku_operand_valid[0][1]), // MaskB OpQueue Valid
     .pe_scalar_resp_ready_o(pe_scalar_resp_ready     ),
     // Interface with the address generator
     .addrgen_ack_i         (addrgen_ack              ),
@@ -411,6 +415,8 @@ module ara import ara_pkg::*; #(
     .pe_vinsn_running_i      (pe_vinsn_running                ),
     .pe_req_ready_o          (pe_req_ready[NrLanes+OffsetMask]),
     .pe_resp_o               (pe_resp[NrLanes+OffsetMask]     ),
+    .result_scalar_o         (result_scalar                   ),
+    .result_scalar_valid_o   (result_scalar_valid             ),
     // Interface with the lanes
     .masku_operand_i         (masku_operand                   ),
     .masku_operand_valid_i   (masku_operand_valid             ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1080,9 +1080,23 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     acc_req_ready_o  = 1'b0;
                     acc_resp_valid_o = 1'b0;
 
-                    ara_req_d.op         = ara_pkg::VMVXS;
+                    case (insn.varith_type.rs1)
+                      5'b00000: begin
+                        ara_req_d.op      = ara_pkg::VMVXS;
+                        ara_req_d.vl      = 1;
+                      end
+                      5'b10000: begin
+                        ara_req_d.op      = ara_pkg::VCPOP;
+                        ara_req_d.use_vs1 = 1'b0;
+                      end
+                      5'b10001: begin
+                        ara_req_d.op      = ara_pkg::VFIRST;
+                        ara_req_d.use_vs1 = 1'b0;
+                      end
+                      default :;
+                    endcase
+
                     ara_req_d.use_vd     = 1'b0;
-                    ara_req_d.vl         = 1;
                     ara_req_d.vstart     = '0;
                     skip_lmul_checks     = 1'b1;
                     ignore_zero_vl_check = 1'b1;

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -114,6 +114,9 @@ module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
         // vmsbf, vmsof, vmsif and viota operand generation
         VMSBF, VMSOF, VMSIF, VIOTA : res = opb;
 
+	      // Vector count population and find first set bit instructions
+        VCPOP, VFIRST : res = operand_b_i;
+
         // Arithmetic instructions
         VADD, VADC, VMADC, VREDSUM, VWREDSUMU, VWREDSUM: unique case (vew_i)
             EW8: for (int b = 0; b < 8; b++) begin


### PR DESCRIPTION
Added support for vector population count `vcpop` and vector find first set bit `vfirst` instructions

## Changelog

### Fixed

- N/A

### Added

- Support for vector population count `vcpop` and vector find first set bit `vfirst` instructions
- Test for  vector population count `vcpop` instruction

### Changed

- Test for find first set bit `vfirst` instruction

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
