### PR TITLE
[HW, SW] Add Power Analysis feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add optimized ASM version of `roi_align`
  - Add support for cache warming before benchmarks
  - Add support to check the results of the ideal dispatcher runs
+ - Add HW/SW environment for automatic VCD dumping
 
 ### Changed
 
@@ -149,6 +150,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - All the data-gen scripts generate now random data
  - Patch `riscv-tests` `crt0.S` also before compiling `riscv-tests`
  - Almost align all the vector/matrix sizes in `benchmark.sh`
+ - Generate data for `fmatmul` at compile time
+ - SIMD multipliers are now power gated
 
 ## 2.2.0 - 2021-11-02
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ cd hardware
 make sim app=${program} ideal_dispatcher=1
 ```
 
+### VCD Dumping
+
+It's possible to dump VCD files for accurate activity-based power analyses. To do so, use the `vcd_dump=1` option to compile the program and to run the simulation:
+
+```bash
+make -C apps bin/${program} vcd_dump=1
+make -C hardware simc app=${program} vcd_dump=1
+```
+
+Currently, the following kernels support automatic VCD dumping: `fmatmul`, `fconv3d`, `fft`, `dwt`, `exp`, `cos`, `log`, `dropout`, `jacobi2d`.
+
 ### Linting Flow
 
 We also provide Synopsys Spyglass linting scripts in the hardware/spyglass. Run make lint in the hardware folder, with a specific MemPool configuration, to run the tests associated with the lint_rtl target.

--- a/apps/common/arch.link.ld
+++ b/apps/common/arch.link.ld
@@ -54,7 +54,8 @@ SECTIONS {
   eoc_address_reg        = 0xD0000000;
   dram_start_address_reg = 0xD0000008;
   dram_end_address_reg   = 0xD0000010;
-  hw_cnt_en_reg          = 0xD0000018;
+  event_trigger          = 0xD0000018;
+  hw_cnt_en_reg          = 0xD0000020;
 
   fake_uart              = 0xC0000000;
 }

--- a/apps/common/runtime.h
+++ b/apps/common/runtime.h
@@ -7,6 +7,7 @@
   asm volatile(                                                                \
       "csrs mstatus, %[bits];" ::[bits] "r"(0x00000600 & (0x00000600 >> 1)))
 
+extern int64_t event_trigger;
 extern int64_t timer;
 // SoC-level CSR
 extern uint64_t hw_cnt_en_reg;

--- a/apps/common/runtime.mk
+++ b/apps/common/runtime.mk
@@ -73,6 +73,9 @@ PYTHON ?= python3
 
 # Defines
 ENV_DEFINES ?=
+ifeq ($(vcd_dump),1)
+ENV_DEFINES += -DVCD_DUMP=1
+endif
 MAKE_DEFINES = -DNR_LANES=$(nr_lanes) -DVLEN=$(vlen)
 DEFINES += $(ENV_DEFINES) $(MAKE_DEFINES)
 

--- a/apps/common/util.h
+++ b/apps/common/util.h
@@ -18,8 +18,31 @@
 //
 // Utility functions for Ara software environment (header file)
 
-#ifndef _UTIL_H_
-#define _UTIL_H_
+#ifndef __UTIL_H__
+#define __UTIL_H__
+
+#ifdef GATE_SIM
+#define NO_PRINTF
+#endif
+
+#ifdef VCD_DUMP
+#define NO_PRINTF
+#define NO_TIMER
+#endif
+
+// Don't measure performance
+#ifdef NO_TIMER
+#define start_timer()
+#define stop_timer()
+#define get_timer() 0
+#endif
+
+// Don't print anything
+#ifdef NO_PRINTF
+#define printf_(...)
+#endif
+
+#define FABS(x) ((x < 0) ? -x : x)
 
 #define FABS(x) ((x < 0) ? -x : x)
 #define MIN(a, b) ((a) <= (b) ? (a) : (b))

--- a/apps/common/util.h
+++ b/apps/common/util.h
@@ -26,6 +26,7 @@
 #endif
 
 #ifdef VCD_DUMP
+#pragma message("VCD_DUMP successfully initialized")
 #define NO_PRINTF
 #define NO_TIMER
 #endif

--- a/apps/cos/kernel/cos.c
+++ b/apps/cos/kernel/cos.c
@@ -23,6 +23,10 @@ void cos_1xf64_bmark(double *angles, double *results, size_t len) {
   size_t avl = len;
   vfloat64m1_t cos_vec, res_vec;
 
+#ifdef VCD_DUMP
+  // Start dumping VCD
+  event_trigger = +1;
+#endif
   for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
     // Strip-mine
     vl = vsetvl_e64m1(avl);
@@ -36,6 +40,10 @@ void cos_1xf64_bmark(double *angles, double *results, size_t len) {
     angles += vl;
     results += vl;
   }
+#ifdef VCD_DUMP
+  // Stop dumping VCD
+  event_trigger = -1;
+#endif
 }
 
 void cos_2xf32_bmark(float *angles, float *results, size_t len) {
@@ -43,6 +51,10 @@ void cos_2xf32_bmark(float *angles, float *results, size_t len) {
   size_t avl = len;
   vfloat32m1_t cos_vec, res_vec;
 
+#ifdef VCD_DUMP
+  // Start dumping VCD
+  event_trigger = +1;
+#endif
   for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
     // Strip-mine
     vl = vsetvl_e32m1(avl);
@@ -56,4 +68,8 @@ void cos_2xf32_bmark(float *angles, float *results, size_t len) {
     angles += vl;
     results += vl;
   }
+#ifdef VCD_DUMP
+  // Stop dumping VCD
+  event_trigger = -1;
+#endif
 }

--- a/apps/dropout/kernel/dropout.c
+++ b/apps/dropout/kernel/dropout.c
@@ -64,6 +64,11 @@ void dropout_vec(const unsigned int n, const float *i, const float scale,
                : [vl] "=r"(vl)
                : [n] "r"(n));
 
+#ifdef VCD_DUMP
+  // Start dumping VCD
+  event_trigger = +1;
+#endif
+
   for (unsigned int avl = n; avl > 0; avl -= vl) {
     // Find next vl
     asm volatile("vsetvli %[vl], %[avl], e32, m8, ta, ma"
@@ -83,5 +88,10 @@ void dropout_vec(const unsigned int n, const float *i, const float scale,
     sel_ptr += vl >> 3;
     o += vl;
   }
+
+#ifdef VCD_DUMP
+  // Stop dumping VCD
+  event_trigger = -1;
+#endif
 }
 #endif

--- a/apps/dwt/kernel/wavelet.c
+++ b/apps/dwt/kernel/wavelet.c
@@ -20,6 +20,8 @@
 #include "wavelet.h"
 #include <stdio.h>
 
+extern int64_t event_trigger;
+
 static inline void dwt_step(const gsl_wavelet *w, float *a, size_t n,
                             float *buf) {
   size_t i, ii;
@@ -152,6 +154,14 @@ void gsl_wavelet_transform_vector(float *data, size_t n, float *buf,
   w->offset = 0;
 
   for (i = n; i >= 2; i >>= 1) {
+#ifdef VCD_DUMP
+    // Start dumping VCD
+    if (i == n)
+      event_trigger = +1;
+    // Stop dumping VCD
+    if (i == (n >> 1))
+      event_trigger = -1;
+#endif
     dwt_step_vector(w, data, i, buf);
     if (first_iter_only)
       i = 0;

--- a/apps/exp/kernel/exp.c
+++ b/apps/exp/kernel/exp.c
@@ -40,6 +40,10 @@ void exp_1xf64_bmark(double *exponents, double *results, size_t len) {
   size_t avl = len;
   vfloat64m1_t exp_vec, res_vec;
 
+#ifdef VCD_DUMP
+  // Start dumping VCD
+  event_trigger = +1;
+#endif
   for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
     // Strip-mine
     vl = vsetvl_e64m1(avl);
@@ -53,6 +57,10 @@ void exp_1xf64_bmark(double *exponents, double *results, size_t len) {
     exponents += vl;
     results += vl;
   }
+#ifdef VCD_DUMP
+  // Stop dumping VCD
+  event_trigger = -1;
+#endif
 }
 
 void exp_2xf32_bmark(float *exponents, float *results, size_t len) {
@@ -60,6 +68,10 @@ void exp_2xf32_bmark(float *exponents, float *results, size_t len) {
   size_t avl = len;
   vfloat32m1_t exp_vec, res_vec;
 
+#ifdef VCD_DUMP
+  // Start dumping VCD
+  event_trigger = +1;
+#endif
   for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
     // Strip-mine
     vl = vsetvl_e32m1(avl);
@@ -73,6 +85,10 @@ void exp_2xf32_bmark(float *exponents, float *results, size_t len) {
     exponents += vl;
     results += vl;
   }
+#ifdef VCD_DUMP
+  // Stop dumping VCD
+  event_trigger = -1;
+#endif
 }
 
 // Intermix the instructions

--- a/apps/fconv3d/fconv3d_3x7x7.c
+++ b/apps/fconv3d/fconv3d_3x7x7.c
@@ -50,6 +50,8 @@
 
 #include "fconv3d.h"
 
+extern int64_t event_trigger;
+
 void fconv3d_CHx7x7(double *o, double *i, double *f, int64_t M, int64_t N,
                     int64_t C, int64_t F) {
 
@@ -407,6 +409,11 @@ void fconv3d_CHx7x7_block(double *o, double *i, double *f, int64_t M, int64_t N,
   // outside of this loop) (We keep F rows outside because of the unrolling by
   // 2, just for easeness)
   for (int j = 0; j < ((M + F - 1) - 2 * F) / 2; ++j) {
+#ifdef VCD_DUMP
+    // Start dumping VCD
+    event_trigger = +1;
+#endif
+
     // Work on F output rows
 
     // Loop on the channels
@@ -525,6 +532,11 @@ void fconv3d_CHx7x7_block(double *o, double *i, double *f, int64_t M, int64_t N,
 
     // Bump the input ptr
     i_ += N + F - 1;
+
+#ifdef VCD_DUMP
+    // Stop dumping VCD
+    event_trigger = -1;
+#endif
 
     //////////////
     // UNROLL 1 //

--- a/apps/fft/kernel/fft.c
+++ b/apps/fft/kernel/fft.c
@@ -25,7 +25,9 @@
 
 #define DEBUG
 
-/////////////////
+extern int64_t event_trigger;
+
+////////////////
 // FIXED-POINT //
 /////////////////
 
@@ -653,6 +655,14 @@ void fft_r2dif_vec(float *samples_re, float *samples_im,
 
   // Butterfly until the end
   for (unsigned int i = 1; i < log2_nfft; ++i) {
+#ifdef VCD_DUMP
+    // Start dumping VCD
+    if (i == 1)
+      event_trigger = +1;
+    // Stop dumping VCD
+    if (i == 3)
+      event_trigger = -1;
+#endif
     // Bump the twiddle pointers.
     twiddles_re += vl;
     twiddles_im += vl;

--- a/apps/fft/main.c
+++ b/apps/fft/main.c
@@ -107,6 +107,9 @@ int main() {
   // DIF FFT //
   /////////////
 
+  int64_t runtime;
+
+#ifndef VCD_DUMP
 #ifdef DEBUG
   printf("Intermediate butterfly outputs:\n");
   for (int k = 0; k < (31 - __builtin_clz(NFFT)) + 2; ++k) {
@@ -130,7 +133,7 @@ int main() {
   printf("Initializing Inputs for DIF\n");
 
   // Performance metrics
-  int64_t runtime = get_timer();
+  runtime = get_timer();
   printf("The DIF execution took %d cycles.\n", runtime);
 
   /////////////
@@ -154,7 +157,7 @@ int main() {
   // Performance metrics
   runtime = get_timer();
   printf("The DIT execution took %d cycles.\n", runtime);
-
+#endif
   ////////////////////
   // Vector DIF FFT //
   ////////////////////

--- a/apps/fmatmul/kernel/fmatmul.c
+++ b/apps/fmatmul/kernel/fmatmul.c
@@ -107,6 +107,13 @@ void fmatmul_vec_4x4(double *c, const double *a, const double *b,
   unsigned long int n = 0;
 
   while (n != N) {
+#ifdef VCD_DUMP
+    // Start dumping VCD
+    if (n == 8)  event_trigger = +1;
+    // Stop dumping VCD
+    if (n == 12) event_trigger = -1;
+#endif
+
     // Calculate pointer to the matrix A
     a = a_ + ++n;
 
@@ -232,6 +239,13 @@ void fmatmul_vec_8x8(double *c, const double *a, const double *b,
   unsigned long int n = 0;
 
   while (n != N) {
+#ifdef VCD_DUMP
+    // Start dumping VCD
+    if (n == 8)  event_trigger = +1;
+    // Stop dumping VCD
+    if (n == 12) event_trigger = -1;
+#endif
+
     // Calculate pointer to the matrix A
     a = a_ + ++n;
 
@@ -401,6 +415,13 @@ void fmatmul_vec_16x16(double *c, const double *a, const double *b,
   unsigned long int n = 0;
 
   while (n != N) {
+#ifdef VCD_DUMP
+    // Start dumping VCD
+    if (n == 8)  event_trigger = +1;
+    // Stop dumping VCD
+    if (n == 12) event_trigger = -1;
+#endif
+
     // Calculate pointer to the matrix A
     a = a_ + ++n;
 

--- a/apps/fmatmul/kernel/fmatmul.c
+++ b/apps/fmatmul/kernel/fmatmul.c
@@ -109,9 +109,11 @@ void fmatmul_vec_4x4(double *c, const double *a, const double *b,
   while (n != N) {
 #ifdef VCD_DUMP
     // Start dumping VCD
-    if (n == 8)  event_trigger = +1;
+    if (n == 8)
+      event_trigger = +1;
     // Stop dumping VCD
-    if (n == 12) event_trigger = -1;
+    if (n == 12)
+      event_trigger = -1;
 #endif
 
     // Calculate pointer to the matrix A
@@ -241,9 +243,11 @@ void fmatmul_vec_8x8(double *c, const double *a, const double *b,
   while (n != N) {
 #ifdef VCD_DUMP
     // Start dumping VCD
-    if (n == 8)  event_trigger = +1;
+    if (n == 8)
+      event_trigger = +1;
     // Stop dumping VCD
-    if (n == 12) event_trigger = -1;
+    if (n == 12)
+      event_trigger = -1;
 #endif
 
     // Calculate pointer to the matrix A
@@ -417,9 +421,11 @@ void fmatmul_vec_16x16(double *c, const double *a, const double *b,
   while (n != N) {
 #ifdef VCD_DUMP
     // Start dumping VCD
-    if (n == 8)  event_trigger = +1;
+    if (n == 8)
+      event_trigger = +1;
     // Stop dumping VCD
-    if (n == 12) event_trigger = -1;
+    if (n == 12)
+      event_trigger = -1;
 #endif
 
     // Calculate pointer to the matrix A

--- a/apps/fmatmul/kernel/fmatmul.h
+++ b/apps/fmatmul/kernel/fmatmul.h
@@ -44,4 +44,8 @@ void fmatmul_vec_16x16_slice_init();
 void fmatmul_vec_16x16(double *c, const double *a, const double *b,
                        unsigned long int n, unsigned long int p);
 
+#define DELTA 0.000001
+
+extern int64_t event_trigger;
+
 #endif

--- a/apps/fmatmul/main.c
+++ b/apps/fmatmul/main.c
@@ -16,8 +16,8 @@
 
 // Author: Matheus Cavalcante, ETH Zurich
 //         Samuel Riedel, ETH Zurich
+//         Matteo Perotti, ETH Zurich
 
-#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -65,7 +65,12 @@ int main() {
   printf("\n");
   printf("\n");
 
-  for (int s = 4; s <= M; s *= 2) {
+#ifdef VCD_DUMP
+  // Measure only the full-size matmul
+  for (uint64_t s = M; s <= M; s *= 2) {
+#else
+  for (uint64_t s = 4; s <= M; s *= 2) {
+#endif
     printf("\n");
     printf("------------------------------------------------------------\n");
     printf("Calculating a (%d x %d) x (%d x %d) matrix multiplication...\n", s,

--- a/apps/jacobi2d/kernel/jacobi2d.c
+++ b/apps/jacobi2d/kernel/jacobi2d.c
@@ -170,6 +170,14 @@ void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
     der_0 = A[1 * c + j + gvl];
 
     for (uint32_t i = 1; i <= size_y; i += 3) {
+#ifdef VCD_DUMP
+      // Start dumping VCD
+      if (i == 7)
+        event_trigger = +1;
+      // Stop dumping VCD
+      if (i == 13)
+        event_trigger = -1;
+#endif
       asm volatile("vfslide1up.vf v24, v4, %0" ::"f"(izq_0));
       asm volatile("vfslide1down.vf v28, v4, %0" ::"f"(der_0));
       asm volatile("vfadd.vv v12, v4, v0");   // middle - top

--- a/apps/jacobi2d/kernel/jacobi2d.h
+++ b/apps/jacobi2d/kernel/jacobi2d.h
@@ -83,6 +83,7 @@ WITH ACCESS OR USE OF THE SOFTWARE.
 
 #include <riscv_vector.h>
 
+#include "runtime.h"
 #include "util.h"
 
 // The vector algorithm seems not to be parametrized on the data type

--- a/apps/jacobi2d/main.c
+++ b/apps/jacobi2d/main.c
@@ -135,12 +135,14 @@ int main() {
   output_printfile(R, C, B_fixed_v);
 #endif
 
+#ifndef VCD_DUMP
   // Measure scalar kernel execution
   printf("Processing the scalar benchmark\n");
   start_timer();
   j2d_s(R, C, A_fixed_s, B_fixed_s, TSTEPS);
   stop_timer();
   printf("Scalar jacobi2d cycle count: %d\n", get_timer());
+#endif
 
   // Measure vector kernel execution
   printf("Processing the vector benchmark\n");

--- a/apps/log/kernel/log.c
+++ b/apps/log/kernel/log.c
@@ -23,6 +23,10 @@ void log_1xf64_bmark(double *args, double *results, size_t len) {
   size_t avl = len;
   vfloat64m1_t log_vec, res_vec;
 
+#ifdef VCD_DUMP
+  // Start dumping VCD
+  event_trigger = +1;
+#endif
   for (size_t vl = vsetvl_e64m1(avl); avl > 0; avl -= vl) {
     // Strip-mine
     vl = vsetvl_e64m1(avl);
@@ -36,6 +40,10 @@ void log_1xf64_bmark(double *args, double *results, size_t len) {
     args += vl;
     results += vl;
   }
+#ifdef VCD_DUMP
+  // Stop dumping VCD
+  event_trigger = -1;
+#endif
 }
 
 void log_2xf32_bmark(float *args, float *results, size_t len) {
@@ -43,6 +51,10 @@ void log_2xf32_bmark(float *args, float *results, size_t len) {
   size_t avl = len;
   vfloat32m1_t log_vec, res_vec;
 
+#ifdef VCD_DUMP
+  // Start dumping VCD
+  event_trigger = +1;
+#endif
   for (size_t vl = vsetvl_e32m1(avl); avl > 0; avl -= vl) {
     // Strip-mine
     vl = vsetvl_e32m1(avl);
@@ -56,4 +68,8 @@ void log_2xf32_bmark(float *args, float *results, size_t len) {
     args += vl;
     results += vl;
   }
+#ifdef VCD_DUMP
+  // Stop dumping VCD
+  event_trigger = -1;
+#endif
 }

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -47,8 +47,12 @@ veril_path     ?= $(abspath $(INSTALL_DIR)/verilator/bin)
 veril_top      ?= ara_tb_verilator
 # Top level module to compile
 top_level      ?= ara_tb
-# QuestaSim Version
-questa_version ?= 2021.2
+# Questa version
+ifeq ($(vcd_dump), 1)
+  questa_version ?= 2019.3
+else
+  questa_version ?= 2021.2
+endif
 # QuestaSim command
 questa_cmd     ?= questa-$(questa_version)
 # QuestaSim arguments

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -65,6 +65,11 @@ ifeq ($(ideal_dispatcher), 1)
   ideal        = "_ideal"
 endif
 
+ifeq ($(vcd_dump), 1)
+  vcd_path    ?= ../vcd/$(app).vcd
+  bender_defs += --define VCD_DUMP=1 --define VCD_PATH=$(vcd_path)
+endif
+
 # Check if the specified QuestaSim version exists
 ifeq (, $(shell which $(questa_cmd)))
   # Spaces are needed for indentation here!

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -18,6 +18,8 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     parameter  int           unsigned AxiAddrWidth = 64,
     parameter  int           unsigned AxiUserWidth = 1,
     parameter  int           unsigned AxiIdWidth   = 5,
+    // AXI Resp Delay [ps] for gate-level simulation
+    parameter                         AxiRespDelay = 200ps,
     // Main memory
     parameter  int           unsigned L2NumWords   = 2**20,
     // Dependant parameters. DO NOT CHANGE!
@@ -106,6 +108,9 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   `AXI_LITE_TYPEDEF_ALL(soc_narrow_lite, axi_addr_t, axi_narrow_data_t, axi_narrow_strb_t)
 
   // Buses
+  system_req_t  system_axi_req_spill;
+  system_resp_t system_axi_resp_spill;
+  system_resp_t system_axi_resp_spill_del;
   system_req_t  system_axi_req;
   system_resp_t system_axi_resp;
 
@@ -481,15 +486,43 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   ara_system
 `endif
   i_system (
-    .clk_i        (clk_i            ),
-    .rst_ni       (rst_ni           ),
-    .boot_addr_i  (DRAMBase         ), // start fetching from DRAM
-    .scan_enable_i(1'b0             ),
-    .scan_data_i  (1'b0             ),
-    .scan_data_o  (/* Unconnected */),
-    .axi_req_o    (system_axi_req   ),
-    .axi_resp_i   (system_axi_resp  )
+    .clk_i        (clk_i                    ),
+    .rst_ni       (rst_ni                   ),
+    .boot_addr_i  (DRAMBase                 ), // start fetching from DRAM
+    .scan_enable_i(1'b0                     ),
+    .scan_data_i  (1'b0                     ),
+    .scan_data_o  (/* Unconnected */        ),
+`ifndef TARGET_GATESIM
+    .axi_req_o    (system_axi_req           ),
+    .axi_resp_i   (system_axi_resp          )
   );
+`else
+    .axi_req_o    (system_axi_req_spill     ),
+    .axi_resp_i   (system_axi_resp_spill_del)
+  );
+`endif
+
+
+`ifdef TARGET_GATESIM
+  assign #(AxiRespDelay) system_axi_resp_spill_del = system_axi_resp_spill;
+
+  axi_cut #(
+    .ar_chan_t   (system_ar_chan_t     ),
+    .aw_chan_t   (system_aw_chan_t     ),
+    .b_chan_t    (system_b_chan_t      ),
+    .r_chan_t    (system_r_chan_t      ),
+    .w_chan_t    (system_w_chan_t      ),
+    .req_t       (system_req_t         ),
+    .resp_t      (system_resp_t        )
+  ) i_system_cut (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+    .slv_req_i   (system_axi_req_spill),
+    .slv_resp_o  (system_axi_resp_spill),
+    .mst_req_o   (system_axi_req),
+    .mst_resp_i  (system_axi_resp)
+  );
+`endif
 
   //////////////////
   //  Assertions  //

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -19,7 +19,7 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     parameter  int           unsigned AxiUserWidth = 1,
     parameter  int           unsigned AxiIdWidth   = 5,
     // AXI Resp Delay [ps] for gate-level simulation
-    parameter                         AxiRespDelay = 200ps,
+    parameter  int           unsigned AxiRespDelay = 200,
     // Main memory
     parameter  int           unsigned L2NumWords   = 2**20,
     // Dependant parameters. DO NOT CHANGE!
@@ -504,7 +504,7 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
 
 
 `ifdef TARGET_GATESIM
-  assign #(AxiRespDelay) system_axi_resp_spill_del = system_axi_resp_spill;
+  assign #(AxiRespDelay*1ps) system_axi_resp_spill_del = system_axi_resp_spill;
 
   axi_cut #(
     .ar_chan_t   (system_ar_chan_t     ),

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -227,7 +227,8 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   tc_sram #(
     .NumWords (L2NumWords  ),
     .NumPorts (1           ),
-    .DataWidth(AxiDataWidth)
+    .DataWidth(AxiDataWidth),
+    .SimInit("random")
   ) i_dram (
     .clk_i  (clk_i                                                                      ),
     .rst_ni (rst_ni                                                                     ),
@@ -348,6 +349,8 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   soc_narrow_lite_req_t  axi_lite_ctrl_registers_req;
   soc_narrow_lite_resp_t axi_lite_ctrl_registers_resp;
 
+  logic [63:0] event_trigger;
+
   axi_to_axi_lite #(
     .AxiAddrWidth   (AxiAddrWidth          ),
     .AxiDataWidth   (AxiNarrowDataWidth    ),
@@ -385,7 +388,8 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     .hw_cnt_en_o          (hw_cnt_en_o                 ),
     .dram_base_addr_o     (/* Unused */                ),
     .dram_end_addr_o      (/* Unused */                ),
-    .exit_o               (exit_o                      )
+    .exit_o               (exit_o                      ),
+    .event_trigger_o      (event_trigger)
   );
 
   axi_dw_converter #(

--- a/hardware/src/ctrl_registers.sv
+++ b/hardware/src/ctrl_registers.sv
@@ -25,6 +25,7 @@ module ctrl_registers #(
     output logic           [DataWidth-1:0] exit_o,
     output logic           [DataWidth-1:0] dram_base_addr_o,
     output logic           [DataWidth-1:0] dram_end_addr_o,
+    output logic           [DataWidth-1:0] event_trigger_o,
     output logic           [DataWidth-1:0] hw_cnt_en_o
   );
 
@@ -34,7 +35,7 @@ module ctrl_registers #(
   //  Definitions  //
   ///////////////////
 
-  localparam int unsigned NumRegs          = 4;
+  localparam int unsigned NumRegs          = 5;
   localparam int unsigned DataWidthInBytes = (DataWidth + 7) / 8;
   localparam int unsigned RegNumBytes      = NumRegs * DataWidthInBytes;
 
@@ -42,17 +43,20 @@ module ctrl_registers #(
   localparam logic [DataWidthInBytes-1:0] ReadWriteReg = {DataWidthInBytes{1'b0}};
 
   // Memory map
-  // [31:24]: dram_end_addr  (rw)
+  // [39:32]: hw_cnt_en      (rw)
+  // [25:31]: event_trigger  (rw)
   // [23:16]: dram_end_addr  (ro)
   // [15:8]:  dram_base_addr (ro)
   // [7:0]:   exit           (rw)
   localparam logic [NumRegs-1:0][DataWidth-1:0] RegRstVal = '{
+    0,
     0,
     DRAMBaseAddr + DRAMLength,
     DRAMBaseAddr,
     0
   };
   localparam logic [NumRegs-1:0][DataWidthInBytes-1:0] AxiReadOnly = '{
+    ReadWriteReg,
     ReadWriteReg,
     ReadOnlyReg,
     ReadOnlyReg,
@@ -66,6 +70,7 @@ module ctrl_registers #(
   logic [RegNumBytes-1:0] wr_active_d, wr_active_q;
 
   logic [DataWidth-1:0] hw_cnt_en;
+  logic [DataWidth-1:0] event_trigger;
   logic [DataWidth-1:0] dram_base_address;
   logic [DataWidth-1:0] dram_end_address;
   logic [DataWidth-1:0] exit;
@@ -87,7 +92,7 @@ module ctrl_registers #(
     .rd_active_o(/* Unused */                               ),
     .reg_d_i    ('0                                         ),
     .reg_load_i ('0                                         ),
-    .reg_q_o    ({hw_cnt_en, dram_end_address, dram_base_address, exit})
+    .reg_q_o    ({hw_cnt_en, event_trigger, dram_end_address, dram_base_address, exit})
   );
 
   `FF(wr_active_q, wr_active_d, '0);
@@ -97,6 +102,7 @@ module ctrl_registers #(
   /////////////////
 
   assign hw_cnt_en_o      = hw_cnt_en;
+  assign event_trigger_o  = event_trigger;
   assign dram_base_addr_o = dram_base_address;
   assign dram_end_addr_o  = dram_end_address;
   assign exit_o           = {exit, logic'(|wr_active_q[7:0])};

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -61,6 +61,9 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     output logic                         mask_ready_o
   );
 
+  // Power gating registers
+  `include "common_cells/registers.svh"
+
   ////////////////////////////////
   //  Vector instruction queue  //
   ////////////////////////////////
@@ -292,26 +295,54 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   // mfpu saturation calculation
   assign mfpu_vxsat_o = |(mfpu_vxsat_q & result_queue_q[result_queue_read_pnt_q].be);
 
+  // Only for power-saving purposes
+  // The pipeline inside the multipliers is passive and always enabled
+  // Masking the inputs is almost necessary since their logic cone is huge
+  elen_t vmul_simd_op_a_gated, vmul_simd_op_b_gated, vmul_simd_op_c_gated;
+  strb_t vmul_simd_mask_gated;
+  ara_op_e vmul_simd_op_gated;
+  logic [3:0] vmul_simd_in_valid_gated;
+  logic gate_ff_en, gate_ff_clr;
+
+  // Enable if the next stage is ready
+  assign gate_ff_en  = vmul_simd_in_ready[vinsn_processing_q.vtype.vsew];
+  // Flush if the next stage is clear but there is no valid input
+  assign gate_ff_clr = vmul_simd_in_ready[vinsn_processing_q.vtype.vsew] &
+                      ~vmul_simd_in_valid[vinsn_issue_q.vtype.vsew];
+
+  `FFLSR(vmul_simd_op_a_gated, vinsn_issue_q.use_scalar_op ? scalar_op : mfpu_operand_i[0],
+    gate_ff_en, '0, clk_i, gate_ff_clr);
+  `FFLSR(vmul_simd_op_b_gated, mfpu_operand_i[1],
+    gate_ff_en, '0, clk_i, gate_ff_clr);
+  `FFLSR(vmul_simd_op_c_gated, mfpu_operand_i[2],
+    gate_ff_en, '0, clk_i, gate_ff_clr);
+  `FFLSR(vmul_simd_mask_gated, mask_i,
+    gate_ff_en, '0, clk_i, gate_ff_clr);
+  `FFLSR(vmul_simd_op_gated, vinsn_issue_q.op,
+    gate_ff_en, ara_op_e'('0), clk_i, gate_ff_clr);
+  `FFLSR(vmul_simd_in_valid_gated, vmul_simd_in_valid,
+    gate_ff_en, '0, clk_i, gate_ff_clr);
+
   simd_mul #(
     .FixPtSupport(FixPtSupport     ),
     .NumPipeRegs (LatMultiplierEW64),
     .ElementWidth(EW64             )
   ) i_simd_mul_ew64 (
-    .clk_i      (clk_i                                                      ),
-    .rst_ni     (rst_ni                                                     ),
-    .operand_a_i(vinsn_issue_q.use_scalar_op ? scalar_op : mfpu_operand_i[0]),
-    .operand_b_i(mfpu_operand_i[1]                                          ),
-    .operand_c_i(mfpu_operand_i[2]                                          ),
-    .mask_i     (mask_i                                                     ),
-    .op_i       (vinsn_issue_q.op                                           ),
-    .vxsat_o    (mfpu_vxsat[EW64]                                           ),
-    .vxrm_i     (mfpu_vxrm_i                                                ),
-    .result_o   (vmul_simd_result[EW64]                                     ),
-    .mask_o     (vmul_simd_mask[EW64]                                       ),
-    .valid_i    (vmul_simd_in_valid[EW64]                                   ),
-    .ready_o    (vmul_simd_in_ready[EW64]                                   ),
-    .ready_i    (vmul_simd_out_ready[EW64]                                  ),
-    .valid_o    (vmul_simd_out_valid[EW64]                                  )
+    .clk_i      (clk_i                         ),
+    .rst_ni     (rst_ni                        ),
+    .operand_a_i(vmul_simd_op_a_gated          ),
+    .operand_b_i(vmul_simd_op_b_gated          ),
+    .operand_c_i(vmul_simd_op_c_gated          ),
+    .mask_i     (vmul_simd_mask_gated          ),
+    .op_i       (vmul_simd_op_gated            ),
+    .vxsat_o    (mfpu_vxsat[EW64]              ),
+    .vxrm_i     (mfpu_vxrm_i                   ),
+    .result_o   (vmul_simd_result[EW64]        ),
+    .mask_o     (vmul_simd_mask[EW64]          ),
+    .valid_i    (vmul_simd_in_valid_gated[EW64]),
+    .ready_o    (vmul_simd_in_ready[EW64]      ),
+    .ready_i    (vmul_simd_out_ready[EW64]     ),
+    .valid_o    (vmul_simd_out_valid[EW64]     )
   );
 
   simd_mul #(
@@ -319,21 +350,21 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     .NumPipeRegs (LatMultiplierEW32),
     .ElementWidth(EW32             )
   ) i_simd_mul_ew32 (
-    .clk_i      (clk_i                                                      ),
-    .rst_ni     (rst_ni                                                     ),
-    .operand_a_i(vinsn_issue_q.use_scalar_op ? scalar_op : mfpu_operand_i[0]),
-    .operand_b_i(mfpu_operand_i[1]                                          ),
-    .operand_c_i(mfpu_operand_i[2]                                          ),
-    .mask_i     (mask_i                                                     ),
-    .op_i       (vinsn_issue_q.op                                           ),
-    .vxsat_o    (mfpu_vxsat[EW32]                                           ),
-    .vxrm_i     (mfpu_vxrm_i                                                ),
-    .result_o   (vmul_simd_result[EW32]                                     ),
-    .mask_o     (vmul_simd_mask[EW32]                                       ),
-    .valid_i    (vmul_simd_in_valid[EW32]                                   ),
-    .ready_o    (vmul_simd_in_ready[EW32]                                   ),
-    .ready_i    (vmul_simd_out_ready[EW32]                                  ),
-    .valid_o    (vmul_simd_out_valid[EW32]                                  )
+    .clk_i      (clk_i                         ),
+    .rst_ni     (rst_ni                        ),
+    .operand_a_i(vmul_simd_op_a_gated          ),
+    .operand_b_i(vmul_simd_op_b_gated          ),
+    .operand_c_i(vmul_simd_op_c_gated          ),
+    .mask_i     (vmul_simd_mask_gated          ),
+    .op_i       (vmul_simd_op_gated            ),
+    .vxsat_o    (mfpu_vxsat[EW32]              ),
+    .vxrm_i     (mfpu_vxrm_i                   ),
+    .result_o   (vmul_simd_result[EW32]        ),
+    .mask_o     (vmul_simd_mask[EW32]          ),
+    .valid_i    (vmul_simd_in_valid_gated[EW32]),
+    .ready_o    (vmul_simd_in_ready[EW32]      ),
+    .ready_i    (vmul_simd_out_ready[EW32]     ),
+    .valid_o    (vmul_simd_out_valid[EW32]     )
   );
 
   simd_mul #(
@@ -341,21 +372,21 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     .NumPipeRegs (LatMultiplierEW16),
     .ElementWidth(EW16             )
   ) i_simd_mul_ew16 (
-    .clk_i      (clk_i                                                      ),
-    .rst_ni     (rst_ni                                                     ),
-    .operand_a_i(vinsn_issue_q.use_scalar_op ? scalar_op : mfpu_operand_i[0]),
-    .operand_b_i(mfpu_operand_i[1]                                          ),
-    .operand_c_i(mfpu_operand_i[2]                                          ),
-    .mask_i     (mask_i                                                     ),
-    .op_i       (vinsn_issue_q.op                                           ),
-    .vxsat_o    (mfpu_vxsat[EW16]                                           ),
-    .vxrm_i     (mfpu_vxrm_i                                                ),
-    .result_o   (vmul_simd_result[EW16]                                     ),
-    .mask_o     (vmul_simd_mask[EW16]                                       ),
-    .valid_i    (vmul_simd_in_valid[EW16]                                   ),
-    .ready_o    (vmul_simd_in_ready[EW16]                                   ),
-    .ready_i    (vmul_simd_out_ready[EW16]                                  ),
-    .valid_o    (vmul_simd_out_valid[EW16]                                  )
+    .clk_i      (clk_i                         ),
+    .rst_ni     (rst_ni                        ),
+    .operand_a_i(vmul_simd_op_a_gated          ),
+    .operand_b_i(vmul_simd_op_b_gated          ),
+    .operand_c_i(vmul_simd_op_c_gated          ),
+    .mask_i     (vmul_simd_mask_gated          ),
+    .op_i       (vmul_simd_op_gated            ),
+    .result_o   (vmul_simd_result[EW16]        ),
+    .vxsat_o    (mfpu_vxsat[EW16]              ),
+    .vxrm_i     (mfpu_vxrm_i                   ),
+    .mask_o     (vmul_simd_mask[EW16]          ),
+    .valid_i    (vmul_simd_in_valid_gated[EW16]),
+    .ready_o    (vmul_simd_in_ready[EW16]      ),
+    .ready_i    (vmul_simd_out_ready[EW16]     ),
+    .valid_o    (vmul_simd_out_valid[EW16]     )
   );
 
   simd_mul #(
@@ -363,21 +394,21 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     .NumPipeRegs (LatMultiplierEW8),
     .ElementWidth(EW8             )
   ) i_simd_mul_ew8 (
-    .clk_i      (clk_i                                                      ),
-    .rst_ni     (rst_ni                                                     ),
-    .operand_a_i(vinsn_issue_q.use_scalar_op ? scalar_op : mfpu_operand_i[0]),
-    .operand_b_i(mfpu_operand_i[1]                                          ),
-    .operand_c_i(mfpu_operand_i[2]                                          ),
-    .mask_i     (mask_i                                                     ),
-    .op_i       (vinsn_issue_q.op                                           ),
-    .vxsat_o    (mfpu_vxsat[EW8]                                            ),
-    .vxrm_i     (mfpu_vxrm_i                                                ),
-    .result_o   (vmul_simd_result[EW8]                                      ),
-    .mask_o     (vmul_simd_mask[EW8]                                        ),
-    .valid_i    (vmul_simd_in_valid[EW8]                                    ),
-    .ready_o    (vmul_simd_in_ready[EW8]                                    ),
-    .ready_i    (vmul_simd_out_ready[EW8]                                   ),
-    .valid_o    (vmul_simd_out_valid[EW8]                                   )
+    .clk_i      (clk_i                         ),
+    .rst_ni     (rst_ni                        ),
+    .operand_a_i(vmul_simd_op_a_gated          ),
+    .operand_b_i(vmul_simd_op_b_gated          ),
+    .operand_c_i(vmul_simd_op_c_gated          ),
+    .mask_i     (vmul_simd_mask_gated          ),
+    .op_i       (vmul_simd_op_gated            ),
+    .vxsat_o    (mfpu_vxsat[EW8]               ),
+    .vxrm_i     (mfpu_vxrm_i                   ),
+    .result_o   (vmul_simd_result[EW8]         ),
+    .mask_o     (vmul_simd_mask[EW8]           ),
+    .valid_i    (vmul_simd_in_valid_gated[EW8] ),
+    .ready_o    (vmul_simd_in_ready[EW8]       ),
+    .ready_i    (vmul_simd_out_ready[EW8]      ),
+    .valid_o    (vmul_simd_out_valid[EW8]      )
   );
 
   // The outputs of the SIMD multipliers are read in order

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -10,6 +10,8 @@ import "DPI-C" function void read_elf (input string filename);
 import "DPI-C" function byte get_section (output longint address, output longint len);
 import "DPI-C" context function byte read_section(input longint address, inout byte buffer[]);
 
+`define STRINGIFY(x) `"x`"
+
 module ara_tb;
 
   /*****************
@@ -192,5 +194,62 @@ module ara_tb;
       $finish(exit >> 1);
     end
   end
+
+// Dump VCD with a SW trigger
+`ifdef VCD_DUMP
+
+  /****************
+  *  VCD DUMPING  *
+  ****************/
+
+`ifdef VCD_PATH
+  string vcd_path = `STRINGIFY(`VCD_PATH);
+`else
+  string vcd_path = "../vcd/last_sim.vcd";
+`endif
+
+  localparam logic [63:0] VCD_TRIGGER_ON  = 64'h0000_0000_0000_0001;
+  localparam logic [63:0] VCD_TRIGGER_OFF = 64'hFFFF_FFFF_FFFF_FFFF;
+
+  event start_dump_event;
+  event stop_dump_event;
+
+  logic [63:0] event_trigger_reg;
+  logic        dumping = 1'b0;
+
+  assign event_trigger_reg =
+           dut.i_ara_soc.i_ctrl_registers.event_trigger_o;
+
+  initial begin
+    $display("VCD_DUMP successfully defined\n");
+  end
+
+  always_ff @(posedge clk) begin
+    if(event_trigger_reg == VCD_TRIGGER_ON && !dumping) begin
+       $display("[TB - VCD] START DUMPING\n");
+       -> start_dump_event;
+       dumping = 1'b1;
+    end
+    if(event_trigger_reg == VCD_TRIGGER_OFF) begin
+       -> stop_dump_event;
+       $display("[TB - VCD] STOP DUMPING\n");
+    end
+  end
+
+  initial begin
+    @(start_dump_event);
+    $dumpfile(vcd_path);
+    $dumpvars(0, dut.i_ara_soc.i_system);
+    $dumpon;
+
+    #1 $display("[TB - VCD] DUMPING...\n");
+
+    @(stop_dump_event)
+    $dumpoff;
+    $dumpflush;
+    $finish;
+  end
+
+`endif
 
 endmodule : ara_tb

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -29,7 +29,8 @@ module ara_tb;
   localparam NrLanes = 0;
   `endif
 
-  localparam ClockPeriod = 1ns;
+  localparam ClockPeriod  = 1ns;
+  localparam AxiRespDelay = 200ps;
 
   localparam AxiAddrWidth      = 64;
   localparam AxiWideDataWidth  = 64 * NrLanes / 2;
@@ -46,18 +47,22 @@ module ara_tb;
   logic clk;
   logic rst_n;
 
-  // Toggling the clock
-  always #(ClockPeriod/2) clk = !clk;
-
   // Controlling the reset
   initial begin
     clk   = 1'b0;
     rst_n = 1'b0;
 
-    repeat (5)
-      #(ClockPeriod);
+    // Synch reset for TB memories
+    repeat (10) #(ClockPeriod/2) clk = ~clk;
+    clk = 1'b0;
 
+    // Asynch reset for main system
+    repeat (5) #(ClockPeriod);
     rst_n = 1'b1;
+    repeat (5) #(ClockPeriod);
+
+    // Start the clock
+    forever #(ClockPeriod/2) clk = ~clk;
   end
 
   /*********
@@ -73,7 +78,8 @@ module ara_tb;
   ara_testharness #(
     .NrLanes     (NrLanes         ),
     .AxiAddrWidth(AxiAddrWidth    ),
-    .AxiDataWidth(AxiWideDataWidth)
+    .AxiDataWidth(AxiWideDataWidth),
+    .AxiRespDelay(AxiRespDelay    )
   ) dut (
     .clk_i (clk  ),
     .rst_ni(rst_n),

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -30,7 +30,8 @@ module ara_tb;
   `endif
 
   localparam ClockPeriod  = 1ns;
-  localparam AxiRespDelay = 200ps;
+  // Axi response delay [ps]
+  localparam int unsigned AxiRespDelay = 200;
 
   localparam AxiAddrWidth      = 64;
   localparam AxiWideDataWidth  = 64 * NrLanes / 2;

--- a/hardware/tb/ara_testharness.sv
+++ b/hardware/tb/ara_testharness.sv
@@ -16,7 +16,7 @@ module ara_testharness #(
     parameter int unsigned AxiAddrWidth = 64,
     parameter int unsigned AxiDataWidth = 64*NrLanes/2,
     // AXI Resp Delay [ps] for gate-level simulation
-    parameter              AxiRespDelay = 200ps
+    parameter int unsigned AxiRespDelay = 200
   ) (
     input  logic        clk_i,
     input  logic        rst_ni,

--- a/hardware/tb/ara_testharness.sv
+++ b/hardware/tb/ara_testharness.sv
@@ -14,7 +14,9 @@ module ara_testharness #(
     parameter int unsigned AxiUserWidth = 1,
     parameter int unsigned AxiIdWidth   = 5,
     parameter int unsigned AxiAddrWidth = 64,
-    parameter int unsigned AxiDataWidth = 64*NrLanes/2
+    parameter int unsigned AxiDataWidth = 64*NrLanes/2,
+    // AXI Resp Delay [ps] for gate-level simulation
+    parameter              AxiRespDelay = 200ps
   ) (
     input  logic        clk_i,
     input  logic        rst_ni,
@@ -68,7 +70,8 @@ module ara_testharness #(
     .AxiAddrWidth(AxiAddrWidth ),
     .AxiDataWidth(AxiDataWidth ),
     .AxiIdWidth  (AxiIdWidth   ),
-    .AxiUserWidth(AxiUserWidth )
+    .AxiUserWidth(AxiUserWidth ),
+    .AxiRespDelay(AxiRespDelay )
   ) i_ara_soc (
     .clk_i         (clk_i       ),
     .rst_ni        (rst_ni      ),


### PR DESCRIPTION
SW: Add initial support for power analysis with automatic VCD dumping for the following kernels: `fmatmul`, `fconv3d`, `fft`, `dwt`, `exp`, `cos`, `log`, `dropout`, `jacobi2d`.

HW: power gate the in-lane SIMD multipliers.

## Changelog

### Added

- Add HW/SW environment for automatic VCD dumping.

### Changed

- Generate data for `fmatmul` at compile time.
- SIMD multipliers are now power gated.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed