### PR TITLE
[HW] :bug: Hotfix - Reshuffle with LMUL > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Operand requesters sanitize partial operands during a reduction
  - Fix load/store-complete signals to CVA6
  - Remove latches/repeated-signals from `masku`
+ - Reshuffle all the registers of a register group that have `eew_q != eew_d` when `LMUL > 1`
+ - `VLXE` and `VSXE` need to wait that the SlideAddrGenA opreq is free before being issued by the lane sequencer to the operand requester stage
 
 ### Added
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -279,6 +279,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       RESHUFFLE: begin
         // Instruction is of one of the RVV types
         automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
+        // Initial temptative VLMAX (then modified by lmul!)
+        automatic int unsigned vlmax = VLENB >> ara_req_d.vtype_d.vsew;
 
         // Stall the interface, wait for the backend to accept the injected uop
         acc_req_ready_o  = 1'b0;
@@ -299,7 +301,22 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         ara_req_d.vm            = 1'b1;
         // Shuffle the whole reg (vl refers to current vsew)
         ara_req_d.vtype.vsew    = eew_new_buffer_q;
-        ara_req_d.vl            = VLENB >> ara_req_d.vtype.vsew;
+        // Maximum vector length. VLMAX = LMUL * VLEN / SEW.
+        unique case (vtype_q.vlmul)
+          LMUL_1  : vlmax <<= 0;
+          LMUL_2  : vlmax <<= 1;
+          LMUL_4  : vlmax <<= 2;
+          LMUL_8  : vlmax <<= 3;
+          default:;
+        endcase
+        // This is a conservative strategy and can be optimized.
+        // If LMUL > 1, technically we should reshuffle only the
+        // next registers that have eew_q != from vsew.
+        // An optimization can be to sequentially go one by one for
+        // LMUL times, starting from the first register, and check
+        // If we need a reshuffle there or not. If yes, inject a
+        // reshuffle instruction.
+        ara_req_d.vl            = vlmax;
         // Vl refers to current system vsew but operand requesters
         // will fetch from a register with a different eew
         ara_req_d.scale_vl      = 1'b1;

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -164,11 +164,13 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             operand_request_valid_o[MulFPUC] ||
             operand_request_valid_o[MaskM]);
         end
-        VFU_LoadUnit : pe_req_ready = !(operand_request_valid_o[MaskM]);
+        VFU_LoadUnit : pe_req_ready = !(operand_request_valid_o[MaskM] ||
+            (pe_req_i.op == VLXE && operand_request_valid_o[SlideAddrGenA]));
         VFU_SlideUnit: pe_req_ready = !(operand_request_valid_o[SlideAddrGenA]);
         VFU_StoreUnit: begin
           pe_req_ready = !(operand_request_valid_o[StA] ||
-            operand_request_valid_o[ MaskM]);
+            operand_request_valid_o[MaskM] ||
+            (pe_req_i.op == VSXE && operand_request_valid_o[SlideAddrGenA]));
         end
         VFU_MaskUnit : begin
           pe_req_ready = !(operand_request_valid_o[AluA] ||


### PR DESCRIPTION
Handle reshuffles when LMUL > 1. Before, only the first register was reshuffled. Now, every register belonging to the register group is checked and, if needed, reshuffled.

## Changelog

### Fixed

- Reshuffle all the registers of a register group that have `eew_q != eew_d` when `LMUL > 1`.
- Wait for `SlideAddrGenA` operand requester during a `VLXE` or `VSXE`.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
