### PR TITLE
[HW] Add support for vector permute instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Parametrize `vfrec7` support
  - Support for vector floating-point reciprocal square-root estimate instruction: `vfrsqrt7`
  - Parametrize `vfrsqrt7` support
+ - Support for vector permute instructions: `vrgather`, `vrgatherei16`, `vcompress`
 
 ### Changed
 

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -75,6 +75,7 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 - Integer Scalar Move instructions: `vmv.x.s`, `vmv.s.x`
 - Floating-Point Scalar Move instructions: `vfmv.f.s`, `vfmv.s.f`
 - Vector slide instructions: `vslideup`, `vslidedown`, `vslide1up`, `vfslide1up`, `vslide1down`, `vfslide1down`
+- Vector permute instructions: `vrgather`, `vrgatherei16`, `vcompress`
 
 ## Vector fixed-point arithmetic instructions
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -172,7 +172,10 @@ rv64uv_sc_tests = vaadd \
                   vse64 \
                   vle_vse_hazards \
                   vfrec7 \
-                  vfrsqrt7
+                  vfrsqrt7 \
+                  vrgather \
+                  vrgatherei16 \
+                  vcompress
 
 #rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfirst vid viota vl vlff vl_nocheck vlx vmsbf vmsif vmsof vpopc_m vrgather vsadd vsaddu vsetvl vsetivli vsetvli vsmul vssra vssrl vssub vssubu vsux vsx
 

--- a/apps/riscv-tests/isa/rv64uv/vcompress.c
+++ b/apps/riscv-tests/isa/rv64uv/vcompress.c
@@ -11,10 +11,10 @@ void TEST_CASE1() {
   VSET(4, e64, m1);
   VLOAD_64(v4, 1, 2, 3, 4);
   VLOAD_64(v0, 12, 0, 0, 0);
-  CLEAR(v2);
+  VCLEAR(v2);
   __asm__ volatile("vcompress.vm v2, v4, v0");
-  DEBUG_64(v2);
-  VEC_CMP_64(1, v2, 3, 4, 0, 0);
+  // DEBUG_64(v2);
+  VCMP_I64(1, v2, 3, 4, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vrgather.c
+++ b/apps/riscv-tests/isa/rv64uv/vrgather.c
@@ -8,55 +8,61 @@
 #include "vector_macros.h"
 
 void TEST_CASE1() {
-  VSET(5, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   VLOAD_8(v6, 1, 0, 4, 3, 2);
   __asm__ volatile("vrgather.vv v2, v4, v6");
-  VEC_CMP_8(1, v2, 20, 10, 50, 40, 30);
+  VCMP_U8(1, v2, 20, 10, 50, 40, 30);
 }
 
 void TEST_CASE2() {
-  VSET(5, e8, m1);
+  VSET(16, e8, m1);
+  VCLEAR(v4);
+  VCLEAR(v6);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   VLOAD_8(v6, 1, 0, 4, 3, 2);
-  VLOAD_U8(v0, 26, 0, 0, 0, 0);
-  CLEAR(v2);
+  VCLEAR(v0);
+  VLOAD_8(v0, 26, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vrgather.vv v2, v4, v6, v0.t");
-  VEC_CMP_8(2, v2, 0, 10, 0, 40, 30);
+  VCMP_U8(2, v2, 0, 10, 0, 40, 30);
 }
 
 void TEST_CASE3() {
-  VSET(5, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   uint64_t scalar = 3;
+  VCLEAR(v2);
   __asm__ volatile("vrgather.vx v2, v4, %[A]" ::[A] "r"(scalar));
-  VEC_CMP_8(3, v2, 40, 40, 40, 40, 40);
+  VCMP_U8(3, v2, 40, 40, 40, 40, 40);
 }
 
 void TEST_CASE4() {
-  VSET(5, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   uint64_t scalar = 3;
-  VLOAD_U8(v0, 7, 0, 0, 0, 0);
-  CLEAR(v2);
+  VCLEAR(v0);
+  VLOAD_8(v0, 7, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vrgather.vx v2, v4, %[A], v0.t" ::[A] "r"(scalar));
-  VEC_CMP_8(4, v2, 40, 40, 40, 0, 0);
+  VCMP_U8(4, v2, 40, 40, 40, 0, 0);
 }
 
 void TEST_CASE5() {
-  VSET(5, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
   __asm__ volatile("vrgather.vi v2, v4, 3");
-  VEC_CMP_8(5, v2, 40, 40, 40, 40, 40);
+  VCMP_U8(5, v2, 40, 40, 40, 40, 40);
 }
 
 void TEST_CASE6() {
-  VSET(5, e8, m1);
+  VSET(16, e8, m1);
   VLOAD_8(v4, 10, 20, 30, 40, 50);
-  VLOAD_U8(v0, 7, 0, 0, 0, 0);
-  CLEAR(v2);
+  VCLEAR(v0);
+  VLOAD_8(v0, 7, 0, 0, 0, 0);
+  VCLEAR(v2);
   __asm__ volatile("vrgather.vi v2, v4, 3, v0.t");
-  VEC_CMP_8(6, v2, 40, 40, 40, 0, 0);
+  VCMP_U8(6, v2, 40, 40, 40, 0, 0);
 }
 
 int main(void) {

--- a/apps/riscv-tests/isa/rv64uv/vrgatherei16.c
+++ b/apps/riscv-tests/isa/rv64uv/vrgatherei16.c
@@ -1,0 +1,34 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Muhammad Ijaz
+
+#include "vector_macros.h"
+
+void TEST_CASE1() {
+  VSET(5, e16, m2);
+  VLOAD_16(v6, 1, 0, 4, 3, 2);
+  VSET(5, e8, m1);
+  VLOAD_8(v4, 10, 20, 30, 40, 50);
+  __asm__ volatile("vrgatherei16.vv v2, v4, v6");
+  VCMP_U8(1, v2, 20, 10, 50, 40, 30);
+}
+void TEST_CASE2() {
+  VSET(5, e16, m2);
+  VLOAD_16(v6, 1, 0, 4, 3, 2);
+  VSET(5, e8, m1);
+  VLOAD_8(v4, 10, 20, 30, 40, 50);
+  VLOAD_8(v0, 26, 0, 0, 0, 0);
+  VCLEAR(v2);
+  __asm__ volatile("vrgatherei16.vv v2, v4, v6, v0.t");
+  VCMP_U8(2, v2, 0, 10, 0, 40, 30);
+}
+
+int main(void) {
+  INIT_CHECK();
+  enable_vec();
+  TEST_CASE1();
+  TEST_CASE2();
+  EXIT_CHECK();
+}

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -138,7 +138,7 @@ package ara_pkg;
     // Floating-point comparison instructions
     VMFEQ, VMFLE, VMFLT, VMFNE, VMFGT, VMFGE,
     // Integer comparison instructions
-    VMSEQ, VMSNE, VMSLTU, VMSLT, VMSLEU, VMSLE, VMSGTU, VMSBF, VMSOF, VMSIF, VIOTA, VID, VCPOP, VFIRST, VMSGT,
+    VMSEQ, VMSNE, VMSLTU, VMSLT, VMSLEU, VMSLE, VMSGTU, VMSBF, VMSOF, VMSIF, VIOTA, VID, VRGATHER, VRGATHEREI16, VCOMPRESS, VCPOP, VFIRST, VMSGT,
     // Integer add-with-carry and subtract-with-borrow carry-out instructions
     VMADC, VMSBC,
     // Mask operations

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -148,6 +148,9 @@ module ara import ara_pkg::*; #(
   logic      [NrLanes-1:0]                     mask_valid;
   logic                                        mask_valid_lane;
   logic      [NrLanes-1:0]                     lane_mask_ready;
+  // Interface with the Mask Unit
+  elen_t     [NrLanes-1:0]                     viota_operand, alu_operand_a, alu_operand_b;
+  logic      [NrLanes-1:0]                     viota_operand_valid, alu_operand_a_valid, alu_operand_b_valid;
 
   // Mask unit scalar result variables
   elen_t     result_scalar;
@@ -302,7 +305,13 @@ module ara import ara_pkg::*; #(
       .masku_result_final_gnt_o        (masku_result_final_gnt[lane]        ),
       .mask_i                          (mask[lane]                          ),
       .mask_valid_i                    (mask_valid[lane] & mask_valid_lane  ),
-      .mask_ready_o                    (lane_mask_ready[lane]               )
+      .mask_ready_o                    (lane_mask_ready[lane]               ),
+      .alu_operand_a_o                 (alu_operand_a[lane]                 ),
+      .alu_operand_a_valid_o           (alu_operand_a_valid[lane]           ),
+      .alu_operand_b_o                 (alu_operand_b[lane]                 ),
+      .alu_operand_b_valid_o           (alu_operand_b_valid[lane]           ),
+      .viota_operand_o                 (viota_operand[lane]                 ),
+      .viota_operand_valid_o           (viota_operand_valid[lane]           )
     );
   end: gen_lanes
 
@@ -440,6 +449,12 @@ module ara import ara_pkg::*; #(
     .masku_result_be_o       (masku_result_be                 ),
     .masku_result_gnt_i      (masku_result_gnt                ),
     .masku_result_final_gnt_i(masku_result_final_gnt          ),
+    .alu_operand_a_i         (alu_operand_a                   ),
+    .alu_operand_a_valid_i   (alu_operand_a_valid             ),
+    .alu_operand_b_i         (alu_operand_b                   ),
+    .alu_operand_b_valid_i   (alu_operand_b_valid             ),
+    .viota_operand_i         (viota_operand                   ),
+    .viota_operand_valid_i   (viota_operand_valid             ),
     // Interface with the VFUs
     .mask_o                  (mask                            ),
     .mask_valid_o            (mask_valid                      ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -529,6 +529,11 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VAND;
                   6'b001010: ara_req_d.op = ara_pkg::VOR;
                   6'b001011: ara_req_d.op = ara_pkg::VXOR;
+                  6'b001100: ara_req_d.op = ara_pkg::VRGATHER;
+                  6'b001110: begin
+                    ara_req_d.op      = ara_pkg::VRGATHEREI16;
+                    ara_req_d.eew_vs1 = vtype_q.vsew.next();
+                  end
                   6'b010000: begin
                     ara_req_d.op = ara_pkg::VADC;
 
@@ -738,6 +743,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VAND;
                   6'b001010: ara_req_d.op = ara_pkg::VOR;
                   6'b001011: ara_req_d.op = ara_pkg::VXOR;
+                  6'b001100: ara_req_d.op = ara_pkg::VRGATHER;
                   6'b001110: begin
                     ara_req_d.op            = ara_pkg::VSLIDEUP;
                     ara_req_d.stride        = acc_req_i.rs1;
@@ -945,6 +951,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VAND;
                   6'b001010: ara_req_d.op = ara_pkg::VOR;
                   6'b001011: ara_req_d.op = ara_pkg::VXOR;
+                  6'b001100: ara_req_d.op = ara_pkg::VRGATHER;
                   6'b001110: begin
                     ara_req_d.op            = ara_pkg::VSLIDEUP;
                     ara_req_d.stride        = {{ELEN{insn.varith_type.rs1[19]}}, insn.varith_type.rs1};
@@ -1256,6 +1263,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001001: ara_req_d.op = ara_pkg::VAADD;
                   6'b001010: ara_req_d.op = ara_pkg::VASUBU;
                   6'b001011: ara_req_d.op = ara_pkg::VASUB;
+                  6'b010111: begin
+                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op        = ara_pkg::VCOMPRESS;
+                  end
                   6'b011000: begin
                     ara_req_d.op        = ara_pkg::VMANDNOT;
                     ara_req_d.use_vd_op = 1'b1;

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -122,7 +122,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     endcase
   end
 
-  // Getting operand for vmsbf, vmsif, vmsof, viota and vid mask instructions + vrgather instruction
+  // Getting operands for permute instruction
   assign alu_operand_a_o         = (vfu_operation.use_scalar_op) ? scalar_op : alu_operand[0];
   assign alu_operand_a_valid_o   = (vfu_operation.use_scalar_op) ? (vfu_operation.use_scalar_op & scalar_op) : alu_operand_valid[0];
   assign alu_operand_b_o         = alu_operand[1];


### PR DESCRIPTION
Add support for `vrgather`, `vrgatherei16` and `vcompress` vector permute instructions
**NOTE**: This PR depends on [PR#149](https://github.com/pulp-platform/ara/pull/149) and needs to be merged after that

## Changelog

### Fixed

- N/A

### Added

- Support for `vrgather`, `vrgatherei16` and `vcompress` vector permute instructions
- Test for `vrgatherei16` permute instruction

### Changed

- Tests for `vrgather` and `vcompress` permute instructions

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
