### PR TITLE
[HW] Add support for vfrsqrt7 instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add support to check the results of the ideal dispatcher runs
  - Add HW/SW environment for automatic VCD dumping
  - Support for vector floating-point reciprocal estimate instruction: `vfrec7`
+ - Support for vector floating-point reciprocal square-root estimate instruction: `vfrsqrt7`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add support to check the results of the ideal dispatcher runs
  - Add HW/SW environment for automatic VCD dumping
  - Support for vector floating-point reciprocal estimate instruction: `vfrec7`
+ - Parametrize `vfrec7` support
  - Support for vector floating-point reciprocal square-root estimate instruction: `vfrsqrt7`
  - Parametrize `vfrsqrt7` support
 
@@ -432,3 +433,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Software support for RISC-V Vector code
 
 - Continuous integration tests through riscv-tests executed both with Spike and on Ara
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,4 +433,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Software support for RISC-V Vector code
 
 - Continuous integration tests through riscv-tests executed both with Spike and on Ara
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Don't mute instructions on mask vectors in the lane sequencer when `vl == 0` in that lane
  - Remove unintentional latches from `valu`, `simd_mul`, `lane_sequencer`
  - Fix `vxsat` CSR update in `dispatcher`
+ - Fix parameter passing through the hierarchy for fixed point support
 
 ### Added
 
@@ -116,6 +117,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add HW/SW environment for automatic VCD dumping
  - Support for vector floating-point reciprocal estimate instruction: `vfrec7`
  - Support for vector floating-point reciprocal square-root estimate instruction: `vfrsqrt7`
+ - Parametrize `vfrsqrt7` support
 
 ### Changed
 

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -55,6 +55,7 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 - Vector widening floating-point/integer type-convert instructions: `vfwcvt.xu.f`, `vfwcvt.x.f`, `vfwcvt.rtz.xu.f`, `vfwcvt.rtz.x.f`, `vfwcvt.f.xu`, `vfwcvt.f.x`, `vfwcvt.f.f`
 - Vector narrowing floating-point/integer type-convert instructions: `vfncvt.xu.f`, `vfncvt.x.f`, `vfncvt.rtz.xu.f`, `vfncvt.rtz.x.f`, `vfncvt.f.xu`, `vfncvt.f.x`, `vfncvt.f.f`
 - Vector floating-point reciprocal estimate instruction: `vfrec7`
+- Vector floating-point reciprocal square-root estimate instruction: `vfrsqrt7`
 
 ## Vector Reduction Operations
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -171,8 +171,9 @@ rv64uv_sc_tests = vaadd \
                   vle64 \
                   vse64 \
                   vle_vse_hazards \
-                  vfrec7
-
+                  vfrec7 \
+                  vfrsqrt7
+                  
 #rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfirst vid viota vl vlff vl_nocheck vlx vmsbf vmsif vmsof vpopc_m vrgather vsadd vsaddu vsetvl vsetivli vsetvli vsmul vssra vssrl vssub vssubu vsux vsx
 
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -179,4 +179,3 @@ rv64uv_sc_tests = vaadd \
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))
 
 spike_ctests += $(rv64uv_p_tests)
-

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -179,3 +179,4 @@ rv64uv_sc_tests = vaadd \
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))
 
 spike_ctests += $(rv64uv_p_tests)
+

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -173,7 +173,7 @@ rv64uv_sc_tests = vaadd \
                   vle_vse_hazards \
                   vfrec7 \
                   vfrsqrt7
-                  
+
 #rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfirst vid viota vl vlff vl_nocheck vlx vmsbf vmsif vmsof vpopc_m vrgather vsadd vsaddu vsetvl vsetivli vsetvli vsmul vssra vssrl vssub vssubu vsux vsx
 
 rv64uv_p_tests = $(addprefix rv64uv-p-, $(rv64uv_sc_tests))

--- a/apps/riscv-tests/isa/rv64uv/vfrsqrt7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrsqrt7.c
@@ -1,0 +1,45 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+// y
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "float_macros.h"
+#include "vector_macros.h"
+
+void TEST_CASE1(void) {
+  VSET(16, e16, m1);
+  VLOAD_16(v2, mInfh, pInfh, qNaNh, sNaNh, pZero, mZeroh, 0x3a12, 0x0001,
+           0x3af7, 0x00fe, 0x01e6, 0x75e6, 0x80fe, 0x35fd, 0x20a7, 0x7bc0);
+  asm volatile("vfrsqrt7.v v1, v2");
+  VCMP_U16(1, v1, qNaNh, pZero, qNaNh, qNaNh, pInfh, mInfh, 0x3c98, 0x6bf8,
+           0x3c48, 0x5c00, 0x59d0, 0x1e98, qNaNh, 0x3e90, 0x4940, 0x1c10);
+  VSET(16, e32, m1);
+  VLOAD_32(v2, mInff, pInff, qNaNf, 0xfe7fca13, 0x00800000, 0x00200000,
+           0x003f3cde, 0x00400000, 0x7f787a12, 0x7f000005, 0x7ef0f42d,
+           0x7f765432, 0x00718abc, 0x00e50000, 0x001ee941, 0x00000003);
+  asm volatile("vfrsqrt7.v v1, v2");
+  VCMP_U32(2, v1, qNaNf, pZero, qNaNf, qNaNf, 0x5eff0000, 0x5f7f0000,
+           0x5f360000, 0x5f340000, 0x1f820000, 0x1fb40000, 0x1fbb0000,
+           0x1f820000, 0x5f080000, 0x5ebf0000, 0x5f820000, 0x64500000);
+  VSET(16, e64, m1);
+  VLOAD_64(v2, mInfd, pInfd, qNaNd, sNaNd, pZero, mZerod, 0xffee384e0c3fbf7c,
+           0x00060000005e7fcf, 0x000bffffd07b5869, 0x7fbfffff9bfec946,
+           0x7fdc709c2bde6967, 0x000347ea91db7acb, 0x7fd5600000000000,
+           0x000000000000001, 0x000000000000ded, 0x7fdc000000006967);
+  asm volatile("vfrsqrt7.v v1, v2");
+  VCMP_U64(3, v1, qNaNd, pZero, qNaNd, qNaNd, pInfd, mInfd, qNaNd,
+           0x5fea000000000000, 0x5fe2800000000000, 0x2006a00000000000,
+           0x1ff8000000000000, 0x5ff1c00000000000, 0x1ffba00000000000,
+           0x617fe00000000000, 0x6121200000000000, 0x1ff8200000000000);
+};
+
+int main(void) {
+  enable_vec();
+  enable_fp();
+
+  TEST_CASE1();
+
+  EXIT_CHECK();
+}

--- a/apps/riscv-tests/isa/rv64uv/vfrsqrt7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrsqrt7.c
@@ -1,9 +1,10 @@
 // Copyright 2021 ETH Zurich and University of Bologna.
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
-// y
+//
 // Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Shafiullah Khan <shafi.ullah@10xengineers.ai>
 
 #include "float_macros.h"
 #include "vector_macros.h"

--- a/apps/riscv-tests/isa/rv64uv/vfrsqrt7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrsqrt7.c
@@ -18,11 +18,11 @@ void TEST_CASE1(void) {
   VSET(16, e32, m1);
   VLOAD_32(v2, mInff, pInff, qNaNf, 0xfe7fca13, 0x00800000, 0x00200000,
            0x003f3cde, 0x00400000, 0x7f787a12, 0x7f000005, 0x7ef0f42d,
-           0x7f765432, 0x00718abc, 0x00e50000, 0x001ee941, 0x00000003);
+           0x7f765432, 0x00718abc, 0x00e50000, 0x001ee941, 0x00000001);
   asm volatile("vfrsqrt7.v v1, v2");
   VCMP_U32(2, v1, qNaNf, pZero, qNaNf, qNaNf, 0x5eff0000, 0x5f7f0000,
            0x5f360000, 0x5f340000, 0x1f820000, 0x1fb40000, 0x1fbb0000,
-           0x1f820000, 0x5f080000, 0x5ebf0000, 0x5f820000, 0x64500000);
+           0x1f820000, 0x5f080000, 0x5ebf0000, 0x5f820000, 0x64b40000);
   VSET(16, e64, m1);
   VLOAD_64(v2, mInfd, pInfd, qNaNd, sNaNd, pZero, mZerod, 0xffee384e0c3fbf7c,
            0x00060000005e7fcf, 0x000bffffd07b5869, 0x7fbfffff9bfec946,
@@ -34,12 +34,37 @@ void TEST_CASE1(void) {
            0x1ff8000000000000, 0x5ff1c00000000000, 0x1ffba00000000000,
            0x617fe00000000000, 0x6121200000000000, 0x1ff8200000000000);
 };
+// Exceptions check
+void TEST_CASE2(void) {
+  // Invalid operation
+  CLEAR_FFLAGS;
+  VSET(16, e16, m1);
+  CHECK_FFLAGS(0);
+  VLOAD_16(v2, mInfh, sNaNh, 0xba12, 0x8001, 0xbaf7, 0x80fe, 0x81e6, 0xf5e6,
+           0x80ff, 0xb5fd, 0xa0a7, 0xfbc0, mInfh, sNaNh, mInfh, sNaNh);
+  asm volatile("vfrsqrt7.v v1, v2");
+  VCMP_U16(4, v1, qNaNh, qNaNh, qNaNh, qNaNh, qNaNh, qNaNh, qNaNh, qNaNh, qNaNh,
+           qNaNh, qNaNh, qNaNh, qNaNh, qNaNh, qNaNh, qNaNh);
+  CHECK_FFLAGS(NV);
+
+  // Divide by zero
+  CLEAR_FFLAGS;
+  VSET(16, e32, m1);
+  CHECK_FFLAGS(0);
+  VLOAD_32(v2, pZero, mZerof, pZero, mZerof, pZero, mZerof, pZero, mZerof,
+           pZero, mZerof, pZero, mZerof, pZero, mZerof, pZero, mZerof);
+  asm volatile("vfrsqrt7.v v1, v2");
+  VCMP_U32(5, v1, pInff, mInff, pInff, mInff, pInff, mInff, pInff, mInff, pInff,
+           mInff, pInff, mInff, pInff, mInff, pInff, mInff);
+  CHECK_FFLAGS(DZ);
+};
 
 int main(void) {
   enable_vec();
   enable_fp();
 
   TEST_CASE1();
+  TEST_CASE2();
 
   EXIT_CHECK();
 }

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1015,6 +1015,7 @@ package ara_pkg;
 
 
   /////////////
+<<<<<<< HEAD
   // VFREC7 //
   ///////////
 
@@ -1052,6 +1053,10 @@ package ara_pkg;
   localparam logic [63:0] E64_mInf = 64'hfff0000000000000;
   localparam logic [62:0] E64_Max  = 63'h7fefffffffffffff;
   localparam logic [62:0] E64_Inf  = 63'h7ff0000000000000;
+
+  localparam logic  [5:0] E16_3xB = 6'd45;
+  localparam logic  [8:0] E32_3xB = 9'd381;
+  localparam logic [11:0] E64_3xB = 12'd3069;
 
   // Structure containing 5 bit flag and desired output
  typedef struct packed {
@@ -1570,403 +1575,364 @@ package ara_pkg;
     return vfrec7_out;
   endfunction : vfrec7_fp64
 
-localparam int unsigned LUT_BITS     = 7;
-localparam int unsigned E16_BITS     = 16;
-localparam int unsigned E32_BITS     = 32;
-localparam int unsigned E64_BITS     = 64;
-
-localparam int unsigned EXP_BITS_E16  = 5;
-localparam int unsigned EXP_BITS_E32  = 8;
-localparam int unsigned EXP_BITS_E64  = 11;
-
-localparam int unsigned VF_TYPE_SEL_BITS  = 10;
-
-localparam logic [5:0] E16_3xB     = 6'd45;
-localparam logic [8:0] E32_3xB     = 9'd381;
-localparam logic [11:0] E64_3xB     = 12'd3069;
-
-localparam logic [15:0] E16_NaN   = 16'h7e00;
-localparam logic [15:0] E16_pInf  = 16'h7c00;
-localparam logic [15:0] E16_mInf  = 16'hfc00;
-
-localparam logic [31:0] E32_NaN   = 32'h7fc00000;
-localparam logic [31:0] E32_pInf  = 32'h7f800000;
-localparam logic [31:0] E32_mInf  = 32'hff800000;
-
-localparam logic [63:0] E64_NaN   = 64'h7ff8000000000000;
-localparam logic [63:0] E64_pInf  = 64'h7ff0000000000000;
-localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
-
-// Structure containing 5 bit flag and desired output
- typedef struct packed {
-  fpnew_pkg::status_t ex_flag;
-  fp16_t              vf7_e16;
- } vf7_flag_out_e16;
-
-  typedef struct packed {
-  fpnew_pkg::status_t ex_flag;
-  fp32_t              vf7_e32;
-  } vf7_flag_out_e32;
-
- typedef struct packed {
-  fpnew_pkg::status_t ex_flag;
-  fp64_t              vf7_e64;
-  } vf7_flag_out_e64;
-
-  ///////////////////////////
-  // VFSQRT7 Look Up Table //
-  //////////////////////////
+  // vfrsqrt7 LUT
   function automatic logic [LUT_BITS-1:0] vfrsqrt7_lut(logic [LUT_BITS-1:0] vfrsqrt7_lut_select);
-      logic [LUT_BITS-1:0] vfrsqrt7_lut_out;
-      unique case (vfrsqrt7_lut_select)
-          7'd0  : vfrsqrt7_lut_out=7'd52;
-          7'd1  : vfrsqrt7_lut_out=7'd51;
-          7'd2  : vfrsqrt7_lut_out=7'd50;
-          7'd3  : vfrsqrt7_lut_out=7'd48;
-          7'd4  : vfrsqrt7_lut_out=7'd47;
-          7'd5  : vfrsqrt7_lut_out=7'd46;
-          7'd6  : vfrsqrt7_lut_out=7'd44;
-          7'd7  : vfrsqrt7_lut_out=7'd43;
-          7'd8  : vfrsqrt7_lut_out=7'd42;
-          7'd9  : vfrsqrt7_lut_out=7'd41;
-          7'd10 : vfrsqrt7_lut_out=7'd40;
-          7'd11 : vfrsqrt7_lut_out=7'd39;
-          7'd12 : vfrsqrt7_lut_out=7'd38;
-          7'd13 : vfrsqrt7_lut_out=7'd36;
-          7'd14 : vfrsqrt7_lut_out=7'd35;
-          7'd15 : vfrsqrt7_lut_out=7'd34;
-          7'd16 : vfrsqrt7_lut_out=7'd33;
-          7'd17 : vfrsqrt7_lut_out=7'd32;
-          7'd18 : vfrsqrt7_lut_out=7'd31;
-          7'd19 : vfrsqrt7_lut_out=7'd30;
-          7'd20 : vfrsqrt7_lut_out=7'd30;
-          7'd21 : vfrsqrt7_lut_out=7'd29;
-          7'd22 : vfrsqrt7_lut_out=7'd28;
-          7'd23 : vfrsqrt7_lut_out=7'd27;
-          7'd24 : vfrsqrt7_lut_out=7'd26;
-          7'd25 : vfrsqrt7_lut_out=7'd25;
-          7'd26 : vfrsqrt7_lut_out=7'd24;
-          7'd27 : vfrsqrt7_lut_out=7'd23;
-          7'd28 : vfrsqrt7_lut_out=7'd23;
-          7'd29 : vfrsqrt7_lut_out=7'd22;
-          7'd30 : vfrsqrt7_lut_out=7'd21;
-          7'd31 : vfrsqrt7_lut_out=7'd20;
-          7'd32 : vfrsqrt7_lut_out=7'd19;
-          7'd33 : vfrsqrt7_lut_out=7'd19;
-          7'd34 : vfrsqrt7_lut_out=7'd18;
-          7'd35 : vfrsqrt7_lut_out=7'd17;
-          7'd36 : vfrsqrt7_lut_out=7'd16;
-          7'd37 : vfrsqrt7_lut_out=7'd16;
-          7'd38 : vfrsqrt7_lut_out=7'd15;
-          7'd39 : vfrsqrt7_lut_out=7'd14;
-          7'd40 : vfrsqrt7_lut_out=7'd14;
-          7'd41 : vfrsqrt7_lut_out=7'd13;
-          7'd42 : vfrsqrt7_lut_out=7'd12;
-          7'd43 : vfrsqrt7_lut_out=7'd12;
-          7'd44 : vfrsqrt7_lut_out=7'd11;
-          7'd45 : vfrsqrt7_lut_out=7'd10;
-          7'd46 : vfrsqrt7_lut_out=7'd10;
-          7'd47 : vfrsqrt7_lut_out=7'd9;
-          7'd48 : vfrsqrt7_lut_out=7'd9;
-          7'd49 : vfrsqrt7_lut_out=7'd8;
-          7'd50 : vfrsqrt7_lut_out=7'd7;
-          7'd51 : vfrsqrt7_lut_out=7'd7;
-          7'd52 : vfrsqrt7_lut_out=7'd6;
-          7'd53 : vfrsqrt7_lut_out=7'd6;
-          7'd54 : vfrsqrt7_lut_out=7'd5;
-          7'd55 : vfrsqrt7_lut_out=7'd4;
-          7'd56 : vfrsqrt7_lut_out=7'd4;
-          7'd57 : vfrsqrt7_lut_out=7'd3;
-          7'd58 : vfrsqrt7_lut_out=7'd3;
-          7'd59 : vfrsqrt7_lut_out=7'd2;
-          7'd60 : vfrsqrt7_lut_out=7'd2;
-          7'd61 : vfrsqrt7_lut_out=7'd1;
-          7'd62 : vfrsqrt7_lut_out=7'd1;
-          7'd63 : vfrsqrt7_lut_out=7'd0;
-          7'd64 : vfrsqrt7_lut_out=7'd127;
-          7'd65 : vfrsqrt7_lut_out=7'd125;
-          7'd66 : vfrsqrt7_lut_out=7'd123;
-          7'd67 : vfrsqrt7_lut_out=7'd121;
-          7'd68 : vfrsqrt7_lut_out=7'd119;
-          7'd69 : vfrsqrt7_lut_out=7'd118;
-          7'd70 : vfrsqrt7_lut_out=7'd116;
-          7'd71 : vfrsqrt7_lut_out=7'd114;
-          7'd72 : vfrsqrt7_lut_out=7'd113;
-          7'd73 : vfrsqrt7_lut_out=7'd111;
-          7'd74 : vfrsqrt7_lut_out=7'd109;
-          7'd75 : vfrsqrt7_lut_out=7'd108;
-          7'd76 : vfrsqrt7_lut_out=7'd106;
-          7'd77 : vfrsqrt7_lut_out=7'd105;
-          7'd78 : vfrsqrt7_lut_out=7'd103;
-          7'd79 : vfrsqrt7_lut_out=7'd102;
-          7'd80 : vfrsqrt7_lut_out=7'd100;
-          7'd81 : vfrsqrt7_lut_out=7'd99;
-          7'd82 : vfrsqrt7_lut_out=7'd97;
-          7'd83 : vfrsqrt7_lut_out=7'd96;
-          7'd84 : vfrsqrt7_lut_out=7'd95;
-          7'd85 : vfrsqrt7_lut_out=7'd93;
-          7'd86 : vfrsqrt7_lut_out=7'd92;
-          7'd87 : vfrsqrt7_lut_out=7'd91;
-          7'd88 : vfrsqrt7_lut_out=7'd90;
-          7'd89 : vfrsqrt7_lut_out=7'd88;
-          7'd90 : vfrsqrt7_lut_out=7'd87;
-          7'd91 : vfrsqrt7_lut_out=7'd86;
-          7'd92 : vfrsqrt7_lut_out=7'd85;
-          7'd93 : vfrsqrt7_lut_out=7'd84;
-          7'd94 : vfrsqrt7_lut_out=7'd83;
-          7'd95 : vfrsqrt7_lut_out=7'd82;
-          7'd96 : vfrsqrt7_lut_out=7'd80;
-          7'd97 : vfrsqrt7_lut_out=7'd79;
-          7'd98 : vfrsqrt7_lut_out=7'd78;
-          7'd99 : vfrsqrt7_lut_out=7'd77;
-          7'd100: vfrsqrt7_lut_out=7'd76;
-          7'd101: vfrsqrt7_lut_out=7'd75;
-          7'd102: vfrsqrt7_lut_out=7'd74;
-          7'd103: vfrsqrt7_lut_out=7'd73;
-          7'd104: vfrsqrt7_lut_out=7'd72;
-          7'd105: vfrsqrt7_lut_out=7'd71;
-          7'd106: vfrsqrt7_lut_out=7'd70;
-          7'd107: vfrsqrt7_lut_out=7'd70;
-          7'd108: vfrsqrt7_lut_out=7'd69;
-          7'd109: vfrsqrt7_lut_out=7'd68;
-          7'd110: vfrsqrt7_lut_out=7'd67;
-          7'd111: vfrsqrt7_lut_out=7'd66;
-          7'd112: vfrsqrt7_lut_out=7'd65;
-          7'd113: vfrsqrt7_lut_out=7'd64;
-          7'd114: vfrsqrt7_lut_out=7'd63;
-          7'd115: vfrsqrt7_lut_out=7'd63;
-          7'd116: vfrsqrt7_lut_out=7'd62;
-          7'd117: vfrsqrt7_lut_out=7'd61;
-          7'd118: vfrsqrt7_lut_out=7'd60;
-          7'd119: vfrsqrt7_lut_out=7'd59;
-          7'd120: vfrsqrt7_lut_out=7'd59;
-          7'd121: vfrsqrt7_lut_out=7'd58;
-          7'd122: vfrsqrt7_lut_out=7'd57;
-          7'd123: vfrsqrt7_lut_out=7'd56;
-          7'd124: vfrsqrt7_lut_out=7'd56;
-          7'd125: vfrsqrt7_lut_out=7'd55;
-          7'd126: vfrsqrt7_lut_out=7'd54;
-          7'd127: vfrsqrt7_lut_out=7'd53;
-      endcase
-      return  vfrsqrt7_lut_out;
-  endfunction :  vfrsqrt7_lut
-  //////////////////////
-  //  VFRSQRT7 OUTPUT //
-  //////////////////////
-//for SEW=16
+    logic [LUT_BITS-1:0] vfrsqrt7_lut_out;
+    unique case (vfrsqrt7_lut_select)
+      7'd0  : vfrsqrt7_lut_out=7'd52;
+      7'd1  : vfrsqrt7_lut_out=7'd51;
+      7'd2  : vfrsqrt7_lut_out=7'd50;
+      7'd3  : vfrsqrt7_lut_out=7'd48;
+      7'd4  : vfrsqrt7_lut_out=7'd47;
+      7'd5  : vfrsqrt7_lut_out=7'd46;
+      7'd6  : vfrsqrt7_lut_out=7'd44;
+      7'd7  : vfrsqrt7_lut_out=7'd43;
+      7'd8  : vfrsqrt7_lut_out=7'd42;
+      7'd9  : vfrsqrt7_lut_out=7'd41;
+      7'd10 : vfrsqrt7_lut_out=7'd40;
+      7'd11 : vfrsqrt7_lut_out=7'd39;
+      7'd12 : vfrsqrt7_lut_out=7'd38;
+      7'd13 : vfrsqrt7_lut_out=7'd36;
+      7'd14 : vfrsqrt7_lut_out=7'd35;
+      7'd15 : vfrsqrt7_lut_out=7'd34;
+      7'd16 : vfrsqrt7_lut_out=7'd33;
+      7'd17 : vfrsqrt7_lut_out=7'd32;
+      7'd18 : vfrsqrt7_lut_out=7'd31;
+      7'd19 : vfrsqrt7_lut_out=7'd30;
+      7'd20 : vfrsqrt7_lut_out=7'd30;
+      7'd21 : vfrsqrt7_lut_out=7'd29;
+      7'd22 : vfrsqrt7_lut_out=7'd28;
+      7'd23 : vfrsqrt7_lut_out=7'd27;
+      7'd24 : vfrsqrt7_lut_out=7'd26;
+      7'd25 : vfrsqrt7_lut_out=7'd25;
+      7'd26 : vfrsqrt7_lut_out=7'd24;
+      7'd27 : vfrsqrt7_lut_out=7'd23;
+      7'd28 : vfrsqrt7_lut_out=7'd23;
+      7'd29 : vfrsqrt7_lut_out=7'd22;
+      7'd30 : vfrsqrt7_lut_out=7'd21;
+      7'd31 : vfrsqrt7_lut_out=7'd20;
+      7'd32 : vfrsqrt7_lut_out=7'd19;
+      7'd33 : vfrsqrt7_lut_out=7'd19;
+      7'd34 : vfrsqrt7_lut_out=7'd18;
+      7'd35 : vfrsqrt7_lut_out=7'd17;
+      7'd36 : vfrsqrt7_lut_out=7'd16;
+      7'd37 : vfrsqrt7_lut_out=7'd16;
+      7'd38 : vfrsqrt7_lut_out=7'd15;
+      7'd39 : vfrsqrt7_lut_out=7'd14;
+      7'd40 : vfrsqrt7_lut_out=7'd14;
+      7'd41 : vfrsqrt7_lut_out=7'd13;
+      7'd42 : vfrsqrt7_lut_out=7'd12;
+      7'd43 : vfrsqrt7_lut_out=7'd12;
+      7'd44 : vfrsqrt7_lut_out=7'd11;
+      7'd45 : vfrsqrt7_lut_out=7'd10;
+      7'd46 : vfrsqrt7_lut_out=7'd10;
+      7'd47 : vfrsqrt7_lut_out=7'd9;
+      7'd48 : vfrsqrt7_lut_out=7'd9;
+      7'd49 : vfrsqrt7_lut_out=7'd8;
+      7'd50 : vfrsqrt7_lut_out=7'd7;
+      7'd51 : vfrsqrt7_lut_out=7'd7;
+      7'd52 : vfrsqrt7_lut_out=7'd6;
+      7'd53 : vfrsqrt7_lut_out=7'd6;
+      7'd54 : vfrsqrt7_lut_out=7'd5;
+      7'd55 : vfrsqrt7_lut_out=7'd4;
+      7'd56 : vfrsqrt7_lut_out=7'd4;
+      7'd57 : vfrsqrt7_lut_out=7'd3;
+      7'd58 : vfrsqrt7_lut_out=7'd3;
+      7'd59 : vfrsqrt7_lut_out=7'd2;
+      7'd60 : vfrsqrt7_lut_out=7'd2;
+      7'd61 : vfrsqrt7_lut_out=7'd1;
+      7'd62 : vfrsqrt7_lut_out=7'd1;
+      7'd63 : vfrsqrt7_lut_out=7'd0;
+      7'd64 : vfrsqrt7_lut_out=7'd127;
+      7'd65 : vfrsqrt7_lut_out=7'd125;
+      7'd66 : vfrsqrt7_lut_out=7'd123;
+      7'd67 : vfrsqrt7_lut_out=7'd121;
+      7'd68 : vfrsqrt7_lut_out=7'd119;
+      7'd69 : vfrsqrt7_lut_out=7'd118;
+      7'd70 : vfrsqrt7_lut_out=7'd116;
+      7'd71 : vfrsqrt7_lut_out=7'd114;
+      7'd72 : vfrsqrt7_lut_out=7'd113;
+      7'd73 : vfrsqrt7_lut_out=7'd111;
+      7'd74 : vfrsqrt7_lut_out=7'd109;
+      7'd75 : vfrsqrt7_lut_out=7'd108;
+      7'd76 : vfrsqrt7_lut_out=7'd106;
+      7'd77 : vfrsqrt7_lut_out=7'd105;
+      7'd78 : vfrsqrt7_lut_out=7'd103;
+      7'd79 : vfrsqrt7_lut_out=7'd102;
+      7'd80 : vfrsqrt7_lut_out=7'd100;
+      7'd81 : vfrsqrt7_lut_out=7'd99;
+      7'd82 : vfrsqrt7_lut_out=7'd97;
+      7'd83 : vfrsqrt7_lut_out=7'd96;
+      7'd84 : vfrsqrt7_lut_out=7'd95;
+      7'd85 : vfrsqrt7_lut_out=7'd93;
+      7'd86 : vfrsqrt7_lut_out=7'd92;
+      7'd87 : vfrsqrt7_lut_out=7'd91;
+      7'd88 : vfrsqrt7_lut_out=7'd90;
+      7'd89 : vfrsqrt7_lut_out=7'd88;
+      7'd90 : vfrsqrt7_lut_out=7'd87;
+      7'd91 : vfrsqrt7_lut_out=7'd86;
+      7'd92 : vfrsqrt7_lut_out=7'd85;
+      7'd93 : vfrsqrt7_lut_out=7'd84;
+      7'd94 : vfrsqrt7_lut_out=7'd83;
+      7'd95 : vfrsqrt7_lut_out=7'd82;
+      7'd96 : vfrsqrt7_lut_out=7'd80;
+      7'd97 : vfrsqrt7_lut_out=7'd79;
+      7'd98 : vfrsqrt7_lut_out=7'd78;
+      7'd99 : vfrsqrt7_lut_out=7'd77;
+      7'd100: vfrsqrt7_lut_out=7'd76;
+      7'd101: vfrsqrt7_lut_out=7'd75;
+      7'd102: vfrsqrt7_lut_out=7'd74;
+      7'd103: vfrsqrt7_lut_out=7'd73;
+      7'd104: vfrsqrt7_lut_out=7'd72;
+      7'd105: vfrsqrt7_lut_out=7'd71;
+      7'd106: vfrsqrt7_lut_out=7'd70;
+      7'd107: vfrsqrt7_lut_out=7'd70;
+      7'd108: vfrsqrt7_lut_out=7'd69;
+      7'd109: vfrsqrt7_lut_out=7'd68;
+      7'd110: vfrsqrt7_lut_out=7'd67;
+      7'd111: vfrsqrt7_lut_out=7'd66;
+      7'd112: vfrsqrt7_lut_out=7'd65;
+      7'd113: vfrsqrt7_lut_out=7'd64;
+      7'd114: vfrsqrt7_lut_out=7'd63;
+      7'd115: vfrsqrt7_lut_out=7'd63;
+      7'd116: vfrsqrt7_lut_out=7'd62;
+      7'd117: vfrsqrt7_lut_out=7'd61;
+      7'd118: vfrsqrt7_lut_out=7'd60;
+      7'd119: vfrsqrt7_lut_out=7'd59;
+      7'd120: vfrsqrt7_lut_out=7'd59;
+      7'd121: vfrsqrt7_lut_out=7'd58;
+      7'd122: vfrsqrt7_lut_out=7'd57;
+      7'd123: vfrsqrt7_lut_out=7'd56;
+      7'd124: vfrsqrt7_lut_out=7'd56;
+      7'd125: vfrsqrt7_lut_out=7'd55;
+      7'd126: vfrsqrt7_lut_out=7'd54;
+      7'd127: vfrsqrt7_lut_out=7'd53;
+      default: vfrsqrt7_lut_out=7'd53;
+    endcase
+    return vfrsqrt7_lut_out;
+  endfunction : vfrsqrt7_lut
+
+  // vfrsqrt7 result (sew: 16 bit)
   function automatic vf7_flag_out_e16 vfrsqrt7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay, logic [3:0] leading_zeros_count);
-     vf7_flag_out_e16 vfrsqrt7_o;
-     fp16_t         vfrsqrt7_i;
+    vf7_flag_out_e16 vfrsqrt7_o;
+    fp16_t           vfrsqrt7_i;
 
-     logic [EXP_BITS_E16:0]  vfrsqrt7_exp_i,
-                             vfrsqrt7_exp_o;
+    logic [EXP_BITS_E16:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-     vfrsqrt7_o.vf7_e16 = 16'd0;
-     vfrsqrt7_o.ex_flag = 5'b0;
-     vfrsqrt7_i         = 16'd0;
-     vfrsqrt7_exp_o     = 6'd0;
-     vfrsqrt7_exp_i     = 6'd0;
-         unique case (vfpu_result[6:5])
-         2'b01: begin // POSSUBNORM
-                //As input is subnormal, So
-                //input exponent:
-                //0 minus the number of leading zeros
-                vfrsqrt7_exp_i = 6'd0-({2'b00,leading_zeros_count});
-                //the normalized input significand(mantissa)
-                //is given by shifting the input significand left by
-                //1 minus the input exponent
-                vfrsqrt7_i.m = operand_a_delay[9:0]<<(6'd1-vfrsqrt7_exp_i);
-         end
-         2'b10: begin // POSNORM
-                vfrsqrt7_exp_i  = {1'b0,operand_a_delay[14:10]};
-                vfrsqrt7_i.m  = operand_a_delay[9:0];
-         end
-         default: begin
-                vfrsqrt7_exp_i = 'x;
-                vfrsqrt7_i.m = 'x;
-         end
-         endcase
-       unique case (vfpu_result)
-          fpnew_pkg:: NEGINF,
-          fpnew_pkg:: NEGNORM,
-          fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: SNAN : begin
-                                 vfrsqrt7_o.vf7_e16    = E16_NaN;
-                                 vfrsqrt7_o.ex_flag.NV = 1'b1;
-                             end
-          fpnew_pkg:: QNAN :     vfrsqrt7_o.vf7_e16    = E16_NaN;
-          fpnew_pkg:: NEGZERO: begin
-                                 vfrsqrt7_o.vf7_e16    = E16_mInf;
-                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSZERO: begin
-                                 vfrsqrt7_o.vf7_e16    = E16_pInf;
-                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSINF:    vfrsqrt7_o.vf7_e16    = 16'd0;
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: POSNORM:
-                         begin
-                                //Output exponent can be found by
-                                //exp_o = (3*B-1-exp_i )/2
-                                //      = (3*B+(~exp_i))/2
-                                vfrsqrt7_exp_o = E16_3xB +(~vfrsqrt7_exp_i);
-                                     // dividing by 2
-                                vfrsqrt7_o.vf7_e16.e = vfrsqrt7_exp_o[5:1];
-                                //Output significand(mantissa) can be found by using lookup table
-                                //The address for LUT is found by concatenating LSB of the normalized input exponent and
-                                //the six MSBs of the normalized input significand
-                                vfrsqrt7_o.vf7_e16.m[9:3] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_i.m[9:4]});
-                                 //The output sign equals the input sign.
-                                vfrsqrt7_o.vf7_e16.s = vfrsqrt7_i.s;
-                         end
-         endcase
-      return vfrsqrt7_o;
+    vfrsqrt7_o.vf7_e16 = 16'd0;
+    vfrsqrt7_o.ex_flag = 5'b0;
+
+    vfrsqrt7_i     = 16'd0;
+    vfrsqrt7_exp_o = 6'd0;
+    vfrsqrt7_exp_i = 6'd0;
+
+    unique case (vfpu_result[6:5])
+      // POSSUBNORM
+      2'b01: begin
+        // As input is subnormal, So
+        // input exponent:
+        // 0 minus the number of leading zeros
+        vfrsqrt7_exp_i = 6'd0 - ({2'b00, leading_zeros_count});
+        // the normalized input significand(mantissa)
+        // is given by shifting the input significand left by
+        // 1 minus the input exponent
+        vfrsqrt7_i.m = operand_a_delay[9:0] << (6'd1 - vfrsqrt7_exp_i);
+      end
+      // POSNORM
+      2'b10: begin
+        vfrsqrt7_exp_i = {1'b0, operand_a_delay[14:10]};
+        vfrsqrt7_i.m   = operand_a_delay[9:0];
+      end
+      default: begin
+        vfrsqrt7_exp_i = 'x;
+        vfrsqrt7_i.m   = 'x;
+      end
+    endcase
+
+    unique case (vfpu_result)
+      fpnew_pkg::NEGINF,
+      fpnew_pkg::NEGNORM,
+      fpnew_pkg::NEGSUBNORM,
+      fpnew_pkg::SNAN: begin
+        vfrsqrt7_o.vf7_e16    = E16_NaN;
+        vfrsqrt7_o.ex_flag.NV = 1'b1;
+      end
+      fpnew_pkg::QNAN: vfrsqrt7_o.vf7_e16 = E16_NaN;
+      fpnew_pkg::NEGZERO: begin
+        vfrsqrt7_o.vf7_e16    = E16_mInf;
+        vfrsqrt7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSZERO: begin
+        vfrsqrt7_o.vf7_e16    = E16_pInf;
+        vfrsqrt7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSINF: vfrsqrt7_o.vf7_e16 = 16'd0;
+      fpnew_pkg::POSSUBNORM,
+      fpnew_pkg::POSNORM: begin
+        // Output exponent can be found by
+        // exp_o = (3*B-1-exp_i )/2
+        //       = (3*B+(~exp_i))/2
+        vfrsqrt7_exp_o = E16_3xB + (~vfrsqrt7_exp_i);
+        // Dividing by 2
+        vfrsqrt7_o.vf7_e16.e = vfrsqrt7_exp_o[5:1];
+        // Output significand(mantissa) can be found by using lookup table
+        // The address for LUT is found by concatenating LSB of the normalized input exponent and
+        // the six MSBs of the normalized input significand
+        vfrsqrt7_o.vf7_e16.m[9:3] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_i.m[9:4]});
+        // The output sign equals the input sign.
+        vfrsqrt7_o.vf7_e16.s = vfrsqrt7_i.s;
+      end
+      default:;
+    endcase
+    return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp16
 
-//for SEW=32
+  // vfrsqrt7 result (sew: 32 bit)
   function automatic vf7_flag_out_e32 vfrsqrt7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay, logic [4:0] leading_zeros_count);
-     vf7_flag_out_e32 vfrsqrt7_o;
-     fp32_t         vfrsqrt7_i;
+    vf7_flag_out_e32 vfrsqrt7_o;
+    fp32_t          vfrsqrt7_i;
 
-     logic [EXP_BITS_E32:0]  vfrsqrt7_exp_i,
-                             vfrsqrt7_exp_o;
+    logic [EXP_BITS_E32:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-     vfrsqrt7_o.vf7_e32     = 32'd0;
-     vfrsqrt7_o.ex_flag = 5'b0;
+    vfrsqrt7_o.vf7_e32 = 32'd0;
+    vfrsqrt7_o.ex_flag = 5'b0;
 
-     vfrsqrt7_i        = 32'd0;
-     vfrsqrt7_exp_o    = 9'd0;
-     vfrsqrt7_exp_i    = 9'd0;
-         unique case (vfpu_result[6:5])
-         2'b01: begin // POSSUBNORM
-                //As input is subnormal, So
-                //input exponent:
-                //0 minus the number of leading zeros
-                vfrsqrt7_exp_i = 9'd0-({4'b0000,leading_zeros_count});
-                //the normalized input significand(mantissa)
-                //is given by shifting the input significand left by
-                //1 minus the input exponent
-                vfrsqrt7_i.m = operand_a_delay[22:0]<<(9'd1-vfrsqrt7_exp_i);
-         end
-         2'b10: begin // POSNORM
-                vfrsqrt7_exp_i  = {1'b0,operand_a_delay[30:23]};
-                vfrsqrt7_i.m  = operand_a_delay[22:0];
-         end
-         default: begin
-                vfrsqrt7_exp_i = 'x;
-                vfrsqrt7_i.m = 'x;
-         end
-         endcase
-       unique case (vfpu_result)
-          fpnew_pkg:: NEGINF,
-          fpnew_pkg:: NEGNORM,
-          fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: SNAN : begin
-                                 vfrsqrt7_o.vf7_e32    = E32_NaN;
-                                 vfrsqrt7_o.ex_flag.NV = 1'b1;
-                             end
-          fpnew_pkg:: QNAN :     vfrsqrt7_o.vf7_e32    = E32_NaN;
-          fpnew_pkg:: NEGZERO: begin
-                                 vfrsqrt7_o.vf7_e32    = E32_mInf;
-                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSZERO: begin
-                                 vfrsqrt7_o.vf7_e32    = E32_pInf;
-                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSINF:    vfrsqrt7_o.vf7_e32     = 32'd0;
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: POSNORM:
-                         begin
-                                //Output exponent can be found by
-                                //exp_o = (3*B-1-exp_i )/2
-                                //      = (3*B+(~exp_i))/2
-                                vfrsqrt7_exp_o = E32_3xB +(~vfrsqrt7_exp_i);
-                                     // dividing by 2
-                                vfrsqrt7_o.vf7_e32.e = vfrsqrt7_exp_o[8:1];
-                                //Output significand(mantissa) can be found by using lookup table
-                                //The address for LUT is found by concatenating LSB of the normalized input exponent and
-                                //the six MSBs of the normalized input significand
-                                vfrsqrt7_o.vf7_e32.m[22:16] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[22:17]});
-                                 //The output sign equals the input sign.
-                                vfrsqrt7_o.vf7_e32.s = vfrsqrt7_i.s;
-                         end
-         endcase
-      return vfrsqrt7_o;
+    vfrsqrt7_i     = 32'd0;
+    vfrsqrt7_exp_o = 9'd0;
+    vfrsqrt7_exp_i = 9'd0;
+
+    unique case (vfpu_result[6:5])
+      // POSSUBNORM
+      2'b01: begin
+        //As input is subnormal, So
+        //input exponent:
+        //0 minus the number of leading zeros
+        vfrsqrt7_exp_i = 9'd0 - ({4'b0000, leading_zeros_count});
+        //the normalized input significand(mantissa)
+        //is given by shifting the input significand left by
+        //1 minus the input exponent
+        vfrsqrt7_i.m = operand_a_delay[22:0] << (9'd1 - vfrsqrt7_exp_i);
+      end
+      // POSNORM
+      2'b10: begin
+        vfrsqrt7_exp_i = {1'b0, operand_a_delay[30:23]};
+        vfrsqrt7_i.m   = operand_a_delay[22:0];
+      end
+      default: begin
+        vfrsqrt7_exp_i = 'x;
+        vfrsqrt7_i.m   = 'x;
+      end
+    endcase
+
+    unique case (vfpu_result)
+      fpnew_pkg::NEGINF,
+      fpnew_pkg::NEGNORM,
+      fpnew_pkg::NEGSUBNORM,
+      fpnew_pkg::SNAN: begin
+        vfrsqrt7_o.vf7_e32    = E32_NaN;
+        vfrsqrt7_o.ex_flag.NV = 1'b1;
+      end
+      fpnew_pkg::QNAN: vfrsqrt7_o.vf7_e32 = E32_NaN;
+      fpnew_pkg::NEGZERO: begin
+        vfrsqrt7_o.vf7_e32    = E32_mInf;
+        vfrsqrt7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSZERO: begin
+        vfrsqrt7_o.vf7_e32    = E32_pInf;
+        vfrsqrt7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSINF: vfrsqrt7_o.vf7_e32 = 32'd0;
+      fpnew_pkg::POSSUBNORM,
+      fpnew_pkg::POSNORM: begin
+        // Output exponent can be found by
+        // exp_o = (3*B-1-exp_i )/2
+        //       = (3*B+(~exp_i))/2
+        vfrsqrt7_exp_o = E32_3xB + (~vfrsqrt7_exp_i);
+        // dividing by 2
+        vfrsqrt7_o.vf7_e32.e = vfrsqrt7_exp_o[8:1];
+        // Output significand(mantissa) can be found by using lookup table
+        // The address for LUT is found by concatenating LSB of the normalized input exponent and
+        // the six MSBs of the normalized input significand
+        vfrsqrt7_o.vf7_e32.m[22:16] = vfrsqrt7_lut({vfrsqrt7_exp_i[0], vfrsqrt7_i.m[22:17]});
+        // The output sign equals the input sign.
+        vfrsqrt7_o.vf7_e32.s = vfrsqrt7_i.s;
+      end
+    endcase
+    return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp32
 
 
-//for SEW=64
+  // vfrsqrt7 result (sew: 64 bit)
   function automatic vf7_flag_out_e64 vfrsqrt7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay, logic [5:0] leading_zeros_count);
-     vf7_flag_out_e64 vfrsqrt7_o;
-     fp64_t     vfrsqrt7_i;
+    vf7_flag_out_e64 vfrsqrt7_o;
+    fp64_t           vfrsqrt7_i;
 
-     logic [EXP_BITS_E64:0]  vfrsqrt7_exp_i,
-                             vfrsqrt7_exp_o;
+    logic [EXP_BITS_E64:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-     vfrsqrt7_o.vf7_e64   = 64'd0;
-     vfrsqrt7_o.ex_flag = 5'b0;
+    vfrsqrt7_o.vf7_e64 = 64'd0;
+    vfrsqrt7_o.ex_flag = 5'b0;
 
-     vfrsqrt7_i        = 64'd0;
-     vfrsqrt7_exp_o    = 12'd0;
-     vfrsqrt7_exp_i    = 12'd0;
-         unique case (vfpu_result[6:5])
-         2'b01: begin // POSSUBNORM
-                //As input is subnormal, So
-                //input exponent:
-                //0 minus the number of leading zeros
-                vfrsqrt7_exp_i = 12'd0-({6'd0,leading_zeros_count});
-                //the normalized input significand(mantissa)
-                //is given by shifting the input significand left by
-                //1 minus the input exponent
-                vfrsqrt7_i.m = operand_a_delay[51:0]<<(12'd1-vfrsqrt7_exp_i);
-         end
-         2'b10: begin // POSNORM
-                vfrsqrt7_exp_i  = {1'b0,operand_a_delay[62:52]};
-                vfrsqrt7_i.m  = operand_a_delay[51:0];
-         end
-         default: begin
-                vfrsqrt7_exp_i = 'x;
-                vfrsqrt7_i.m = 'x;
-         end
-         endcase
-       unique case (vfpu_result)
-          fpnew_pkg:: NEGINF,
-          fpnew_pkg:: NEGNORM,
-          fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: SNAN : begin
-                                 vfrsqrt7_o.vf7_e64    = E64_NaN;
-                                 vfrsqrt7_o.ex_flag.NV = 1'b1;
-                             end
-          fpnew_pkg:: QNAN :     vfrsqrt7_o.vf7_e64    = E64_NaN;
-          fpnew_pkg:: NEGZERO: begin
-                                 vfrsqrt7_o.vf7_e64    = E64_mInf;
-                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSZERO: begin
-                                 vfrsqrt7_o.vf7_e64    = E64_pInf;
-                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSINF:    vfrsqrt7_o.vf7_e64    = 64'd0;
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: POSNORM:
-                         begin
-                                //Output exponent can be found by
-                                //exp_o = (3*B-1-exp_i )/2
-                                //      = (3*B+(~exp_i))/2
-                                vfrsqrt7_exp_o = E64_3xB +(~vfrsqrt7_exp_i);
-                                     // dividing by 2
-                                vfrsqrt7_o.vf7_e64.e = vfrsqrt7_exp_o[11:1];
-                                //Output significand(mantissa) can be found by using lookup table
-                                //The address for LUT is found by concatenating LSB of the normalized input exponent and
-                                //the six MSBs of the normalized input significand
-                                vfrsqrt7_o.vf7_e64.m[51:45] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[51:46]});
-                                 //The output sign equals the input sign.
-                                vfrsqrt7_o.vf7_e64.s = vfrsqrt7_i.s;
-                         end
-         endcase
-      return vfrsqrt7_o;
+    vfrsqrt7_i     = 64'd0;
+    vfrsqrt7_exp_o = 12'd0;
+    vfrsqrt7_exp_i = 12'd0;
+
+    unique case (vfpu_result[6:5])
+    // POSSUBNORM
+    2'b01: begin
+      // As input is subnormal, So
+      // input exponent:
+      // 0 minus the number of leading zeros
+      vfrsqrt7_exp_i = 12'd0 - ({6'd0, leading_zeros_count});
+      // the normalized input significand(mantissa)
+      // is given by shifting the input significand left by
+      // 1 minus the input exponent
+      vfrsqrt7_i.m = operand_a_delay[51:0] << (12'd1 - vfrsqrt7_exp_i);
+    end
+    // POSNORM
+    2'b10: begin
+      vfrsqrt7_exp_i = {1'b0, operand_a_delay[62:52]};
+      vfrsqrt7_i.m   = operand_a_delay[51:0];
+    end
+    default: begin
+      vfrsqrt7_exp_i = 'x;
+      vfrsqrt7_i.m   = 'x;
+    end
+    endcase
+    unique case (vfpu_result)
+       fpnew_pkg::NEGINF,
+       fpnew_pkg::NEGNORM,
+       fpnew_pkg::NEGSUBNORM,
+       fpnew_pkg::SNAN: begin
+         vfrsqrt7_o.vf7_e64    = E64_NaN;
+         vfrsqrt7_o.ex_flag.NV = 1'b1;
+       end
+       fpnew_pkg::QNAN: vfrsqrt7_o.vf7_e64 = E64_NaN;
+       fpnew_pkg::NEGZERO: begin
+         vfrsqrt7_o.vf7_e64    = E64_mInf;
+         vfrsqrt7_o.ex_flag.DZ = 1'b1;
+       end
+       fpnew_pkg::POSZERO: begin
+         vfrsqrt7_o.vf7_e64    = E64_pInf;
+         vfrsqrt7_o.ex_flag.DZ = 1'b1;
+       end
+       fpnew_pkg::POSINF: vfrsqrt7_o.vf7_e64 = 64'd0;
+       fpnew_pkg::POSSUBNORM,
+       fpnew_pkg::POSNORM: begin
+         // Output exponent can be found by
+         // exp_o = (3*B-1-exp_i )/2
+         //       = (3*B+(~exp_i))/2
+         vfrsqrt7_exp_o = E64_3xB +(~vfrsqrt7_exp_i);
+         // dividing by 2
+         vfrsqrt7_o.vf7_e64.e = vfrsqrt7_exp_o[11:1];
+         // Output significand(mantissa) can be found by using lookup table
+         // The address for LUT is found by concatenating LSB of the normalized input exponent and
+         // the six MSBs of the normalized input significand
+         vfrsqrt7_o.vf7_e64.m[51:45] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[51:46]});
+         // The output sign equals the input sign.
+         vfrsqrt7_o.vf7_e64.s = vfrsqrt7_i.s;
+      end
+    endcase
+    return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp64
 
 endpackage : ara_pkg

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1719,12 +1719,10 @@ package ara_pkg;
 
     logic [EXP_BITS_E16:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-    vfrsqrt7_o.vf7_e16 = 16'd0;
-    vfrsqrt7_o.ex_flag = 5'b0;
-
-    vfrsqrt7_i     = 16'd0;
-    vfrsqrt7_exp_o = 6'd0;
-    vfrsqrt7_exp_i = 6'd0;
+    vfrsqrt7_o.vf7_e16 = 21'd0;
+    vfrsqrt7_i         = 16'd0;
+    vfrsqrt7_exp_o     = 6'd0;
+    vfrsqrt7_exp_i     = 6'd0;
 
     unique case (vfpu_result[6:5])
       // POSSUBNORM
@@ -1794,12 +1792,10 @@ package ara_pkg;
 
     logic [EXP_BITS_E32:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-    vfrsqrt7_o.vf7_e32 = 32'd0;
-    vfrsqrt7_o.ex_flag = 5'b0;
-
-    vfrsqrt7_i     = 32'd0;
-    vfrsqrt7_exp_o = 9'd0;
-    vfrsqrt7_exp_i = 9'd0;
+    vfrsqrt7_o.vf7_e32 = 37'd0;
+    vfrsqrt7_i         = 32'd0;
+    vfrsqrt7_exp_o     = 9'd0;
+    vfrsqrt7_exp_i     = 9'd0;
 
     unique case (vfpu_result[6:5])
       // POSSUBNORM
@@ -1862,7 +1858,6 @@ package ara_pkg;
     return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp32
 
-
   // vfrsqrt7 result (sew: 64 bit)
   function automatic vf7_flag_out_e64 vfrsqrt7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay, logic [5:0] leading_zeros_count);
     vf7_flag_out_e64 vfrsqrt7_o;
@@ -1870,12 +1865,10 @@ package ara_pkg;
 
     logic [EXP_BITS_E64:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-    vfrsqrt7_o.vf7_e64 = 64'd0;
-    vfrsqrt7_o.ex_flag = 5'b0;
-
-    vfrsqrt7_i     = 64'd0;
-    vfrsqrt7_exp_o = 12'd0;
-    vfrsqrt7_exp_i = 12'd0;
+    vfrsqrt7_o.vf7_e64 = 69'd0;
+    vfrsqrt7_i         = 64'd0;
+    vfrsqrt7_exp_o     = 12'd0;
+    vfrsqrt7_exp_i     = 12'd0;
 
     unique case (vfpu_result[6:5])
     // POSSUBNORM

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1570,9 +1570,6 @@ package ara_pkg;
     return vfrec7_out;
   endfunction : vfrec7_fp64
 
-  ///////////////////////////
-  // VFSQRT7 Look Up Table //
-  //////////////////////////
 localparam int unsigned LUT_BITS     = 7;
 localparam int unsigned E16_BITS     = 16;
 localparam int unsigned E32_BITS     = 32;
@@ -1592,30 +1589,33 @@ localparam logic [15:0] E16_NaN   = 16'h7e00;
 localparam logic [15:0] E16_pInf  = 16'h7c00;
 localparam logic [15:0] E16_mInf  = 16'hfc00;
 
-localparam int unsigned E32_NaN   = 32'h7fc00000;
-localparam int unsigned E32_pInf  = 32'h7f800000;
-localparam int unsigned E32_mInf  = 32'hff800000;
+localparam logic [31:0] E32_NaN   = 32'h7fc00000;
+localparam logic [31:0] E32_pInf  = 32'h7f800000;
+localparam logic [31:0] E32_mInf  = 32'hff800000;
 
 localparam logic [63:0] E64_NaN   = 64'h7ff8000000000000;
 localparam logic [63:0] E64_pInf  = 64'h7ff0000000000000;
 localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
 
-
+// Structure containing 5 bit flag and desired output
  typedef struct packed {
   fpnew_pkg::status_t ex_flag;
   fp16_t              vf7_e16;
-  } vf7_struct_e16;
+ } vf7_flag_out_e16;
 
   typedef struct packed {
   fpnew_pkg::status_t ex_flag;
   fp32_t              vf7_e32;
-  } vf7_struct_e32;
+  } vf7_flag_out_e32;
 
  typedef struct packed {
   fpnew_pkg::status_t ex_flag;
   fp64_t              vf7_e64;
-  } vf7_struct_e64;
+  } vf7_flag_out_e64;
 
+  ///////////////////////////
+  // VFSQRT7 Look Up Table //
+  //////////////////////////
   function automatic logic [LUT_BITS-1:0] vfrsqrt7_lut(logic [LUT_BITS-1:0] vfrsqrt7_lut_select);
       logic [LUT_BITS-1:0] vfrsqrt7_lut_out;
       unique case (vfrsqrt7_lut_select)
@@ -1750,12 +1750,12 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
       endcase
       return  vfrsqrt7_lut_out;
   endfunction :  vfrsqrt7_lut
-  ////////////////////
+  //////////////////////
   //  VFRSQRT7 OUTPUT //
-  ////////////////////
+  //////////////////////
 //for SEW=16
-  function automatic vf7_struct_e16 vfrsqrt7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay, logic [3:0] leading_zeros_count);
-     vf7_struct_e16 vfrsqrt7_o;
+  function automatic vf7_flag_out_e16 vfrsqrt7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay, logic [3:0] leading_zeros_count);
+     vf7_flag_out_e16 vfrsqrt7_o;
      fp16_t         vfrsqrt7_i;
 
      logic [EXP_BITS_E16:0]  vfrsqrt7_exp_i,
@@ -1813,8 +1813,8 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
                                 vfrsqrt7_exp_o = E16_3xB +(~vfrsqrt7_exp_i);
                                      // dividing by 2
                                 vfrsqrt7_o.vf7_e16.e = vfrsqrt7_exp_o[5:1];
-                                //Output significand(mantissa) can be found by
-                                //concatenating LSB of the normalized input exponent and
+                                //Output significand(mantissa) can be found by using lookup table
+                                //The address for LUT is found by concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
                                 vfrsqrt7_o.vf7_e16.m[9:3] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_i.m[9:4]});
                                  //The output sign equals the input sign.
@@ -1825,8 +1825,8 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
   endfunction : vfrsqrt7_fp16
 
 //for SEW=32
-  function automatic vf7_struct_e32 vfrsqrt7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay, logic [4:0] leading_zeros_count);
-     vf7_struct_e32 vfrsqrt7_o;
+  function automatic vf7_flag_out_e32 vfrsqrt7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay, logic [4:0] leading_zeros_count);
+     vf7_flag_out_e32 vfrsqrt7_o;
      fp32_t         vfrsqrt7_i;
 
      logic [EXP_BITS_E32:0]  vfrsqrt7_exp_i,
@@ -1885,8 +1885,8 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
                                 vfrsqrt7_exp_o = E32_3xB +(~vfrsqrt7_exp_i);
                                      // dividing by 2
                                 vfrsqrt7_o.vf7_e32.e = vfrsqrt7_exp_o[8:1];
-                                //Output significand(mantissa) can be found by
-                                //concatenating LSB of the normalized input exponent and
+                                //Output significand(mantissa) can be found by using lookup table
+                                //The address for LUT is found by concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
                                 vfrsqrt7_o.vf7_e32.m[22:16] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[22:17]});
                                  //The output sign equals the input sign.
@@ -1898,8 +1898,8 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
 
 
 //for SEW=64
-  function automatic vf7_struct_e64 vfrsqrt7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay, logic [5:0] leading_zeros_count);
-     vf7_struct_e64 vfrsqrt7_o;
+  function automatic vf7_flag_out_e64 vfrsqrt7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay, logic [5:0] leading_zeros_count);
+     vf7_flag_out_e64 vfrsqrt7_o;
      fp64_t     vfrsqrt7_i;
 
      logic [EXP_BITS_E64:0]  vfrsqrt7_exp_i,
@@ -1958,8 +1958,8 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
                                 vfrsqrt7_exp_o = E64_3xB +(~vfrsqrt7_exp_i);
                                      // dividing by 2
                                 vfrsqrt7_o.vf7_e64.e = vfrsqrt7_exp_o[11:1];
-                                //Output significand(mantissa) can be found by
-                                //concatenating LSB of the normalized input exponent and
+                                //Output significand(mantissa) can be found by using lookup table
+                                //The address for LUT is found by concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
                                 vfrsqrt7_o.vf7_e64.m[51:45] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[51:46]});
                                  //The output sign equals the input sign.

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1014,7 +1014,6 @@ package ara_pkg;
   } addrgen_axi_req_t;
 
 
-
     ////////////////////////
     // VFREC7 & VFRSQRT7 //
     ///////////////////////
@@ -1038,19 +1037,13 @@ package ara_pkg;
   localparam logic [15:0] E16_NaN  = 16'h7e00;
   localparam logic [15:0] E16_pInf = 16'h7c00;
   localparam logic [15:0] E16_mInf = 16'hfc00;
-  localparam logic [14:0] E16_Max  = 15'h7bff;
-  localparam logic [14:0] E16_Inf  = 15'h7c00;
 
   localparam logic [14:0] E16_Max  = 15'h7bff;     // Max Number without sign
   localparam logic [14:0] E16_Inf  = 15'h7c00;     // Inf without sign
 
-
   localparam logic [31:0] E32_NaN  = 32'h7fc00000;
   localparam logic [31:0] E32_pInf = 32'h7f800000;
   localparam logic [31:0] E32_mInf = 32'hff800000;
-  localparam logic [30:0] E32_Max  = 31'h7f7fffff;
-  localparam logic [30:0] E32_Inf  = 31'hff800000;
-
 
   localparam logic [30:0] E32_Max  = 31'h7f7fffff;  // Max Number without sign
   localparam logic [30:0] E32_Inf  = 31'hff800000;  // Inf without sign
@@ -1058,8 +1051,6 @@ package ara_pkg;
   localparam logic [63:0] E64_NaN  = 64'h7ff8000000000000;
   localparam logic [63:0] E64_pInf = 64'h7ff0000000000000;
   localparam logic [63:0] E64_mInf = 64'hfff0000000000000;
-  localparam logic [62:0] E64_Max  = 63'h7fefffffffffffff;
-  localparam logic [62:0] E64_Inf  = 63'h7ff0000000000000;
 
   localparam logic  [5:0] E16_3xB = 6'd45;
   localparam logic  [8:0] E32_3xB = 9'd381;

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1602,19 +1602,19 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
 
 
  typedef struct packed {
-  fpnew_pkg::status_t vfrsqrt7_ex_flag;
-  fp16_t              vfrsqrt7_e16;
-  } vfr_struct_e16;
+  fpnew_pkg::status_t ex_flag;
+  fp16_t              vf7_e16;
+  } vf7_struct_e16;
 
   typedef struct packed {
-  fpnew_pkg::status_t vfrsqrt7_ex_flag;
-  fp32_t              vfrsqrt7_e32;
-  } vfr_struct_e32;
+  fpnew_pkg::status_t ex_flag;
+  fp32_t              vf7_e32;
+  } vf7_struct_e32;
 
  typedef struct packed {
-  fpnew_pkg::status_t vfrsqrt7_ex_flag;
-  fp64_t              vfrsqrt7_e64;
-  } vfr_struct_e64;
+  fpnew_pkg::status_t ex_flag;
+  fp64_t              vf7_e64;
+  } vf7_struct_e64;
 
   function automatic logic [LUT_BITS-1:0] vfrsqrt7_lut(logic [LUT_BITS-1:0] vfrsqrt7_lut_select);
       logic [LUT_BITS-1:0] vfrsqrt7_lut_out;
@@ -1754,18 +1754,18 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
   //  VFRSQRT7 OUTPUT //
   ////////////////////
 //for SEW=16
-  function automatic vfr_struct_e16 vfrsqrt7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay, logic [3:0] leading_zeros_count);
-     vfr_struct_e16 vfrsqrt7_o;
+  function automatic vf7_struct_e16 vfrsqrt7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay, logic [3:0] leading_zeros_count);
+     vf7_struct_e16 vfrsqrt7_o;
      fp16_t         vfrsqrt7_i;
 
      logic [EXP_BITS_E16:0]  vfrsqrt7_exp_i,
                              vfrsqrt7_exp_o;
 
-     vfrsqrt7_o.vfrsqrt7_e16     = 16'd0;
-     vfrsqrt7_o.vfrsqrt7_ex_flag = '{1'b0, 1'b0, 1'b0, 1'b0, 1'b0};
-     vfrsqrt7_i        = 16'd0;
-     vfrsqrt7_exp_o    = 6'd0;
-     vfrsqrt7_exp_i    = 6'd0;
+     vfrsqrt7_o.vf7_e16 = 16'd0;
+     vfrsqrt7_o.ex_flag = 5'b0;
+     vfrsqrt7_i         = 16'd0;
+     vfrsqrt7_exp_o     = 6'd0;
+     vfrsqrt7_exp_i     = 6'd0;
          unique case (vfpu_result[6:5])
          2'b01: begin // POSSUBNORM
                 //As input is subnormal, So
@@ -1790,20 +1790,20 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
           fpnew_pkg:: NEGINF,
           fpnew_pkg:: NEGNORM,
           fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: QNAN : begin
-                                 vfrsqrt7_o.vfrsqrt7_e16 = E16_NaN;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.NV=1'b1;
+          fpnew_pkg:: SNAN : begin
+                                 vfrsqrt7_o.vf7_e16    = E16_NaN;
+                                 vfrsqrt7_o.ex_flag.NV = 1'b1;
                              end
-          fpnew_pkg:: SNAN :     vfrsqrt7_o.vfrsqrt7_e16 = E16_NaN;
+          fpnew_pkg:: QNAN :     vfrsqrt7_o.vf7_e16    = E16_NaN;
           fpnew_pkg:: NEGZERO: begin
-                                 vfrsqrt7_o.vfrsqrt7_e16 = E16_mInf;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ=1'b1;
+                                 vfrsqrt7_o.vf7_e16    = E16_mInf;
+                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
                                end
           fpnew_pkg:: POSZERO: begin
-                                 vfrsqrt7_o.vfrsqrt7_e16 = E16_pInf;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ=1'b1;
+                                 vfrsqrt7_o.vf7_e16    = E16_pInf;
+                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
                                end
-          fpnew_pkg:: POSINF:    vfrsqrt7_o.vfrsqrt7_e16 = 16'd0;
+          fpnew_pkg:: POSINF:    vfrsqrt7_o.vf7_e16    = 16'd0;
           fpnew_pkg:: POSSUBNORM,
           fpnew_pkg:: POSNORM:
                          begin
@@ -1812,28 +1812,28 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
                                 //      = (3*B+(~exp_i))/2
                                 vfrsqrt7_exp_o = E16_3xB +(~vfrsqrt7_exp_i);
                                      // dividing by 2
-                                vfrsqrt7_o.vfrsqrt7_e16.e = vfrsqrt7_exp_o[5:1];
+                                vfrsqrt7_o.vf7_e16.e = vfrsqrt7_exp_o[5:1];
                                 //Output significand(mantissa) can be found by
                                 //concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
-                                vfrsqrt7_o.vfrsqrt7_e16.m[9:3] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_i.m[9:4]});
+                                vfrsqrt7_o.vf7_e16.m[9:3] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_i.m[9:4]});
                                  //The output sign equals the input sign.
-                                vfrsqrt7_o.vfrsqrt7_e16.s = vfrsqrt7_i.s;
+                                vfrsqrt7_o.vf7_e16.s = vfrsqrt7_i.s;
                          end
          endcase
       return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp16
 
 //for SEW=32
-  function automatic vfr_struct_e32 vfrsqrt7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay, logic [4:0] leading_zeros_count);
-     vfr_struct_e32 vfrsqrt7_o;
+  function automatic vf7_struct_e32 vfrsqrt7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay, logic [4:0] leading_zeros_count);
+     vf7_struct_e32 vfrsqrt7_o;
      fp32_t         vfrsqrt7_i;
 
      logic [EXP_BITS_E32:0]  vfrsqrt7_exp_i,
                              vfrsqrt7_exp_o;
 
-     vfrsqrt7_o.vfrsqrt7_e32     = 32'd0;
-     vfrsqrt7_o.vfrsqrt7_ex_flag = '{1'b0, 1'b0, 1'b0, 1'b0, 1'b0};
+     vfrsqrt7_o.vf7_e32     = 32'd0;
+     vfrsqrt7_o.ex_flag = 5'b0;
 
      vfrsqrt7_i        = 32'd0;
      vfrsqrt7_exp_o    = 9'd0;
@@ -1862,20 +1862,20 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
           fpnew_pkg:: NEGINF,
           fpnew_pkg:: NEGNORM,
           fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: QNAN : begin
-                                 vfrsqrt7_o.vfrsqrt7_e32 = E32_NaN;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.NV=1'b1;
+          fpnew_pkg:: SNAN : begin
+                                 vfrsqrt7_o.vf7_e32    = E32_NaN;
+                                 vfrsqrt7_o.ex_flag.NV = 1'b1;
                              end
-          fpnew_pkg:: SNAN :     vfrsqrt7_o.vfrsqrt7_e32 = E32_NaN;
+          fpnew_pkg:: QNAN :     vfrsqrt7_o.vf7_e32    = E32_NaN;
           fpnew_pkg:: NEGZERO: begin
-                                 vfrsqrt7_o.vfrsqrt7_e32 = E32_mInf;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ=1'b1;
+                                 vfrsqrt7_o.vf7_e32    = E32_mInf;
+                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
                                end
           fpnew_pkg:: POSZERO: begin
-                                 vfrsqrt7_o.vfrsqrt7_e32 = E32_pInf;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ=1'b1;
+                                 vfrsqrt7_o.vf7_e32    = E32_pInf;
+                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
                                end
-          fpnew_pkg:: POSINF:    vfrsqrt7_o.vfrsqrt7_e32 = 32'd0;
+          fpnew_pkg:: POSINF:    vfrsqrt7_o.vf7_e32     = 32'd0;
           fpnew_pkg:: POSSUBNORM,
           fpnew_pkg:: POSNORM:
                          begin
@@ -1884,13 +1884,13 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
                                 //      = (3*B+(~exp_i))/2
                                 vfrsqrt7_exp_o = E32_3xB +(~vfrsqrt7_exp_i);
                                      // dividing by 2
-                                vfrsqrt7_o.vfrsqrt7_e32.e = vfrsqrt7_exp_o[8:1];
+                                vfrsqrt7_o.vf7_e32.e = vfrsqrt7_exp_o[8:1];
                                 //Output significand(mantissa) can be found by
                                 //concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
-                                vfrsqrt7_o.vfrsqrt7_e32.m[22:16] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[22:17]});
+                                vfrsqrt7_o.vf7_e32.m[22:16] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[22:17]});
                                  //The output sign equals the input sign.
-                                vfrsqrt7_o.vfrsqrt7_e32.s = vfrsqrt7_i.s;
+                                vfrsqrt7_o.vf7_e32.s = vfrsqrt7_i.s;
                          end
          endcase
       return vfrsqrt7_o;
@@ -1898,15 +1898,15 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
 
 
 //for SEW=64
-  function automatic vfr_struct_e64 vfrsqrt7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay, logic [5:0] leading_zeros_count);
-     vfr_struct_e64 vfrsqrt7_o;
+  function automatic vf7_struct_e64 vfrsqrt7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay, logic [5:0] leading_zeros_count);
+     vf7_struct_e64 vfrsqrt7_o;
      fp64_t     vfrsqrt7_i;
 
      logic [EXP_BITS_E64:0]  vfrsqrt7_exp_i,
                              vfrsqrt7_exp_o;
 
-     vfrsqrt7_o.vfrsqrt7_e64   = 64'd0;
-     vfrsqrt7_o.vfrsqrt7_ex_flag = '{1'b0, 1'b0, 1'b0, 1'b0, 1'b0};
+     vfrsqrt7_o.vf7_e64   = 64'd0;
+     vfrsqrt7_o.ex_flag = 5'b0;
 
      vfrsqrt7_i        = 64'd0;
      vfrsqrt7_exp_o    = 12'd0;
@@ -1935,20 +1935,20 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
           fpnew_pkg:: NEGINF,
           fpnew_pkg:: NEGNORM,
           fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: QNAN : begin
-                                 vfrsqrt7_o.vfrsqrt7_e64        = E64_NaN;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.NV = 1'b1;
+          fpnew_pkg:: SNAN : begin
+                                 vfrsqrt7_o.vf7_e64    = E64_NaN;
+                                 vfrsqrt7_o.ex_flag.NV = 1'b1;
                              end
-          fpnew_pkg:: SNAN :     vfrsqrt7_o.vfrsqrt7_e64        = E64_NaN;
+          fpnew_pkg:: QNAN :     vfrsqrt7_o.vf7_e64    = E64_NaN;
           fpnew_pkg:: NEGZERO: begin
-                                 vfrsqrt7_o.vfrsqrt7_e64        = E64_mInf;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ = 1'b1;
+                                 vfrsqrt7_o.vf7_e64    = E64_mInf;
+                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
                                end
           fpnew_pkg:: POSZERO: begin
-                                 vfrsqrt7_o.vfrsqrt7_e64        = E64_pInf;
-                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ = 1'b1;
+                                 vfrsqrt7_o.vf7_e64    = E64_pInf;
+                                 vfrsqrt7_o.ex_flag.DZ = 1'b1;
                                end
-          fpnew_pkg:: POSINF:    vfrsqrt7_o.vfrsqrt7_e64        = 64'd0;
+          fpnew_pkg:: POSINF:    vfrsqrt7_o.vf7_e64    = 64'd0;
           fpnew_pkg:: POSSUBNORM,
           fpnew_pkg:: POSNORM:
                          begin
@@ -1957,13 +1957,13 @@ localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
                                 //      = (3*B+(~exp_i))/2
                                 vfrsqrt7_exp_o = E64_3xB +(~vfrsqrt7_exp_i);
                                      // dividing by 2
-                                vfrsqrt7_o.vfrsqrt7_e64.e = vfrsqrt7_exp_o[11:1];
+                                vfrsqrt7_o.vf7_e64.e = vfrsqrt7_exp_o[11:1];
                                 //Output significand(mantissa) can be found by
                                 //concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
-                                vfrsqrt7_o.vfrsqrt7_e64.m[51:45] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[51:46]});
+                                vfrsqrt7_o.vf7_e64.m[51:45] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[51:46]});
                                  //The output sign equals the input sign.
-                                vfrsqrt7_o.vfrsqrt7_e64.s = vfrsqrt7_i.s;
+                                vfrsqrt7_o.vf7_e64.s = vfrsqrt7_i.s;
                          end
          endcase
       return vfrsqrt7_o;

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -131,7 +131,7 @@ package ara_pkg;
     VDIVU, VDIV, VREMU, VREM,
     // FPU
     VFADD, VFSUB, VFRSUB, VFMUL, VFDIV, VFRDIV, VFMACC, VFNMACC, VFMSAC, VFNMSAC, VFMADD, VFNMADD, VFMSUB,
-    VFNMSUB, VFSQRT, VFMIN, VFMAX, VFREC7, VFCLASS, VFSGNJ, VFSGNJN, VFSGNJX, VFCVTXUF, VFCVTXF, VFCVTFXU, VFCVTFX,
+    VFNMSUB, VFSQRT, VFMIN, VFMAX, VFREC7, VFRSQRT7, VFCLASS, VFSGNJ, VFSGNJN, VFSGNJX, VFCVTXUF, VFCVTXF, VFCVTFXU, VFCVTFX,
     VFCVTRTZXUF, VFCVTRTZXF, VFCVTFF,
     // Floating-point reductions
     VFREDUSUM, VFREDOSUM, VFREDMIN, VFREDMAX, VFWREDUSUM, VFWREDOSUM,
@@ -1569,5 +1569,338 @@ package ara_pkg;
     endcase
     return vfrec7_out;
   endfunction : vfrec7_fp64
+
+///////////////////////////
+  // VFSQRT7 Look Up Table //
+  //////////////////////////
+
+  function automatic logic [6:0] vfrsqrt7_lut(logic [6:0] vfrsqrt7_lut_select);
+      logic [6:0] vfrsqrt7_lut_out;
+      unique case (vfrsqrt7_lut_select)
+          7'd0  : vfrsqrt7_lut_out=7'd52;
+          7'd1  : vfrsqrt7_lut_out=7'd51;
+          7'd2  : vfrsqrt7_lut_out=7'd50;
+          7'd3  : vfrsqrt7_lut_out=7'd48;
+          7'd4  : vfrsqrt7_lut_out=7'd47;
+          7'd5  : vfrsqrt7_lut_out=7'd46;
+          7'd6  : vfrsqrt7_lut_out=7'd44;
+          7'd7  : vfrsqrt7_lut_out=7'd43;
+          7'd8  : vfrsqrt7_lut_out=7'd42;
+          7'd9  : vfrsqrt7_lut_out=7'd41;
+          7'd10 : vfrsqrt7_lut_out=7'd40;
+          7'd11 : vfrsqrt7_lut_out=7'd39;
+          7'd12 : vfrsqrt7_lut_out=7'd38;
+          7'd13 : vfrsqrt7_lut_out=7'd36;
+          7'd14 : vfrsqrt7_lut_out=7'd35;
+          7'd15 : vfrsqrt7_lut_out=7'd34;
+          7'd16 : vfrsqrt7_lut_out=7'd33;
+          7'd17 : vfrsqrt7_lut_out=7'd32;
+          7'd18 : vfrsqrt7_lut_out=7'd31;
+          7'd19 : vfrsqrt7_lut_out=7'd30;
+          7'd20 : vfrsqrt7_lut_out=7'd30;
+          7'd21 : vfrsqrt7_lut_out=7'd29;
+          7'd22 : vfrsqrt7_lut_out=7'd28;
+          7'd23 : vfrsqrt7_lut_out=7'd27;
+          7'd24 : vfrsqrt7_lut_out=7'd26;
+          7'd25 : vfrsqrt7_lut_out=7'd25;
+          7'd26 : vfrsqrt7_lut_out=7'd24;
+          7'd27 : vfrsqrt7_lut_out=7'd23;
+          7'd28 : vfrsqrt7_lut_out=7'd23;
+          7'd29 : vfrsqrt7_lut_out=7'd22;
+          7'd30 : vfrsqrt7_lut_out=7'd21;
+          7'd31 : vfrsqrt7_lut_out=7'd20;
+          7'd32 : vfrsqrt7_lut_out=7'd19;
+          7'd33 : vfrsqrt7_lut_out=7'd19;
+          7'd34 : vfrsqrt7_lut_out=7'd18;
+          7'd35 : vfrsqrt7_lut_out=7'd17;
+          7'd36 : vfrsqrt7_lut_out=7'd16;
+          7'd37 : vfrsqrt7_lut_out=7'd16;
+          7'd38 : vfrsqrt7_lut_out=7'd15;
+          7'd39 : vfrsqrt7_lut_out=7'd14;
+          7'd40 : vfrsqrt7_lut_out=7'd14;
+          7'd41 : vfrsqrt7_lut_out=7'd13;
+          7'd42 : vfrsqrt7_lut_out=7'd12;
+          7'd43 : vfrsqrt7_lut_out=7'd12;
+          7'd44 : vfrsqrt7_lut_out=7'd11;
+          7'd45 : vfrsqrt7_lut_out=7'd10;
+          7'd46 : vfrsqrt7_lut_out=7'd10;
+          7'd47 : vfrsqrt7_lut_out=7'd9;
+          7'd48 : vfrsqrt7_lut_out=7'd9;
+          7'd49 : vfrsqrt7_lut_out=7'd8;
+          7'd50 : vfrsqrt7_lut_out=7'd7;
+          7'd51 : vfrsqrt7_lut_out=7'd7;
+          7'd52 : vfrsqrt7_lut_out=7'd6;
+          7'd53 : vfrsqrt7_lut_out=7'd6;
+          7'd54 : vfrsqrt7_lut_out=7'd5;
+          7'd55 : vfrsqrt7_lut_out=7'd4;
+          7'd56 : vfrsqrt7_lut_out=7'd4;
+          7'd57 : vfrsqrt7_lut_out=7'd3;
+          7'd58 : vfrsqrt7_lut_out=7'd3;
+          7'd59 : vfrsqrt7_lut_out=7'd2;
+          7'd60 : vfrsqrt7_lut_out=7'd2;
+          7'd61 : vfrsqrt7_lut_out=7'd1;
+          7'd62 : vfrsqrt7_lut_out=7'd1;
+          7'd63 : vfrsqrt7_lut_out=7'd0;
+          7'd64 : vfrsqrt7_lut_out=7'd127;
+          7'd65 : vfrsqrt7_lut_out=7'd125;
+          7'd66 : vfrsqrt7_lut_out=7'd123;
+          7'd67 : vfrsqrt7_lut_out=7'd121;
+          7'd68 : vfrsqrt7_lut_out=7'd119;
+          7'd69 : vfrsqrt7_lut_out=7'd118;
+          7'd70 : vfrsqrt7_lut_out=7'd116;
+          7'd71 : vfrsqrt7_lut_out=7'd114;
+          7'd72 : vfrsqrt7_lut_out=7'd113;
+          7'd73 : vfrsqrt7_lut_out=7'd111;
+          7'd74 : vfrsqrt7_lut_out=7'd109;
+          7'd75 : vfrsqrt7_lut_out=7'd108;
+          7'd76 : vfrsqrt7_lut_out=7'd106;
+          7'd77 : vfrsqrt7_lut_out=7'd105;
+          7'd78 : vfrsqrt7_lut_out=7'd103;
+          7'd79 : vfrsqrt7_lut_out=7'd102;
+          7'd80 : vfrsqrt7_lut_out=7'd100;
+          7'd81 : vfrsqrt7_lut_out=7'd99;
+          7'd82 : vfrsqrt7_lut_out=7'd97;
+          7'd83 : vfrsqrt7_lut_out=7'd96;
+          7'd84 : vfrsqrt7_lut_out=7'd95;
+          7'd85 : vfrsqrt7_lut_out=7'd93;
+          7'd86 : vfrsqrt7_lut_out=7'd92;
+          7'd87 : vfrsqrt7_lut_out=7'd91;
+          7'd88 : vfrsqrt7_lut_out=7'd90;
+          7'd89 : vfrsqrt7_lut_out=7'd88;
+          7'd90 : vfrsqrt7_lut_out=7'd87;
+          7'd91 : vfrsqrt7_lut_out=7'd86;
+          7'd92 : vfrsqrt7_lut_out=7'd85;
+          7'd93 : vfrsqrt7_lut_out=7'd84;
+          7'd94 : vfrsqrt7_lut_out=7'd83;
+          7'd95 : vfrsqrt7_lut_out=7'd82;
+          7'd96 : vfrsqrt7_lut_out=7'd80;
+          7'd97 : vfrsqrt7_lut_out=7'd79;
+          7'd98 : vfrsqrt7_lut_out=7'd78;
+          7'd99 : vfrsqrt7_lut_out=7'd77;
+          7'd100: vfrsqrt7_lut_out=7'd76;
+          7'd101: vfrsqrt7_lut_out=7'd75;
+          7'd102: vfrsqrt7_lut_out=7'd74;
+          7'd103: vfrsqrt7_lut_out=7'd73;
+          7'd104: vfrsqrt7_lut_out=7'd72;
+          7'd105: vfrsqrt7_lut_out=7'd71;
+          7'd106: vfrsqrt7_lut_out=7'd70;
+          7'd107: vfrsqrt7_lut_out=7'd70;
+          7'd108: vfrsqrt7_lut_out=7'd69;
+          7'd109: vfrsqrt7_lut_out=7'd68;
+          7'd110: vfrsqrt7_lut_out=7'd67;
+          7'd111: vfrsqrt7_lut_out=7'd66;
+          7'd112: vfrsqrt7_lut_out=7'd65;
+          7'd113: vfrsqrt7_lut_out=7'd64;
+          7'd114: vfrsqrt7_lut_out=7'd63;
+          7'd115: vfrsqrt7_lut_out=7'd63;
+          7'd116: vfrsqrt7_lut_out=7'd62;
+          7'd117: vfrsqrt7_lut_out=7'd61;
+          7'd118: vfrsqrt7_lut_out=7'd60;
+          7'd119: vfrsqrt7_lut_out=7'd59;
+          7'd120: vfrsqrt7_lut_out=7'd59;
+          7'd121: vfrsqrt7_lut_out=7'd58;
+          7'd122: vfrsqrt7_lut_out=7'd57;
+          7'd123: vfrsqrt7_lut_out=7'd56;
+          7'd124: vfrsqrt7_lut_out=7'd56;
+          7'd125: vfrsqrt7_lut_out=7'd55;
+          7'd126: vfrsqrt7_lut_out=7'd54;
+          7'd127: vfrsqrt7_lut_out=7'd53;
+      endcase
+      return  vfrsqrt7_lut_out;
+  endfunction :  vfrsqrt7_lut
+  ////////////////////
+  //  VFRSQRT7 OUTPUT //
+  ////////////////////
+
+ //for SEW=16
+
+  function automatic logic [16:0]  vfrsqrt7_fp16(logic [9:0] vfpu_result, logic [15:0] operand_a_delay, logic[5:0] leading_zeros_count);
+
+     logic [15:0] vfrsqrt7_result,
+                  vfrsqrt7_norm_sig;
+     logic [5:0]  vfrsqrt7_exp_o,
+                  vfrsqrt7_exp_i;
+
+     vfrsqrt7_result   = 16'd0;
+     vfrsqrt7_norm_sig = 16'd0;
+     vfrsqrt7_exp_o    = 6'd0;
+     vfrsqrt7_exp_i    = 6'd0;
+
+        unique case (vfpu_result[9:0])
+          fpnew_pkg:: NEGINF,
+          fpnew_pkg:: NEGNORM,
+          fpnew_pkg:: NEGSUBNORM,
+          fpnew_pkg:: SNAN,
+          fpnew_pkg:: QNAN :     vfrsqrt7_result = 16'h7e00;
+          fpnew_pkg:: NEGZERO:   vfrsqrt7_result = 16'hfc00;
+          fpnew_pkg:: POSZERO:   vfrsqrt7_result = 16'h7c00;
+          fpnew_pkg:: POSINF:    vfrsqrt7_result = {operand_a_delay [15],15'b0};
+          fpnew_pkg:: POSSUBNORM:
+                        begin
+                                //Input exponent:
+                                //0 minus the number of leading zeros
+                                vfrsqrt7_exp_i = 6'd0-leading_zeros_count;
+                                //Output exponent can be found by
+                                //exp_o = (3*B-1-exp_i )/2
+                                //      = (3*B+(~exp_i))/2
+                                vfrsqrt7_exp_o = 6'd45+ +(~vfrsqrt7_exp_i);
+                                     // dividing by 2
+                                vfrsqrt7_result[14:10] = vfrsqrt7_exp_o[5:1];
+                                //As input is subnormal, So the normalized input significand
+                                //is given by shifting the input significand left by
+                                //1 minus the input exponent
+                                vfrsqrt7_norm_sig = operand_a_delay<<(6'd1-vfrsqrt7_exp_i);
+                                //Output significand can be found by
+                                //concatenating LSB of the normalized input exponent and
+                                //the six MSBs of the normalized input significand
+                                vfrsqrt7_result[9:3] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_norm_sig[9:4]});
+                                 //The output signequals the input sign.
+                                vfrsqrt7_result[15] = operand_a_delay [15];
+                        end
+          fpnew_pkg:: POSNORM:
+                       begin
+                                 //Output exponent can be found by
+                                 //exp_o = (3*B-1-exp_i )/2
+                                 //      = (3*B+(~exp_i))/2
+                                vfrsqrt7_exp_o = 6'd45+(~operand_a_delay[14:10]);
+                                     // dividing by 2
+                                vfrsqrt7_result[14:10] = vfrsqrt7_exp_o[5:1];
+                                //Output significand can be found by
+                                //concatenating LSB of the normalized input exponent and
+                                //the six MSBs of the normalized input significand
+                                vfrsqrt7_result[9:3]= vfrsqrt7_lut(operand_a_delay[10:4]);
+                                 //The output signequals the input sign.
+                                vfrsqrt7_result[15] = operand_a_delay[15];
+                        end
+         endcase
+      return vfrsqrt7_result;
+  endfunction : vfrsqrt7_fp16
+
+//for SEW=32
+  function automatic logic [31:0] vfrsqrt7_fp32(logic [9:0] vfpu_result, logic [31:0] operand_a_delay, logic [4:0] leading_zeros_count);
+
+     logic [31:0] vfrsqrt7_result,
+                  vfrsqrt7_norm_sig;
+     logic [8:0]  vfrsqrt7_exp_o,
+                  vfrsqrt7_exp_i;
+
+     vfrsqrt7_result   = 32'd0;
+     vfrsqrt7_norm_sig = 32'd0;
+     vfrsqrt7_exp_o    = 9'd0;
+     vfrsqrt7_exp_i    = 9'd0;
+
+       unique case (vfpu_result[9:0])
+          fpnew_pkg:: NEGINF,
+          fpnew_pkg:: NEGNORM,
+          fpnew_pkg:: NEGSUBNORM,
+          fpnew_pkg:: SNAN,
+          fpnew_pkg:: QNAN :     vfrsqrt7_result = 32'h7fc00000;
+          fpnew_pkg:: NEGZERO:   vfrsqrt7_result = 32'hff800000;
+          fpnew_pkg:: POSZERO:   vfrsqrt7_result = 32'h7f800000;
+          fpnew_pkg:: POSINF:    vfrsqrt7_result = {operand_a_delay [31],31'b0};
+          fpnew_pkg:: POSSUBNORM:
+                         begin
+                                //Input exponent:
+                                //0 minus the number of leading zeros
+                                vfrsqrt7_exp_i = 9'd0-leading_zeros_count;
+                                //Output exponent can be found by
+                                //exp_o = (3*B-1-exp_i )/2
+                                //      = (3*B+(~exp_i))/2
+                                vfrsqrt7_exp_o = 9'd381 +(~vfrsqrt7_exp_i);
+                                     // dividing by 2
+                                vfrsqrt7_result[30:23] = vfrsqrt7_exp_o[8:1];
+                                //As input is subnormal, So the normalized input significand
+                                //is given by shifting the input significand left by
+                                //1 minus the input exponent
+                                vfrsqrt7_norm_sig = operand_a_delay<<(9'd1-vfrsqrt7_exp_i);
+                                //Output significand can be found by
+                                //concatenating LSB of the normalized input exponent and
+                                //the six MSBs of the normalized input significand
+                                vfrsqrt7_result[22:16] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_norm_sig[22:17]});
+                                 //The output signequals the input sign.
+                                vfrsqrt7_result[31] = operand_a_delay [31];
+                         end
+          fpnew_pkg:: POSNORM:
+                         begin
+                                 //Exponent can be found by
+                                 //exp_o = (3*B-1-exp_i )/2
+                                 //      = (3*B+(~exp_i))/2
+                                 vfrsqrt7_exp_o = 9'd381 +(~operand_a_delay[30:23]);
+                                     // dividing by 2
+                                 vfrsqrt7_result[30:23] = vfrsqrt7_exp_o[8:1];
+                                //Output significand can be found by
+                                //concatenating LSB of the normalized input exponent and
+                                //the six MSBs of the normalized input significand
+                                 vfrsqrt7_result[22:16]= vfrsqrt7_lut(operand_a_delay[23:17]);
+                                 //The output signequals the input sign.
+                                 vfrsqrt7_result[31] =operand_a_delay [31];
+                          end
+         endcase
+      return vfrsqrt7_result;
+  endfunction : vfrsqrt7_fp32
+
+// for SEW=64
+
+  function automatic elen_t vfrsqrt7_fp64(logic [9:0] vfpu_result, elen_t operand_a_delay,logic [11:0] leading_zeros_count);
+
+     elen_t        vfrsqrt7_result,
+                   vfrsqrt7_norm_sig;
+     logic [11:0]  vfrsqrt7_exp_o,
+                   vfrsqrt7_exp_i;
+
+     vfrsqrt7_result   = 64'd0;
+     vfrsqrt7_norm_sig = 64'd0;
+     vfrsqrt7_exp_o    = 12'd0;
+     vfrsqrt7_exp_i    = 12'd0;
+
+            unique case (vfpu_result[9:0])
+          fpnew_pkg:: NEGINF,
+          fpnew_pkg:: NEGNORM,
+          fpnew_pkg:: NEGSUBNORM,
+          fpnew_pkg:: SNAN,
+          fpnew_pkg:: QNAN :     vfrsqrt7_result[63:0] = 64'h7ff8000000000000;
+          fpnew_pkg:: NEGZERO:   vfrsqrt7_result[63:0] = 64'hfff0000000000000;
+          fpnew_pkg:: POSZERO:   vfrsqrt7_result[63:0] = 64'h7ff0000000000000;
+          fpnew_pkg:: POSINF:    vfrsqrt7_result[63:0] = {operand_a_delay [63],63'b0};
+          fpnew_pkg:: POSSUBNORM:
+                      begin
+                                //Input exponent:
+                                //0 minus the number of leading zeros
+                                vfrsqrt7_exp_i = 12'd0-leading_zeros_count;
+                                //Output exponent can be found by
+                                //exp_o = (3*B-1-exp_i )/2
+                                //      = (3*B+(~exp_i))/2
+                                vfrsqrt7_exp_o = 12'd3069 +(~vfrsqrt7_exp_i);
+                                     // dividing by 2
+                                vfrsqrt7_result[62:52] = vfrsqrt7_exp_o[11:1];
+                                //As input is subnormal, So the normalized input significand
+                                //is given by shifting the input significand left by
+                                //1 minus the input exponent
+                                vfrsqrt7_norm_sig = operand_a_delay<<(12'd1-vfrsqrt7_exp_i);
+                                //Output significand can be found by
+                                //concatenating LSB of the normalized input exponent and
+                                //the six MSBs of the normalized input significand
+                                vfrsqrt7_result[51:45] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_norm_sig[51:46]});
+                                 //The output signequals the input sign.
+                                vfrsqrt7_result[63] = operand_a_delay [63];
+                      end
+          fpnew_pkg:: POSNORM:
+                      begin
+                                //Output exponent can be found by
+                                //exp_o = (3*B-1-exp_i )/2
+                                //      = (3*B+(~exp_i))/2
+                                vfrsqrt7_exp_o= 12'd3069 +(~operand_a_delay[62:52]);
+                                    // dividing by 2
+                                vfrsqrt7_result[62:52] = vfrsqrt7_exp_o[11:1];
+                                //Output significand can be found by
+                                //concatenating LSB of the normalized input exponent and
+                                //the six MSBs of the normalized input significand
+                                vfrsqrt7_result[51:45]= vfrsqrt7_lut(operand_a_delay[52:46]);
+                                //The output signequals the input sign.
+                                vfrsqrt7_result[63] =operand_a_delay [63];
+                        end
+            endcase
+         return vfrsqrt7_result;
+  endfunction : vfrsqrt7_fp64
 
 endpackage : ara_pkg

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1857,6 +1857,7 @@ package ara_pkg;
         // The output sign equals the input sign.
         vfrsqrt7_o.vf7_e32.s = vfrsqrt7_i.s;
       end
+      default:;
     endcase
     return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp32
@@ -1931,6 +1932,7 @@ package ara_pkg;
          // The output sign equals the input sign.
          vfrsqrt7_o.vf7_e64.s = vfrsqrt7_i.s;
       end
+      default:;
     endcase
     return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp64

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1570,12 +1570,54 @@ package ara_pkg;
     return vfrec7_out;
   endfunction : vfrec7_fp64
 
-///////////////////////////
+  ///////////////////////////
   // VFSQRT7 Look Up Table //
   //////////////////////////
+localparam int unsigned LUT_BITS     = 7;
+localparam int unsigned E16_BITS     = 16;
+localparam int unsigned E32_BITS     = 32;
+localparam int unsigned E64_BITS     = 64;
 
-  function automatic logic [6:0] vfrsqrt7_lut(logic [6:0] vfrsqrt7_lut_select);
-      logic [6:0] vfrsqrt7_lut_out;
+localparam int unsigned EXP_BITS_E16  = 5;
+localparam int unsigned EXP_BITS_E32  = 8;
+localparam int unsigned EXP_BITS_E64  = 11;
+
+localparam int unsigned VF_TYPE_SEL_BITS  = 10;
+
+localparam logic [5:0] E16_3xB     = 6'd45;
+localparam logic [8:0] E32_3xB     = 9'd381;
+localparam logic [11:0] E64_3xB     = 12'd3069;
+
+localparam logic [15:0] E16_NaN   = 16'h7e00;
+localparam logic [15:0] E16_pInf  = 16'h7c00;
+localparam logic [15:0] E16_mInf  = 16'hfc00;
+
+localparam int unsigned E32_NaN   = 32'h7fc00000;
+localparam int unsigned E32_pInf  = 32'h7f800000;
+localparam int unsigned E32_mInf  = 32'hff800000;
+
+localparam logic [63:0] E64_NaN   = 64'h7ff8000000000000;
+localparam logic [63:0] E64_pInf  = 64'h7ff0000000000000;
+localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
+
+
+ typedef struct packed {
+  fpnew_pkg::status_t vfrsqrt7_ex_flag;
+  fp16_t              vfrsqrt7_e16;
+  } vfr_struct_e16;
+
+  typedef struct packed {
+  fpnew_pkg::status_t vfrsqrt7_ex_flag;
+  fp32_t              vfrsqrt7_e32;
+  } vfr_struct_e32;
+
+ typedef struct packed {
+  fpnew_pkg::status_t vfrsqrt7_ex_flag;
+  fp64_t              vfrsqrt7_e64;
+  } vfr_struct_e64;
+
+  function automatic logic [LUT_BITS-1:0] vfrsqrt7_lut(logic [LUT_BITS-1:0] vfrsqrt7_lut_select);
+      logic [LUT_BITS-1:0] vfrsqrt7_lut_out;
       unique case (vfrsqrt7_lut_select)
           7'd0  : vfrsqrt7_lut_out=7'd52;
           7'd1  : vfrsqrt7_lut_out=7'd51;
@@ -1711,196 +1753,220 @@ package ara_pkg;
   ////////////////////
   //  VFRSQRT7 OUTPUT //
   ////////////////////
+//for SEW=16
+  function automatic vfr_struct_e16 vfrsqrt7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay, logic [3:0] leading_zeros_count);
+     vfr_struct_e16 vfrsqrt7_o;
+     fp16_t         vfrsqrt7_i;
 
- //for SEW=16
+     logic [EXP_BITS_E16:0]  vfrsqrt7_exp_i,
+                             vfrsqrt7_exp_o;
 
-  function automatic logic [16:0]  vfrsqrt7_fp16(logic [9:0] vfpu_result, logic [15:0] operand_a_delay, logic[5:0] leading_zeros_count);
-
-     logic [15:0] vfrsqrt7_result,
-                  vfrsqrt7_norm_sig;
-     logic [5:0]  vfrsqrt7_exp_o,
-                  vfrsqrt7_exp_i;
-
-     vfrsqrt7_result   = 16'd0;
-     vfrsqrt7_norm_sig = 16'd0;
+     vfrsqrt7_o.vfrsqrt7_e16     = 16'd0;
+     vfrsqrt7_o.vfrsqrt7_ex_flag = '{1'b0, 1'b0, 1'b0, 1'b0, 1'b0};
+     vfrsqrt7_i        = 16'd0;
      vfrsqrt7_exp_o    = 6'd0;
      vfrsqrt7_exp_i    = 6'd0;
-
-        unique case (vfpu_result[9:0])
+         unique case (vfpu_result[6:5])
+         2'b01: begin // POSSUBNORM
+                //As input is subnormal, So
+                //input exponent:
+                //0 minus the number of leading zeros
+                vfrsqrt7_exp_i = 6'd0-({2'b00,leading_zeros_count});
+                //the normalized input significand(mantissa)
+                //is given by shifting the input significand left by
+                //1 minus the input exponent
+                vfrsqrt7_i.m = operand_a_delay[9:0]<<(6'd1-vfrsqrt7_exp_i);
+         end
+         2'b10: begin // POSNORM
+                vfrsqrt7_exp_i  = {1'b0,operand_a_delay[14:10]};
+                vfrsqrt7_i.m  = operand_a_delay[9:0];
+         end
+         default: begin
+                vfrsqrt7_exp_i = 'x;
+                vfrsqrt7_i.m = 'x;
+         end
+         endcase
+       unique case (vfpu_result)
           fpnew_pkg:: NEGINF,
           fpnew_pkg:: NEGNORM,
           fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: SNAN,
-          fpnew_pkg:: QNAN :     vfrsqrt7_result = 16'h7e00;
-          fpnew_pkg:: NEGZERO:   vfrsqrt7_result = 16'hfc00;
-          fpnew_pkg:: POSZERO:   vfrsqrt7_result = 16'h7c00;
-          fpnew_pkg:: POSINF:    vfrsqrt7_result = {operand_a_delay [15],15'b0};
-          fpnew_pkg:: POSSUBNORM:
-                        begin
-                                //Input exponent:
-                                //0 minus the number of leading zeros
-                                vfrsqrt7_exp_i = 6'd0-leading_zeros_count;
+          fpnew_pkg:: QNAN : begin
+                                 vfrsqrt7_o.vfrsqrt7_e16 = E16_NaN;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.NV=1'b1;
+                             end
+          fpnew_pkg:: SNAN :     vfrsqrt7_o.vfrsqrt7_e16 = E16_NaN;
+          fpnew_pkg:: NEGZERO: begin
+                                 vfrsqrt7_o.vfrsqrt7_e16 = E16_mInf;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ=1'b1;
+                               end
+          fpnew_pkg:: POSZERO: begin
+                                 vfrsqrt7_o.vfrsqrt7_e16 = E16_pInf;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ=1'b1;
+                               end
+          fpnew_pkg:: POSINF:    vfrsqrt7_o.vfrsqrt7_e16 = 16'd0;
+          fpnew_pkg:: POSSUBNORM,
+          fpnew_pkg:: POSNORM:
+                         begin
                                 //Output exponent can be found by
                                 //exp_o = (3*B-1-exp_i )/2
                                 //      = (3*B+(~exp_i))/2
-                                vfrsqrt7_exp_o = 6'd45+ +(~vfrsqrt7_exp_i);
+                                vfrsqrt7_exp_o = E16_3xB +(~vfrsqrt7_exp_i);
                                      // dividing by 2
-                                vfrsqrt7_result[14:10] = vfrsqrt7_exp_o[5:1];
-                                //As input is subnormal, So the normalized input significand
-                                //is given by shifting the input significand left by
-                                //1 minus the input exponent
-                                vfrsqrt7_norm_sig = operand_a_delay<<(6'd1-vfrsqrt7_exp_i);
-                                //Output significand can be found by
+                                vfrsqrt7_o.vfrsqrt7_e16.e = vfrsqrt7_exp_o[5:1];
+                                //Output significand(mantissa) can be found by
                                 //concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
-                                vfrsqrt7_result[9:3] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_norm_sig[9:4]});
-                                 //The output signequals the input sign.
-                                vfrsqrt7_result[15] = operand_a_delay [15];
-                        end
-          fpnew_pkg:: POSNORM:
-                       begin
-                                 //Output exponent can be found by
-                                 //exp_o = (3*B-1-exp_i )/2
-                                 //      = (3*B+(~exp_i))/2
-                                vfrsqrt7_exp_o = 6'd45+(~operand_a_delay[14:10]);
-                                     // dividing by 2
-                                vfrsqrt7_result[14:10] = vfrsqrt7_exp_o[5:1];
-                                //Output significand can be found by
-                                //concatenating LSB of the normalized input exponent and
-                                //the six MSBs of the normalized input significand
-                                vfrsqrt7_result[9:3]= vfrsqrt7_lut(operand_a_delay[10:4]);
-                                 //The output signequals the input sign.
-                                vfrsqrt7_result[15] = operand_a_delay[15];
-                        end
+                                vfrsqrt7_o.vfrsqrt7_e16.m[9:3] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_i.m[9:4]});
+                                 //The output sign equals the input sign.
+                                vfrsqrt7_o.vfrsqrt7_e16.s = vfrsqrt7_i.s;
+                         end
          endcase
-      return vfrsqrt7_result;
+      return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp16
 
 //for SEW=32
-  function automatic logic [31:0] vfrsqrt7_fp32(logic [9:0] vfpu_result, logic [31:0] operand_a_delay, logic [4:0] leading_zeros_count);
+  function automatic vfr_struct_e32 vfrsqrt7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay, logic [4:0] leading_zeros_count);
+     vfr_struct_e32 vfrsqrt7_o;
+     fp32_t         vfrsqrt7_i;
 
-     logic [31:0] vfrsqrt7_result,
-                  vfrsqrt7_norm_sig;
-     logic [8:0]  vfrsqrt7_exp_o,
-                  vfrsqrt7_exp_i;
+     logic [EXP_BITS_E32:0]  vfrsqrt7_exp_i,
+                             vfrsqrt7_exp_o;
 
-     vfrsqrt7_result   = 32'd0;
-     vfrsqrt7_norm_sig = 32'd0;
+     vfrsqrt7_o.vfrsqrt7_e32     = 32'd0;
+     vfrsqrt7_o.vfrsqrt7_ex_flag = '{1'b0, 1'b0, 1'b0, 1'b0, 1'b0};
+
+     vfrsqrt7_i        = 32'd0;
      vfrsqrt7_exp_o    = 9'd0;
      vfrsqrt7_exp_i    = 9'd0;
-
-       unique case (vfpu_result[9:0])
+         unique case (vfpu_result[6:5])
+         2'b01: begin // POSSUBNORM
+                //As input is subnormal, So
+                //input exponent:
+                //0 minus the number of leading zeros
+                vfrsqrt7_exp_i = 9'd0-({4'b0000,leading_zeros_count});
+                //the normalized input significand(mantissa)
+                //is given by shifting the input significand left by
+                //1 minus the input exponent
+                vfrsqrt7_i.m = operand_a_delay[22:0]<<(9'd1-vfrsqrt7_exp_i);
+         end
+         2'b10: begin // POSNORM
+                vfrsqrt7_exp_i  = {1'b0,operand_a_delay[30:23]};
+                vfrsqrt7_i.m  = operand_a_delay[22:0];
+         end
+         default: begin
+                vfrsqrt7_exp_i = 'x;
+                vfrsqrt7_i.m = 'x;
+         end
+         endcase
+       unique case (vfpu_result)
           fpnew_pkg:: NEGINF,
           fpnew_pkg:: NEGNORM,
           fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: SNAN,
-          fpnew_pkg:: QNAN :     vfrsqrt7_result = 32'h7fc00000;
-          fpnew_pkg:: NEGZERO:   vfrsqrt7_result = 32'hff800000;
-          fpnew_pkg:: POSZERO:   vfrsqrt7_result = 32'h7f800000;
-          fpnew_pkg:: POSINF:    vfrsqrt7_result = {operand_a_delay [31],31'b0};
-          fpnew_pkg:: POSSUBNORM:
+          fpnew_pkg:: QNAN : begin
+                                 vfrsqrt7_o.vfrsqrt7_e32 = E32_NaN;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.NV=1'b1;
+                             end
+          fpnew_pkg:: SNAN :     vfrsqrt7_o.vfrsqrt7_e32 = E32_NaN;
+          fpnew_pkg:: NEGZERO: begin
+                                 vfrsqrt7_o.vfrsqrt7_e32 = E32_mInf;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ=1'b1;
+                               end
+          fpnew_pkg:: POSZERO: begin
+                                 vfrsqrt7_o.vfrsqrt7_e32 = E32_pInf;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ=1'b1;
+                               end
+          fpnew_pkg:: POSINF:    vfrsqrt7_o.vfrsqrt7_e32 = 32'd0;
+          fpnew_pkg:: POSSUBNORM,
+          fpnew_pkg:: POSNORM:
                          begin
-                                //Input exponent:
-                                //0 minus the number of leading zeros
-                                vfrsqrt7_exp_i = 9'd0-leading_zeros_count;
                                 //Output exponent can be found by
                                 //exp_o = (3*B-1-exp_i )/2
                                 //      = (3*B+(~exp_i))/2
-                                vfrsqrt7_exp_o = 9'd381 +(~vfrsqrt7_exp_i);
+                                vfrsqrt7_exp_o = E32_3xB +(~vfrsqrt7_exp_i);
                                      // dividing by 2
-                                vfrsqrt7_result[30:23] = vfrsqrt7_exp_o[8:1];
-                                //As input is subnormal, So the normalized input significand
-                                //is given by shifting the input significand left by
-                                //1 minus the input exponent
-                                vfrsqrt7_norm_sig = operand_a_delay<<(9'd1-vfrsqrt7_exp_i);
-                                //Output significand can be found by
+                                vfrsqrt7_o.vfrsqrt7_e32.e = vfrsqrt7_exp_o[8:1];
+                                //Output significand(mantissa) can be found by
                                 //concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
-                                vfrsqrt7_result[22:16] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_norm_sig[22:17]});
-                                 //The output signequals the input sign.
-                                vfrsqrt7_result[31] = operand_a_delay [31];
+                                vfrsqrt7_o.vfrsqrt7_e32.m[22:16] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[22:17]});
+                                 //The output sign equals the input sign.
+                                vfrsqrt7_o.vfrsqrt7_e32.s = vfrsqrt7_i.s;
                          end
-          fpnew_pkg:: POSNORM:
-                         begin
-                                 //Exponent can be found by
-                                 //exp_o = (3*B-1-exp_i )/2
-                                 //      = (3*B+(~exp_i))/2
-                                 vfrsqrt7_exp_o = 9'd381 +(~operand_a_delay[30:23]);
-                                     // dividing by 2
-                                 vfrsqrt7_result[30:23] = vfrsqrt7_exp_o[8:1];
-                                //Output significand can be found by
-                                //concatenating LSB of the normalized input exponent and
-                                //the six MSBs of the normalized input significand
-                                 vfrsqrt7_result[22:16]= vfrsqrt7_lut(operand_a_delay[23:17]);
-                                 //The output signequals the input sign.
-                                 vfrsqrt7_result[31] =operand_a_delay [31];
-                          end
          endcase
-      return vfrsqrt7_result;
+      return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp32
 
-// for SEW=64
 
-  function automatic elen_t vfrsqrt7_fp64(logic [9:0] vfpu_result, elen_t operand_a_delay,logic [11:0] leading_zeros_count);
+//for SEW=64
+  function automatic vfr_struct_e64 vfrsqrt7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay, logic [5:0] leading_zeros_count);
+     vfr_struct_e64 vfrsqrt7_o;
+     fp64_t     vfrsqrt7_i;
 
-     elen_t        vfrsqrt7_result,
-                   vfrsqrt7_norm_sig;
-     logic [11:0]  vfrsqrt7_exp_o,
-                   vfrsqrt7_exp_i;
+     logic [EXP_BITS_E64:0]  vfrsqrt7_exp_i,
+                             vfrsqrt7_exp_o;
 
-     vfrsqrt7_result   = 64'd0;
-     vfrsqrt7_norm_sig = 64'd0;
+     vfrsqrt7_o.vfrsqrt7_e64   = 64'd0;
+     vfrsqrt7_o.vfrsqrt7_ex_flag = '{1'b0, 1'b0, 1'b0, 1'b0, 1'b0};
+
+     vfrsqrt7_i        = 64'd0;
      vfrsqrt7_exp_o    = 12'd0;
      vfrsqrt7_exp_i    = 12'd0;
-
-            unique case (vfpu_result[9:0])
+         unique case (vfpu_result[6:5])
+         2'b01: begin // POSSUBNORM
+                //As input is subnormal, So
+                //input exponent:
+                //0 minus the number of leading zeros
+                vfrsqrt7_exp_i = 12'd0-({6'd0,leading_zeros_count});
+                //the normalized input significand(mantissa)
+                //is given by shifting the input significand left by
+                //1 minus the input exponent
+                vfrsqrt7_i.m = operand_a_delay[51:0]<<(12'd1-vfrsqrt7_exp_i);
+         end
+         2'b10: begin // POSNORM
+                vfrsqrt7_exp_i  = {1'b0,operand_a_delay[62:52]};
+                vfrsqrt7_i.m  = operand_a_delay[51:0];
+         end
+         default: begin
+                vfrsqrt7_exp_i = 'x;
+                vfrsqrt7_i.m = 'x;
+         end
+         endcase
+       unique case (vfpu_result)
           fpnew_pkg:: NEGINF,
           fpnew_pkg:: NEGNORM,
           fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: SNAN,
-          fpnew_pkg:: QNAN :     vfrsqrt7_result[63:0] = 64'h7ff8000000000000;
-          fpnew_pkg:: NEGZERO:   vfrsqrt7_result[63:0] = 64'hfff0000000000000;
-          fpnew_pkg:: POSZERO:   vfrsqrt7_result[63:0] = 64'h7ff0000000000000;
-          fpnew_pkg:: POSINF:    vfrsqrt7_result[63:0] = {operand_a_delay [63],63'b0};
-          fpnew_pkg:: POSSUBNORM:
-                      begin
-                                //Input exponent:
-                                //0 minus the number of leading zeros
-                                vfrsqrt7_exp_i = 12'd0-leading_zeros_count;
-                                //Output exponent can be found by
-                                //exp_o = (3*B-1-exp_i )/2
-                                //      = (3*B+(~exp_i))/2
-                                vfrsqrt7_exp_o = 12'd3069 +(~vfrsqrt7_exp_i);
-                                     // dividing by 2
-                                vfrsqrt7_result[62:52] = vfrsqrt7_exp_o[11:1];
-                                //As input is subnormal, So the normalized input significand
-                                //is given by shifting the input significand left by
-                                //1 minus the input exponent
-                                vfrsqrt7_norm_sig = operand_a_delay<<(12'd1-vfrsqrt7_exp_i);
-                                //Output significand can be found by
-                                //concatenating LSB of the normalized input exponent and
-                                //the six MSBs of the normalized input significand
-                                vfrsqrt7_result[51:45] = vfrsqrt7_lut({vfrsqrt7_exp_i[0],vfrsqrt7_norm_sig[51:46]});
-                                 //The output signequals the input sign.
-                                vfrsqrt7_result[63] = operand_a_delay [63];
-                      end
+          fpnew_pkg:: QNAN : begin
+                                 vfrsqrt7_o.vfrsqrt7_e64        = E64_NaN;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.NV = 1'b1;
+                             end
+          fpnew_pkg:: SNAN :     vfrsqrt7_o.vfrsqrt7_e64        = E64_NaN;
+          fpnew_pkg:: NEGZERO: begin
+                                 vfrsqrt7_o.vfrsqrt7_e64        = E64_mInf;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ = 1'b1;
+                               end
+          fpnew_pkg:: POSZERO: begin
+                                 vfrsqrt7_o.vfrsqrt7_e64        = E64_pInf;
+                                 vfrsqrt7_o.vfrsqrt7_ex_flag.DZ = 1'b1;
+                               end
+          fpnew_pkg:: POSINF:    vfrsqrt7_o.vfrsqrt7_e64        = 64'd0;
+          fpnew_pkg:: POSSUBNORM,
           fpnew_pkg:: POSNORM:
-                      begin
+                         begin
                                 //Output exponent can be found by
                                 //exp_o = (3*B-1-exp_i )/2
                                 //      = (3*B+(~exp_i))/2
-                                vfrsqrt7_exp_o= 12'd3069 +(~operand_a_delay[62:52]);
-                                    // dividing by 2
-                                vfrsqrt7_result[62:52] = vfrsqrt7_exp_o[11:1];
-                                //Output significand can be found by
+                                vfrsqrt7_exp_o = E64_3xB +(~vfrsqrt7_exp_i);
+                                     // dividing by 2
+                                vfrsqrt7_o.vfrsqrt7_e64.e = vfrsqrt7_exp_o[11:1];
+                                //Output significand(mantissa) can be found by
                                 //concatenating LSB of the normalized input exponent and
                                 //the six MSBs of the normalized input significand
-                                vfrsqrt7_result[51:45]= vfrsqrt7_lut(operand_a_delay[52:46]);
-                                //The output signequals the input sign.
-                                vfrsqrt7_result[63] =operand_a_delay [63];
-                        end
-            endcase
-         return vfrsqrt7_result;
+                                vfrsqrt7_o.vfrsqrt7_e64.m[51:45] = vfrsqrt7_lut({vfrsqrt7_exp_i [0],vfrsqrt7_i.m[51:46]});
+                                 //The output sign equals the input sign.
+                                vfrsqrt7_o.vfrsqrt7_e64.s = vfrsqrt7_i.s;
+                         end
+         endcase
+      return vfrsqrt7_o;
   endfunction : vfrsqrt7_fp64
 
 endpackage : ara_pkg

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1719,10 +1719,10 @@ package ara_pkg;
 
     logic [EXP_BITS_E16:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-    vfrsqrt7_o.vf7_e16 = 21'd0;
-    vfrsqrt7_i         = 16'd0;
-    vfrsqrt7_exp_o     = 6'd0;
-    vfrsqrt7_exp_i     = 6'd0;
+    vfrsqrt7_o     = 21'd0;
+    vfrsqrt7_i     = 16'd0;
+    vfrsqrt7_exp_o = 6'd0;
+    vfrsqrt7_exp_i = 6'd0;
 
     unique case (vfpu_result[6:5])
       // POSSUBNORM
@@ -1792,10 +1792,10 @@ package ara_pkg;
 
     logic [EXP_BITS_E32:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-    vfrsqrt7_o.vf7_e32 = 37'd0;
-    vfrsqrt7_i         = 32'd0;
-    vfrsqrt7_exp_o     = 9'd0;
-    vfrsqrt7_exp_i     = 9'd0;
+    vfrsqrt7_o     = 37'd0;
+    vfrsqrt7_i     = 32'd0;
+    vfrsqrt7_exp_o = 9'd0;
+    vfrsqrt7_exp_i = 9'd0;
 
     unique case (vfpu_result[6:5])
       // POSSUBNORM
@@ -1865,10 +1865,10 @@ package ara_pkg;
 
     logic [EXP_BITS_E64:0] vfrsqrt7_exp_i, vfrsqrt7_exp_o;
 
-    vfrsqrt7_o.vf7_e64 = 69'd0;
-    vfrsqrt7_i         = 64'd0;
-    vfrsqrt7_exp_o     = 12'd0;
-    vfrsqrt7_exp_i     = 12'd0;
+    vfrsqrt7_o     = 69'd0;
+    vfrsqrt7_i     = 64'd0;
+    vfrsqrt7_exp_o = 12'd0;
+    vfrsqrt7_exp_i = 12'd0;
 
     unique case (vfpu_result[6:5])
     // POSSUBNORM

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1015,9 +1015,9 @@ package ara_pkg;
 
 
 
-  ///////////////////////
-  // VFREC7 & VFRSQRT7 //
-  //////////////////////
+    ////////////////////////
+    // VFREC7 & VFRSQRT7 //
+    ///////////////////////
 
   localparam int unsigned LUT_BITS = 7;
 
@@ -1041,12 +1041,19 @@ package ara_pkg;
   localparam logic [14:0] E16_Max  = 15'h7bff;
   localparam logic [14:0] E16_Inf  = 15'h7c00;
 
+  localparam logic [14:0] E16_Max  = 15'h7bff;     // Max Number without sign
+  localparam logic [14:0] E16_Inf  = 15'h7c00;     // Inf without sign
+
+
   localparam logic [31:0] E32_NaN  = 32'h7fc00000;
   localparam logic [31:0] E32_pInf = 32'h7f800000;
   localparam logic [31:0] E32_mInf = 32'hff800000;
   localparam logic [30:0] E32_Max  = 31'h7f7fffff;
   localparam logic [30:0] E32_Inf  = 31'hff800000;
 
+
+  localparam logic [30:0] E32_Max  = 31'h7f7fffff;  // Max Number without sign
+  localparam logic [30:0] E32_Inf  = 31'hff800000;  // Inf without sign
 
   localparam logic [63:0] E64_NaN  = 64'h7ff8000000000000;
   localparam logic [63:0] E64_pInf = 64'h7ff0000000000000;
@@ -1057,6 +1064,9 @@ package ara_pkg;
   localparam logic  [5:0] E16_3xB = 6'd45;
   localparam logic  [8:0] E32_3xB = 9'd381;
   localparam logic [11:0] E64_3xB = 12'd3069;
+
+  localparam logic [62:0] E64_Max  = 63'h7fefffffffffffff; // Max Number without sign
+  localparam logic [62:0] E64_Inf  = 63'h7ff0000000000000; // Inf without sign
 
   // Structure containing 5 bit flag and desired output
  typedef struct packed {
@@ -1711,6 +1721,8 @@ package ara_pkg;
     endcase
     return vfrsqrt7_lut_out;
   endfunction : vfrsqrt7_lut
+
+  // vfrsqrt7 results
 
   // vfrsqrt7 result (sew: 16 bit)
   function automatic vf7_flag_out_e16 vfrsqrt7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay, logic [3:0] leading_zeros_count);

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1014,10 +1014,10 @@ package ara_pkg;
   } addrgen_axi_req_t;
 
 
-  /////////////
-<<<<<<< HEAD
-  // VFREC7 //
-  ///////////
+
+  ///////////////////////
+  // VFREC7 & VFRSQRT7 //
+  //////////////////////
 
   localparam int unsigned LUT_BITS = 7;
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1982,6 +1982,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       5'b00000: ara_req_d.op = ara_pkg::VFSQRT;
                       5'b00101: ara_req_d.op = ara_pkg::VFREC7;
                       5'b00100: ara_req_d.op = ara_pkg::VFRSQRT7;
+                      5'b00101: ara_req_d.op = ara_pkg::VFREC7;
                       5'b10000: ara_req_d.op = ara_pkg::VFCLASS;
                       default : illegal_insn = 1'b1;
                     endcase

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -3024,8 +3024,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       if (ara_req_valid_d && (ara_req_d.op inside {[VSADDU:VNCLIPU], VSMUL}) && (FixPtSupport == FixedPointDisable))
         illegal_insn = 1'b1;
 
-      // Check that we have we have vfrec7 support
-      if (ara_req_valid_d && (ara_req_d.op inside {VFREC7}) && (FPExtSupport == FPExtSupportDisable))
+      // Check that we have we have vfrec7 and vfrsqrt7 support
+      if (ara_req_valid_d && (ara_req_d.op inside {VFREC7,VFRSQRT7}) && (FPExtSupport == FPExtSupportDisable))
         illegal_insn = 1'b1;
 
       // Check if we need to reshuffle our vector registers involved in the operation

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1980,7 +1980,6 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                     unique case (insn.varith_type.rs1)
                       5'b00000: ara_req_d.op = ara_pkg::VFSQRT;
-                      5'b00101: ara_req_d.op = ara_pkg::VFREC7;
                       5'b00100: ara_req_d.op = ara_pkg::VFRSQRT7;
                       5'b00101: ara_req_d.op = ara_pkg::VFREC7;
                       5'b10000: ara_req_d.op = ara_pkg::VFCLASS;
@@ -3026,7 +3025,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         illegal_insn = 1'b1;
 
       // Check that we have we have vfrec7 and vfrsqrt7 support
-      if (ara_req_valid_d && (ara_req_d.op inside {VFREC7,VFRSQRT7}) && (FPExtSupport == FPExtSupportDisable))
+      if (ara_req_valid_d && (ara_req_d.op inside {VFREC7, VFRSQRT7}) && (FPExtSupport == FPExtSupportDisable))
         illegal_insn = 1'b1;
 
       // Check if we need to reshuffle our vector registers involved in the operation

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1981,6 +1981,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     unique case (insn.varith_type.rs1)
                       5'b00000: ara_req_d.op = ara_pkg::VFSQRT;
                       5'b00101: ara_req_d.op = ara_pkg::VFREC7;
+                      5'b00100: ara_req_d.op = ara_pkg::VFRSQRT7;
                       5'b10000: ara_req_d.op = ara_pkg::VFCLASS;
                       default : illegal_insn = 1'b1;
                     endcase

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -927,19 +927,24 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     // vfrsqrt7 //
     //////////////
 
+    elen_t operand_a_delay, vfrsqrt7_result_o;
+
+    fpu_mask_t vfpu_flag_mask;
+
+    vf7_flag_out_e16 vfrsqrt7_out_e16[4];
+    vf7_flag_out_e32 vfrsqrt7_out_e32[2];
+    vf7_flag_out_e64 vfrsqrt7_out_e64[1];
+
+    status_t vfrsqrt7_ex_flag;
+
+    elen_t [LatFNonComp-1:0] operand_a_q;
+    elen_t [LatFNonComp:0]   operand_a_d;
+
+    logic [15:0] lzc_e16;
+    logic [9:0]  lzc_e32;
+    logic [5:0]  lzc_e64;
+
     if (FPExtSupport) begin
-      elen_t operand_a_delay, vfrsqrt7_result_o;
-
-      fpu_mask_t vfpu_flag_mask;
-
-      vf7_flag_out_e16 vfrsqrt7_out_e16[4];
-      vf7_flag_out_e32 vfrsqrt7_out_e32[2];
-      vf7_flag_out_e64 vfrsqrt7_out_e64[1];
-
-      status_t vfrsqrt7_ex_flag;
-
-      elen_t [LatFNonComp-1:0] operand_a_q;
-      elen_t [LatFNonComp:0]   operand_a_d;
 
       // Delay for vfpu mask
       `FF(vfpu_flag_mask, vfpu_simd_mask, '0, clk_i, rst_ni);
@@ -949,7 +954,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       for (genvar i = 0; i < LatFNonComp; i++) begin
         assign operand_a_d[i+1] = operand_a_q[i];
 
-         `FF(operand_a_q[i], operand_a_d[i], '0, clk_i, rst_ni);
+        `FF(operand_a_q[i], operand_a_d[i], '0, clk_i, rst_ni);
       end
 
       assign operand_a_delay = operand_a_d[LatFNonComp];
@@ -958,10 +963,6 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       localparam int unsigned SIG_BITS_E16   = 10;
       localparam int unsigned SIG_BITS_E32   = 23;
       localparam int unsigned SIG_BITS_E64   = 52;
-
-      logic [15:0] lzc_e16;
-      logic [9:0]  lzc_e32;
-      logic [5:0]  lzc_e64;
 
       // sew: 16-bit
       for (genvar i = 0; i < 4; i = i + 1) begin

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -923,25 +923,36 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       .busy_o        (/* Unused */   )
     );
 
-    //////////////
-    // vfrsqrt7 //
-    //////////////
+    ////////////////////////
+    // VFREC7 & VFRSQRT7 //
+    ///////////////////////
 
-    elen_t operand_a_delay, vfrsqrt7_result_o;
+    elen_t operand_a_delay, vfrec7_result_o, vfrsqrt7_result_o;
 
     fpu_mask_t vfpu_flag_mask;
+
+    vf7_flag_out_e16 vfrec7_out_e16[4];
+    vf7_flag_out_e32 vfrec7_out_e32[2];
+    vf7_flag_out_e64 vfrec7_out_e64[1];
+
+    status_t vfrec7_ex_flag, vfrsqrt7_ex_flag;
+
+    roundmode_e fp_rm_process;
+
+    elen_t [LatFNonComp:0]   operand_a_d, vfpu_flag_mask_d;
 
     vf7_flag_out_e16 vfrsqrt7_out_e16[4];
     vf7_flag_out_e32 vfrsqrt7_out_e32[2];
     vf7_flag_out_e64 vfrsqrt7_out_e64[1];
 
-    status_t vfrsqrt7_ex_flag;
-
-    elen_t [LatFNonComp:0]   operand_a_d, vfpu_flag_mask_d;
-
     logic [15:0] lzc_e16;
     logic [9:0]  lzc_e32;
     logic [5:0]  lzc_e64;
+
+    // Leading zeros modules
+    localparam int unsigned SIG_BITS_E16   = 10;
+    localparam int unsigned SIG_BITS_E32   = 23;
+    localparam int unsigned SIG_BITS_E64   = 52;
 
     if (FPExtSupport) begin
       //Pipeline Stages
@@ -956,11 +967,6 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
 
       assign operand_a_delay = operand_a_d[LatFNonComp];
       assign vfpu_flag_mask  = vfpu_flag_mask_d[LatFNonComp];
-
-      // Leading zeros modules
-      localparam int unsigned SIG_BITS_E16   = 10;
-      localparam int unsigned SIG_BITS_E32   = 23;
-      localparam int unsigned SIG_BITS_E64   = 52;
 
       // sew: 16-bit
       for (genvar i = 0; i < 4; i = i + 1) begin
@@ -1043,8 +1049,46 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
 
     always_comb begin: fpu_result_processing_p
 
-      // vfrec7
       if (FPExtSupport) begin
+
+        // vfrec7
+        unique case (vinsn_processing_q.vtype.vsew)
+          EW16: begin
+            for (int h = 0; h < 4; h++) vfrec7_out_e16[h] =
+              vfrec7_fp16(vfpu_result[h*16 +: 10], operand_a_delay[h*16 +: 16], fp_rm_process);
+
+            vfrec7_result_o = {vfrec7_out_e16[3].vf7_e16, vfrec7_out_e16[2].vf7_e16,
+                               vfrec7_out_e16[1].vf7_e16, vfrec7_out_e16[0].vf7_e16};
+
+            vfrec7_ex_flag  = (vfrec7_out_e16[3].ex_flag & {5{vfpu_flag_mask[3]}})
+                            | (vfrec7_out_e16[2].ex_flag & {5{vfpu_flag_mask[2]}})
+                            | (vfrec7_out_e16[1].ex_flag & {5{vfpu_flag_mask[1]}})
+                            | (vfrec7_out_e16[0].ex_flag & {5{vfpu_flag_mask[0]}});
+          end
+          EW32: begin
+            for (int w = 0; w < 2; w++) vfrec7_out_e32[w] =
+              vfrec7_fp32(vfpu_result[w*32 +: 10], operand_a_delay[w*32 +: 32], fp_rm_process);
+
+            vfrec7_result_o = {vfrec7_out_e32[1].vf7_e32, vfrec7_out_e32[0].vf7_e32};
+
+            vfrec7_ex_flag  = (vfrec7_out_e32[1].ex_flag & {5{vfpu_flag_mask[2]}})
+                            | (vfrec7_out_e32[0].ex_flag & {5{vfpu_flag_mask[0]}});
+          end
+          EW64: begin
+            for (int d = 0; d < 1; d++) vfrec7_out_e64[d] =
+              vfrec7_fp64(vfpu_result[d*64 +: 10], operand_a_delay[d*64 +: 64], fp_rm_process);
+
+            vfrec7_result_o  =  vfrec7_out_e64[0].vf7_e64;
+
+            vfrec7_ex_flag   =  vfrec7_out_e64[0].ex_flag & {5{vfpu_flag_mask[0]}};
+          end
+          default: begin
+            vfrec7_result_o = 'x;
+            vfrec7_ex_flag  = 'x;
+          end
+        endcase
+
+       //vfrsqrt7
         unique case (vinsn_processing_q.vtype.vsew)
           EW16: begin
             for (int h = 0; h < 4; h++) vfrec7_out_e16[h] =
@@ -1130,7 +1174,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
            vfpu_ex_flag          = vfpu_ex_flag_fn;
       end
       end else begin
-        // NO vfrec7, vfrsqrt7, rto support
+        // NO vfrec7, vfrsqrt7, rod support
         vfpu_processed_result = vfpu_result;
         vfpu_ex_flag          = vfpu_ex_flag_fn;
       end

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -924,10 +924,11 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     );
 elen_t operand_a_delay,
        vfrsqrt7_result_o;
+fpu_mask_t vfpu_flag_mask;
 
-vfr_struct_e16 vfrsqrt7_out_e16[4];
-vfr_struct_e32 vfrsqrt7_out_e32[2];
-vfr_struct_e64 vfrsqrt7_out_e64;
+vf7_struct_e16 vfrsqrt7_out_e16[4];
+vf7_struct_e32 vfrsqrt7_out_e32[2];
+vf7_struct_e64 vfrsqrt7_out_e64;
 status_t    vfrsqrt7_ex_flag;
 
     // register for delay of operand_a
@@ -935,8 +936,10 @@ status_t    vfrsqrt7_ex_flag;
     begin
          if (!rst_ni) begin
                 operand_a_delay <= 64'b0;
+                 vfpu_flag_mask <= 4'b0;
          end else begin
                 operand_a_delay <=operand_a ;
+                vfpu_flag_mask  <=vfpu_simd_mask;
          end
     end
         ////////////////////////////
@@ -1065,21 +1068,27 @@ logic [5:0]  lzc_e64;
              vfrsqrt7_out_e16[2] = vfrsqrt7_fp16(vfpu_result[41:32],operand_a_delay[47:32],lzc_e16[11:8]);
              vfrsqrt7_out_e16[3] = vfrsqrt7_fp16(vfpu_result[57:48],operand_a_delay[63:48],lzc_e16[15:12]);
 
-             vfrsqrt7_result_o = {vfrsqrt7_out_e16[3].vfrsqrt7_e16,vfrsqrt7_out_e16[2].vfrsqrt7_e16,vfrsqrt7_out_e16[1].vfrsqrt7_e16,vfrsqrt7_out_e16[0].vfrsqrt7_e16};
-             vfrsqrt7_ex_flag  = vfrsqrt7_out_e16[3].vfrsqrt7_ex_flag | vfrsqrt7_out_e16[2].vfrsqrt7_ex_flag | vfrsqrt7_out_e16[1].vfrsqrt7_ex_flag | vfrsqrt7_out_e16[0].vfrsqrt7_ex_flag;
+             vfrsqrt7_result_o = {vfrsqrt7_out_e16[3].vf7_e16,vfrsqrt7_out_e16[2].vf7_e16,vfrsqrt7_out_e16[1].vf7_e16,vfrsqrt7_out_e16[0].vf7_e16};
+             vfrsqrt7_ex_flag  = (vfrsqrt7_out_e16[3].ex_flag   & {5{vfpu_flag_mask[3]}})
+                                 | (vfrsqrt7_out_e16[2].ex_flag & {5{vfpu_flag_mask[2]}})
+                                 | (vfrsqrt7_out_e16[1].ex_flag & {5{vfpu_flag_mask[1]}})
+                                 | (vfrsqrt7_out_e16[0].ex_flag & {5{vfpu_flag_mask[0]}});
+
          end
          EW32: begin
              vfrsqrt7_out_e32[0] = vfrsqrt7_fp32(vfpu_result[9:0] ,operand_a_delay[31:0] , lzc_e32[4:0]);
              vfrsqrt7_out_e32[1] = vfrsqrt7_fp32(vfpu_result[41:32],operand_a_delay[63:32],lzc_e32[9:5]);
 
-             vfrsqrt7_result_o = {vfrsqrt7_out_e32[1].vfrsqrt7_e32,vfrsqrt7_out_e32[0].vfrsqrt7_e32};
-             vfrsqrt7_ex_flag  = vfrsqrt7_out_e32[1].vfrsqrt7_ex_flag | vfrsqrt7_out_e32[0].vfrsqrt7_ex_flag;
+             vfrsqrt7_result_o = {vfrsqrt7_out_e32[1].vf7_e32,vfrsqrt7_out_e32[0].vf7_e32};
+             vfrsqrt7_ex_flag  = (vfrsqrt7_out_e32[1].ex_flag & {5{vfpu_flag_mask[2]}} )
+                                 | (vfrsqrt7_out_e32[0].ex_flag & {5{vfpu_flag_mask[0]}});
+
          end
          EW64: begin
             vfrsqrt7_out_e64 = vfrsqrt7_fp64(vfpu_result[9:0],operand_a_delay[63:0],lzc_e64[5:0]);
 
-             vfrsqrt7_result_o  =  vfrsqrt7_out_e64.vfrsqrt7_e64;
-             vfrsqrt7_ex_flag   =    vfrsqrt7_out_e64.vfrsqrt7_ex_flag;
+             vfrsqrt7_result_o  =  vfrsqrt7_out_e64.vf7_e64;
+             vfrsqrt7_ex_flag   =  vfrsqrt7_out_e64.ex_flag & {5{vfpu_flag_mask[0]}};
          end
          default: vfrsqrt7_result_o='x;
       endcase

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -760,7 +760,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
         VFCLASS,
         VFREC7,
         VFRSQRT7: begin
-           fp_op = CLASSIFY;
+          fp_op = CLASSIFY;
         end
         VFSGNJ : begin
           fp_op = SGNJ;
@@ -922,75 +922,79 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       .out_ready_i   (vfpu_out_ready ),
       .busy_o        (/* Unused */   )
     );
-   elen_t operand_a_delay,
-          vfrsqrt7_result_o;
 
-   fpu_mask_t vfpu_flag_mask;
+    //////////////
+    // vfrsqrt7 //
+    //////////////
 
-   vf7_flag_out_e16 vfrsqrt7_out_e16[4];
-   vf7_flag_out_e32 vfrsqrt7_out_e32[2];
-   vf7_flag_out_e64 vfrsqrt7_out_e64[1];
-   status_t    vfrsqrt7_ex_flag;
+    elen_t operand_a_delay, vfrsqrt7_result_o;
 
-   elen_t [LatFNonComp-1:0] operand_a_q;
-   elen_t [LatFNonComp:0]   operand_a_d;
+    fpu_mask_t vfpu_flag_mask;
 
+    vf7_flag_out_e16 vfrsqrt7_out_e16[4];
+    vf7_flag_out_e32 vfrsqrt7_out_e32[2];
+    vf7_flag_out_e64 vfrsqrt7_out_e64[1];
 
-   //Delay for vfpu mask
-   `FF(vfpu_flag_mask,vfpu_simd_mask,'0,clk_i,rst_ni);
+    status_t vfrsqrt7_ex_flag;
 
-   //Pipeline for operand_a
-   assign operand_a_d[0]   = operand_a;
-   for (genvar i = 0; i < LatFNonComp; i++) begin
-     assign operand_a_d[i+1]   = operand_a_q[i];
+    elen_t [LatFNonComp-1:0] operand_a_q;
+    elen_t [LatFNonComp:0]   operand_a_d;
 
-      `FF(operand_a_q[i], operand_a_d[i], '0, clk_i, rst_ni);
-   end
+    // Delay for vfpu mask
+    `FF(vfpu_flag_mask, vfpu_simd_mask, '0, clk_i, rst_ni);
 
-   assign operand_a_delay = operand_a_d[LatFNonComp];
-      ////////////////////////////
-      //  Leading zeros modules //
-      ////////////////////////////
-   localparam int unsigned SIG_BITS_E16   = 10;
-   localparam int unsigned SIG_BITS_E32   = 23;
-   localparam int unsigned SIG_BITS_E64   = 52;
+    // Pipeline for operand_a
+    assign operand_a_d[0] = operand_a;
+    for (genvar i = 0; i < LatFNonComp; i++) begin
+      assign operand_a_d[i+1] = operand_a_q[i];
 
-   logic [15:0] lzc_e16;
-   logic [9:0]  lzc_e32;
-   logic [5:0]  lzc_e64;
-    /////E16///
-     for (genvar i = 0; i < 4; i = i + 1) begin
-       lzc#(
-       .WIDTH(SIG_BITS_E16),
-       .MODE (1)
-     ) leading_zero_e16_i (
-       .in_i    (operand_a_delay[(16*i)+(SIG_BITS_E16-1):(16*i)]),
-       .cnt_o   (lzc_e16[(4*i)+3:(4*i)] ),
-       .empty_o ()
-     );
-     end
-   /////E32///
+       `FF(operand_a_q[i], operand_a_d[i], '0, clk_i, rst_ni);
+    end
 
-     for (genvar j = 0; j < 2; j = j + 1) begin
-       lzc#(
-       .WIDTH(SIG_BITS_E32),
-       .MODE (1)
-     ) leading_zero_e32_i (
-       .in_i    (operand_a_delay[(32*j)+(SIG_BITS_E32-1):(32*j)]),
-       .cnt_o   (lzc_e32[(5*j)+4:(5*j)] ),
-       .empty_o ()
-     );
-     end
+    assign operand_a_delay = operand_a_d[LatFNonComp];
 
-   /////E64///
-     lzc#(
-       .WIDTH(SIG_BITS_E64),
-       .MODE (1)
-     ) leading_zero_e64 (
-       .in_i    (operand_a_delay[SIG_BITS_E64-1:0]),
-       .cnt_o   (lzc_e64),
-       .empty_o ()
-     );
+    // Leading zeros modules
+    localparam int unsigned SIG_BITS_E16   = 10;
+    localparam int unsigned SIG_BITS_E32   = 23;
+    localparam int unsigned SIG_BITS_E64   = 52;
+
+    logic [15:0] lzc_e16;
+    logic [9:0]  lzc_e32;
+    logic [5:0]  lzc_e64;
+
+    // sew: 16-bit
+    for (genvar i = 0; i < 4; i = i + 1) begin
+      lzc #(
+        .WIDTH(SIG_BITS_E16),
+        .MODE (1           )
+      ) leading_zero_e16_i (
+         .in_i    (operand_a_delay[(16*i)+(SIG_BITS_E16-1):(16*i)]),
+         .cnt_o   (lzc_e16[(4*i)+3:(4*i)]                         ),
+         .empty_o ( /*Unused*/                                    )
+      );
+    end
+
+    // sew: 32-bit
+    for (genvar j = 0; j < 2; j = j + 1) begin
+      lzc #(
+        .WIDTH(SIG_BITS_E32),
+        .MODE (1           )
+      ) leading_zero_e32_i (
+        .in_i    (operand_a_delay[(32*j)+(SIG_BITS_E32-1):(32*j)]),
+        .cnt_o   (lzc_e32[(5*j)+4:(5*j)]                         ),
+        .empty_o (                                               )
+      );
+    end
+
+    // sew: 64-bit
+    lzc #(
+      .WIDTH(SIG_BITS_E64),
+      .MODE (1           )
+    ) leading_zero_e64 (
+      .in_i    (operand_a_delay[SIG_BITS_E64-1:0]),
+      .cnt_o   (lzc_e64                          ),
+      .empty_o (                                 )
+    );
 
     ////////////
     // vfrec7 //
@@ -1068,37 +1072,39 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
 
       //vfrsqrt7
       unique case (vinsn_processing_q.vtype.vsew)
-         EW16: begin
-            for (int h = 0; h < 4; h++) vfrsqrt7_out_e16[h] =
+        EW16: begin
+          for (int h = 0; h < 4; h++) vfrsqrt7_out_e16[h] =
             vfrsqrt7_fp16(vfpu_result[h*16 +: 10], operand_a_delay[h*16 +: 16], lzc_e16[h*4 +: 4]);
 
-             vfrsqrt7_result_o = {vfrsqrt7_out_e16[3].vf7_e16,vfrsqrt7_out_e16[2].vf7_e16,vfrsqrt7_out_e16[1].vf7_e16,vfrsqrt7_out_e16[0].vf7_e16};
-             vfrsqrt7_ex_flag  = (vfrsqrt7_out_e16[3].ex_flag   & {5{vfpu_flag_mask[3]}})
-                                 | (vfrsqrt7_out_e16[2].ex_flag & {5{vfpu_flag_mask[2]}})
-                                 | (vfrsqrt7_out_e16[1].ex_flag & {5{vfpu_flag_mask[1]}})
-                                 | (vfrsqrt7_out_e16[0].ex_flag & {5{vfpu_flag_mask[0]}});
+          vfrsqrt7_result_o = {vfrsqrt7_out_e16[3].vf7_e16, vfrsqrt7_out_e16[2].vf7_e16,
+                               vfrsqrt7_out_e16[1].vf7_e16, vfrsqrt7_out_e16[0].vf7_e16};
 
-         end
-         EW32: begin
-            for (int w = 0; w < 2; w++) vfrsqrt7_out_e32[w] =
-             vfrsqrt7_fp32(vfpu_result[w*32 +: 10], operand_a_delay[w*32 +: 32], lzc_e32[w*5 +: 5]);
+          vfrsqrt7_ex_flag = (vfrsqrt7_out_e16[3].ex_flag & {5{vfpu_flag_mask[3]}})
+                           | (vfrsqrt7_out_e16[2].ex_flag & {5{vfpu_flag_mask[2]}})
+                           | (vfrsqrt7_out_e16[1].ex_flag & {5{vfpu_flag_mask[1]}})
+                           | (vfrsqrt7_out_e16[0].ex_flag & {5{vfpu_flag_mask[0]}});
+        end
+        EW32: begin
+          for (int w = 0; w < 2; w++) vfrsqrt7_out_e32[w] =
+            vfrsqrt7_fp32(vfpu_result[w*32 +: 10], operand_a_delay[w*32 +: 32], lzc_e32[w*5 +: 5]);
 
-             vfrsqrt7_result_o = {vfrsqrt7_out_e32[1].vf7_e32,vfrsqrt7_out_e32[0].vf7_e32};
-             vfrsqrt7_ex_flag  = (vfrsqrt7_out_e32[1].ex_flag & {5{vfpu_flag_mask[2]}} )
-                                 | (vfrsqrt7_out_e32[0].ex_flag & {5{vfpu_flag_mask[0]}});
+          vfrsqrt7_result_o = {vfrsqrt7_out_e32[1].vf7_e32, vfrsqrt7_out_e32[0].vf7_e32};
 
-         end
-         EW64: begin
-            for (int d = 0; d < 1; d++) vfrsqrt7_out_e64[d] =
-             vfrsqrt7_fp64(vfpu_result[d*64 +: 10], operand_a_delay[d*64 +: 64], lzc_e64[d*6 +: 6]);
+          vfrsqrt7_ex_flag = (vfrsqrt7_out_e32[1].ex_flag & {5{vfpu_flag_mask[2]}})
+                           | (vfrsqrt7_out_e32[0].ex_flag & {5{vfpu_flag_mask[0]}});
+        end
+        EW64: begin
+          for (int d = 0; d < 1; d++) vfrsqrt7_out_e64[d] =
+            vfrsqrt7_fp64(vfpu_result[d*64 +: 10], operand_a_delay[d*64 +: 64], lzc_e64[d*6 +: 6]);
 
-             vfrsqrt7_result_o  =  vfrsqrt7_out_e64[0].vf7_e64;
-             vfrsqrt7_ex_flag   =  vfrsqrt7_out_e64[0].ex_flag & {5{vfpu_flag_mask[0]}};
-         end
-         default: begin
-             vfrsqrt7_result_o='x;
-             vfrsqrt7_ex_flag ='x;
-         end
+          vfrsqrt7_result_o = vfrsqrt7_out_e64[0].vf7_e64;
+
+          vfrsqrt7_ex_flag = vfrsqrt7_out_e64[0].ex_flag & {5{vfpu_flag_mask[0]}};
+        end
+        default: begin
+          vfrsqrt7_result_o = 'x;
+          vfrsqrt7_ex_flag  = 'x;
+        end
       endcase
 
         // Forward the result

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -924,6 +924,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     );
    elen_t operand_a_delay,
           vfrsqrt7_result_o;
+
    fpu_mask_t vfpu_flag_mask;
 
    vf7_flag_out_e16 vfrsqrt7_out_e16[4];
@@ -944,7 +945,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
      assign operand_a_d[i+1]   = operand_a_q[i];
 
       `FF(operand_a_q[i], operand_a_d[i], '0, clk_i, rst_ni);
-         end
+   end
 
    assign operand_a_delay = operand_a_d[LatFNonComp];
       ////////////////////////////
@@ -955,7 +956,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
    localparam int unsigned SIG_BITS_E64   = 52;
 
    logic [15:0] lzc_e16;
-   logic [9:0] lzc_e32;
+   logic [9:0]  lzc_e32;
    logic [5:0]  lzc_e64;
     /////E16///
      for (genvar i = 0; i < 4; i = i + 1) begin

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -1081,7 +1081,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
          end
          EW32: begin
             for (int w = 0; w < 2; w++) vfrsqrt7_out_e32[w] =
-            vfrsqrt7_fp32(vfpu_result[w*32 +: 10], operand_a_delay[w*32 +: 32], lzc_e32[w*5 +: 5]);
+             vfrsqrt7_fp32(vfpu_result[w*32 +: 10], operand_a_delay[w*32 +: 32], lzc_e32[w*5 +: 5]);
 
              vfrsqrt7_result_o = {vfrsqrt7_out_e32[1].vf7_e32,vfrsqrt7_out_e32[0].vf7_e32};
              vfrsqrt7_ex_flag  = (vfrsqrt7_out_e32[1].ex_flag & {5{vfpu_flag_mask[2]}} )
@@ -1090,12 +1090,15 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
          end
          EW64: begin
             for (int d = 0; d < 1; d++) vfrsqrt7_out_e64[d] =
-            vfrsqrt7_fp64(vfpu_result[d*64 +: 10], operand_a_delay[d*64 +: 64], lzc_e64[d*6 +: 6]);
+             vfrsqrt7_fp64(vfpu_result[d*64 +: 10], operand_a_delay[d*64 +: 64], lzc_e64[d*6 +: 6]);
 
              vfrsqrt7_result_o  =  vfrsqrt7_out_e64[0].vf7_e64;
              vfrsqrt7_ex_flag   =  vfrsqrt7_out_e64[0].ex_flag & {5{vfpu_flag_mask[0]}};
          end
-         default: vfrsqrt7_result_o='x;
+         default: begin
+             vfrsqrt7_result_o='x;
+             vfrsqrt7_ex_flag ='x;
+         end
       endcase
 
         // Forward the result
@@ -1107,7 +1110,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
          vfpu_ex_flag          = vfrsqrt7_ex_flag;
         end else begin
            vfpu_processed_result = vfpu_result;
-           vfpu_ex_flag          = vfpu_ex_flag;
+           vfpu_ex_flag          = vfpu_ex_flag_fn;
       end
       end else begin
         // NO vfrec7, vfrsqrt7, rto support

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -1119,7 +1119,6 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
         endcase
 
         // Forward the result
-<<<<<<< HEAD
         if (vinsn_processing_q.op == VFREC7) begin
           vfpu_processed_result = vfrec7_result_o;
           vfpu_ex_flag          = vfrec7_ex_flag;
@@ -1132,17 +1131,6 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       end
       end else begin
         // NO vfrec7, vfrsqrt7, rto support
-=======
-        if (vinsn_processing_q.op == VFRSQRT7) begin
-          vfpu_processed_result = vfrsqrt7_result_o;
-          vfpu_ex_flag          = vfrsqrt7_ex_flag;
-        end else begin
-          vfpu_processed_result = vfpu_result;
-          vfpu_ex_flag          = vfpu_ex_flag_fn;
-        end
-      end else begin
-        // NO vfrec, vfrsqrt7, rto support
->>>>>>> [hardware] Parametrize vfrsqrt7 support
         vfpu_processed_result = vfpu_result;
         vfpu_ex_flag          = vfpu_ex_flag_fn;
       end


### PR DESCRIPTION
vfrsqrt7 is a unary vector-vector instruction that returns an estimate of 1/sqrt(x) accurate to 7 bit.
### Input
For the non-exceptional cases:
- If input is normal, normalized input exponent is equal to the input exponent and normalized input significand(mantissa) is equal to the input significand.
- If input is subnormal, normalized input exponent is equal to 0 minus the number of leading zeros in the signifcand and the normalized input significand is given by shifting the input significand left by 1 minus the normalized input exponent.
### Output
- Output exponent can be found by:
                exp_o = (3*B-1-exp_i )/2
                         where B is exponent bias.
- Output 7-bit significand can be found by using lookup table.
- The address of lookup table is found by concatenating last LSB of the normalized input exponent and the six MSBs of the normalized input significand.
- The remainder of the result significand is zero
- The output sign equals the input sign.
## Changelog

### Fixed

- N/A

### Added

- Added support for vfrsqrt7 instruction
- Added tests for vfrsqrt7 instruction

### Changed

- N/A

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
