### PR TITLE
[HW] Add support for vfrec7 instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add support for cache warming before benchmarks
  - Add support to check the results of the ideal dispatcher runs
  - Add HW/SW environment for automatic VCD dumping
+ - Support for vector floating-point reciprocal estimate instruction: `vfrec7`
 
 ### Changed
 

--- a/FUNCTIONALITIES.md
+++ b/FUNCTIONALITIES.md
@@ -54,6 +54,7 @@ This file specifies the functionalities of the RISC-V Vector Specification suppo
 - Vector single-width floating-point/integer type-convert instructions:`vfcvt.xu.f`, `vfcvt.x.f`, `vfcvt.rtz.xu.f`, `vfcvt.rtz.x.f`, `vfcvt.f.xu`, `vfcvt.f.x`
 - Vector widening floating-point/integer type-convert instructions: `vfwcvt.xu.f`, `vfwcvt.x.f`, `vfwcvt.rtz.xu.f`, `vfwcvt.rtz.x.f`, `vfwcvt.f.xu`, `vfwcvt.f.x`, `vfwcvt.f.f`
 - Vector narrowing floating-point/integer type-convert instructions: `vfncvt.xu.f`, `vfncvt.x.f`, `vfncvt.rtz.xu.f`, `vfncvt.rtz.x.f`, `vfncvt.f.xu`, `vfncvt.f.x`, `vfncvt.f.f`
+- Vector floating-point reciprocal estimate instruction: `vfrec7`
 
 ## Vector Reduction Operations
 

--- a/apps/riscv-tests/isa/rv64uv/Makefrag
+++ b/apps/riscv-tests/isa/rv64uv/Makefrag
@@ -170,7 +170,8 @@ rv64uv_sc_tests = vaadd \
                   vse32 \
                   vle64 \
                   vse64 \
-                  vle_vse_hazards
+                  vle_vse_hazards \
+                  vfrec7
 
 #rv64uv_sc_tests = vaadd vaaddu vadc vasub vasubu vcompress vfirst vid viota vl vlff vl_nocheck vlx vmsbf vmsif vmsof vpopc_m vrgather vsadd vsaddu vsetvl vsetivli vsetvli vsmul vssra vssrl vssub vssubu vsux vsx
 

--- a/apps/riscv-tests/isa/rv64uv/vfrec7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrec7.c
@@ -1,0 +1,57 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//y
+// Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+//         Basile Bougenot <bbougenot@student.ethz.ch>
+
+#include "float_macros.h"
+#include "vector_macros.h"
+
+void TEST_CASE1(void) {
+
+ VSET(16, e16, m1);
+  VLOAD_16(v2, mInfh, pInfh, qNaNh, sNaNh,
+               pZero, mZeroh, 0xba72,0x3a12,
+               0x3af7, 0x00fe,0x01e6,0x75e6,
+               0x80fe,0xb5fd, 0xb4e7, 0x7bc0);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U16(1, v1,mZeroh,pZero,qNaNh,qNaNh,
+              pInfh,mInfh, 0xbcf8,0x3d40,
+              0x3c98,pInfh,0x7838,0x02b8,
+              mInfh,0xc158,0xc288,0x0108);
+
+  VSET(16, e32, m1);
+  VLOAD_32(v2, mInff, pInff, qNaNf, sNaNf,
+               pZero, mZerof,0xfe7fca13,0x00800000,
+                 0x807ee93e, 0x803ee93e,0x00200000,0x00400000,
+                 0x00800000, 0xff787a12,0xff000005,0x800dd27e);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U32(2, v1,mZerof,pZero,qNaNf,qNaNf,
+                pInff,mInff,0x80800000,0x7e7f0000,
+                0xfe810000,0xff020000,0x7f7f0000,0x7eff0000,
+                0x7e7f0000,0x80210000,0x803fc000,mInff);
+  VSET(16, e64, m1);
+  VLOAD_64(v2, mInfd, pInfd, qNaNd, sNaNd,
+              pZero, mZerod,0xffee384e0c3fbf7c,0xffdfa4dc68d2ae1a,
+              0xffcf49b8d1aa1fda,0x800f47ea9ea8e436,0x800747ea961ff344,0x00060000005e7fcf,
+              0x000bffffd07b5869,0x7fbfffff9bfec946,0x7fdc709c2bde6967,0x000347ea91db7acb);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U64(3, v1,mZerod,pZero,qNaNd,qNaNd,
+              pInfd,mInfd,0x8004400000000000,0x8008100000000000,
+              0x8010600000000000,0xffd0c00000000000, 0xffe1a00000000000,0x7fe5400000000000,
+              0x7fd5600000000000,0x0020000000000000,0x0009000000000000, pInfd);
+
+
+};
+
+int main(void) {
+  enable_vec();
+  enable_fp();
+
+  TEST_CASE1();
+  
+  EXIT_CHECK();
+
+  
+}

--- a/apps/riscv-tests/isa/rv64uv/vfrec7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrec7.c
@@ -35,12 +35,86 @@ void TEST_CASE1(void) {
            0xffe1a00000000000, 0x7fe5400000000000, 0x7fd5600000000000,
            0x0020000000000000, 0x0009000000000000, pInfd);
 };
+// Test to check DZ flag
+void TEST_CASE2(void) {
+  CLEAR_FFLAGS;
+  VSET(16, e16, m1);
+  CHECK_FFLAGS(0);
+  VLOAD_16(v2, pZero, mZeroh, pZero, mZeroh, pZero, mZeroh, pZero, mZeroh,
+           pZero, mZeroh, pZero, mZeroh, pZero, mZeroh, pZero, mZeroh);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U16(4, v1, pInfh, mInfh, pInfh, mInfh, pInfh, mInfh, pInfh, mInfh, pInfh,
+           mInfh, pInfh, mInfh, pInfh, mInfh, pInfh, mInfh);
+  CHECK_FFLAGS(DZ);
 
+  CLEAR_FFLAGS;
+  VSET(16, e32, m1);
+  CHECK_FFLAGS(0);
+  VLOAD_32(v2, pZero, mZerof, pZero, mZerof, pZero, mZerof, pZero, mZerof,
+           pZero, mZerof, pZero, mZerof, pZero, mZerof, pZero, mZerof);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U32(5, v1, pInff, mInff, pInff, mInff, pInff, mInff, pInff, mInff, pInff,
+           mInff, pInff, mInff, pInff, mInff, pInff, mInff);
+  CHECK_FFLAGS(DZ);
+
+  CLEAR_FFLAGS;
+  VSET(16, e64, m1);
+  CHECK_FFLAGS(0);
+  VLOAD_64(v2, pZero, mZerod, pZero, mZerod, pZero, mZerod, pZero, mZerod,
+           pZero, mZerod, pZero, mZerod, pZero, mZerod, pZero, mZerod);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U64(6, v1, pInfd, mInfd, pInfd, mInfd, pInfd, mInfd, pInfd, mInfd, pInfd,
+           mInfd, pInfd, mInfd, pInfd, mInfd, pInfd, mInfd);
+  CHECK_FFLAGS(DZ);
+};
+// Test to check NX,OF flags as well as for subnormal numbers with sig=00..
+void TEST_CASE3(void) {
+  CLEAR_FFLAGS;
+  VSET(16, e16, m1);
+  CHECK_FFLAGS(0);
+  CHANGE_RM(RM_RUP);
+  VLOAD_16(v2, 0x80fe, 0x807e, 0x803e, 0x801e, 0x800e, 0x8006, 0x8002, 0x8030,
+           0x00fe, 0x007e, 0x003e, 0x001e, 0x000e, 0x0006, 0x0002, 0x0030);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U16(7, v1, mMaxh, mMaxh, mMaxh, mMaxh, mMaxh, mMaxh, mMaxh, mMaxh, pInfh,
+           pInfh, pInfh, pInfh, pInfh, pInfh, pInfh, pInfh);
+  CHECK_FFLAGS(NX | OF);
+
+  CLEAR_FFLAGS;
+  VSET(16, e32, m1);
+  CHECK_FFLAGS(0);
+  CHANGE_RM(RM_RDN);
+  VLOAD_32(v2, 0x800dd27e, 0x8005d27e, 0x8005d27c, 0x8001d27c, 0x8000d27c,
+           0x8000527c, 0x8000127c, 0x8000107c, 0x000dd27e, 0x0005d27e,
+           0x0005d27c, 0x0001d27c, 0x0000d27c, 0x0000527c, 0x0000127c,
+           0x0000107c);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U32(8, v1, mInff, mInff, mInff, mInff, mInff, mInff, mInff, mInff, pMaxf,
+           pMaxf, pMaxf, pMaxf, pMaxf, pMaxf, pMaxf, pMaxf);
+  CHECK_FFLAGS(NX | OF);
+
+  CLEAR_FFLAGS;
+  VSET(16, e64, m1);
+  CHECK_FFLAGS(0);
+  CHANGE_RM(RM_RTZ);
+  VLOAD_64(v2, 0x000147ea91db7acb, 0x000347ea91db7acb, 0x000047ea91db7acb,
+           0x000347ea91db70cb, 0x000347ea91db7a0b, 0x000347ea91db7ac0,
+           0x000347ea91db0acb, 0x000348e91db7acb, 0x800147ea91db7acb,
+           0x800347ea91db7acb, 0x800047ea91db7acb, 0x800347ea91db70cb,
+           0x800347ea91db7a0b, 0x800347ea91db7ac0, 0x800347ea91db0acb,
+           0x800147ea91db7a0b);
+  asm volatile("vfrec7.v v1, v2");
+  VCMP_U64(9, v1, pMaxd, pMaxd, pMaxd, pMaxd, pMaxd, pMaxd, pMaxd, pMaxd, mMaxd,
+           mMaxd, mMaxd, mMaxd, mMaxd, mMaxd, mMaxd, mMaxd);
+  CHECK_FFLAGS(NX | OF);
+};
 int main(void) {
   enable_vec();
   enable_fp();
 
   TEST_CASE1();
+  TEST_CASE2();
+  TEST_CASE3();
 
   EXIT_CHECK();
 }

--- a/apps/riscv-tests/isa/rv64uv/vfrec7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrec7.c
@@ -50,8 +50,8 @@ int main(void) {
   enable_fp();
 
   TEST_CASE1();
-  
+
   EXIT_CHECK();
 
-  
+
 }

--- a/apps/riscv-tests/isa/rv64uv/vfrec7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrec7.c
@@ -1,7 +1,7 @@
 // Copyright 2021 ETH Zurich and University of Bologna.
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
-//y
+// y
 // Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
 
@@ -9,40 +9,31 @@
 #include "vector_macros.h"
 
 void TEST_CASE1(void) {
-
- VSET(16, e16, m1);
-  VLOAD_16(v2, mInfh, pInfh, qNaNh, sNaNh,
-               pZero, mZeroh, 0xba72,0x3a12,
-               0x3af7, 0x00fe,0x01e6,0x75e6,
-               0x80fe,0xb5fd, 0xb4e7, 0x7bc0);
+  VSET(16, e16, m1);
+  VLOAD_16(v2, mInfh, pInfh, qNaNh, sNaNh, pZero, mZeroh, 0xba72, 0x3a12,
+           0x3af7, 0x00fe, 0x01e6, 0x75e6, 0x80fe, 0xb5fd, 0xb4e7, 0x7bc0);
   asm volatile("vfrec7.v v1, v2");
-  VCMP_U16(1, v1,mZeroh,pZero,qNaNh,qNaNh,
-              pInfh,mInfh, 0xbcf8,0x3d40,
-              0x3c98,pInfh,0x7838,0x02b8,
-              mInfh,0xc158,0xc288,0x0108);
+  VCMP_U16(1, v1, mZeroh, pZero, qNaNh, qNaNh, pInfh, mInfh, 0xbcf8, 0x3d40,
+           0x3c98, pInfh, 0x7838, 0x02b8, mInfh, 0xc158, 0xc288, 0x0108);
 
   VSET(16, e32, m1);
-  VLOAD_32(v2, mInff, pInff, qNaNf, sNaNf,
-               pZero, mZerof,0xfe7fca13,0x00800000,
-                 0x807ee93e, 0x803ee93e,0x00200000,0x00400000,
-                 0x00800000, 0xff787a12,0xff000005,0x800dd27e);
+  VLOAD_32(v2, mInff, pInff, qNaNf, sNaNf, pZero, mZerof, 0xfe7fca13,
+           0x00800000, 0x807ee93e, 0x803ee93e, 0x00200000, 0x00400000,
+           0x00800000, 0xff787a12, 0xff000005, 0x800dd27e);
   asm volatile("vfrec7.v v1, v2");
-  VCMP_U32(2, v1,mZerof,pZero,qNaNf,qNaNf,
-                pInff,mInff,0x80800000,0x7e7f0000,
-                0xfe810000,0xff020000,0x7f7f0000,0x7eff0000,
-                0x7e7f0000,0x80210000,0x803fc000,mInff);
+  VCMP_U32(2, v1, mZerof, pZero, qNaNf, qNaNf, pInff, mInff, 0x80800000,
+           0x7e7f0000, 0xfe810000, 0xff020000, 0x7f7f0000, 0x7eff0000,
+           0x7e7f0000, 0x80210000, 0x803fc000, mInff);
   VSET(16, e64, m1);
-  VLOAD_64(v2, mInfd, pInfd, qNaNd, sNaNd,
-              pZero, mZerod,0xffee384e0c3fbf7c,0xffdfa4dc68d2ae1a,
-              0xffcf49b8d1aa1fda,0x800f47ea9ea8e436,0x800747ea961ff344,0x00060000005e7fcf,
-              0x000bffffd07b5869,0x7fbfffff9bfec946,0x7fdc709c2bde6967,0x000347ea91db7acb);
+  VLOAD_64(v2, mInfd, pInfd, qNaNd, sNaNd, pZero, mZerod, 0xffee384e0c3fbf7c,
+           0xffdfa4dc68d2ae1a, 0xffcf49b8d1aa1fda, 0x800f47ea9ea8e436,
+           0x800747ea961ff344, 0x00060000005e7fcf, 0x000bffffd07b5869,
+           0x7fbfffff9bfec946, 0x7fdc709c2bde6967, 0x000347ea91db7acb);
   asm volatile("vfrec7.v v1, v2");
-  VCMP_U64(3, v1,mZerod,pZero,qNaNd,qNaNd,
-              pInfd,mInfd,0x8004400000000000,0x8008100000000000,
-              0x8010600000000000,0xffd0c00000000000, 0xffe1a00000000000,0x7fe5400000000000,
-              0x7fd5600000000000,0x0020000000000000,0x0009000000000000, pInfd);
-
-
+  VCMP_U64(3, v1, mZerod, pZero, qNaNd, qNaNd, pInfd, mInfd, 0x8004400000000000,
+           0x8008100000000000, 0x8010600000000000, 0xffd0c00000000000,
+           0xffe1a00000000000, 0x7fe5400000000000, 0x7fd5600000000000,
+           0x0020000000000000, 0x0009000000000000, pInfd);
 };
 
 int main(void) {
@@ -52,6 +43,4 @@ int main(void) {
   TEST_CASE1();
 
   EXIT_CHECK();
-
-
 }

--- a/apps/riscv-tests/isa/rv64uv/vfrec7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrec7.c
@@ -1,9 +1,10 @@
 // Copyright 2021 ETH Zurich and University of Bologna.
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
-// y
+// 
 // Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
+//         Shafiullah Khan <shafi.ullah@10xengineers.ai>
 
 #include "float_macros.h"
 #include "vector_macros.h"

--- a/apps/riscv-tests/isa/rv64uv/vfrec7.c
+++ b/apps/riscv-tests/isa/rv64uv/vfrec7.c
@@ -1,7 +1,7 @@
 // Copyright 2021 ETH Zurich and University of Bologna.
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
-// 
+//
 // Author: Matteo Perotti <mperotti@iis.ee.ethz.ch>
 //         Basile Bougenot <bbougenot@student.ethz.ch>
 //         Shafiullah Khan <shafi.ullah@10xengineers.ai>

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -38,6 +38,13 @@ package ara_pkg;
     FixedPointEnable  = 1'b1
   } fixpt_support_e;
 
+  // FP support outside of the FPU (external)
+  // vfrec7, vfrsqrt7, round-toward-odd
+  typedef enum logic {
+    FPExtSupportDisable = 1'b0,
+    FPExtSupportEnable  = 1'b1
+  } fpext_support_e;
+
   // The three bits correspond to {RVVD, RVVF, RVVH}
   typedef enum logic [2:0] {
     FPUSupportNone             = 3'b000,
@@ -1007,47 +1014,50 @@ package ara_pkg;
   } addrgen_axi_req_t;
 
 
+  /////////////
+  // VFREC7 //
+  ///////////
+
+  localparam int unsigned LUT_BITS = 7;
+
+  localparam int unsigned E16_BITS = 16;
+  localparam int unsigned E32_BITS = 32;
+  localparam int unsigned E64_BITS = 64;
+
+  localparam int unsigned EXP_BITS_E16 = 5;
+  localparam int unsigned EXP_BITS_E32 = 8;
+  localparam int unsigned EXP_BITS_E64 = 11;
+
+  localparam int unsigned VF_TYPE_SEL_BITS = 10;
+
+  localparam logic [4:0]  E16_2xB = 5'd30;
+  localparam logic [7:0]  E32_2xB = 8'd254;
+  localparam logic [10:0] E64_2xB = 11'd2046;
+
+  localparam logic [15:0] E16_NaN  = 16'h7e00;
+  localparam logic [15:0] E16_pInf = 16'h7c00;
+  localparam logic [15:0] E16_mInf = 16'hfc00;
+  localparam logic [14:0] E16_Max  = 15'h7bff;
+  localparam logic [14:0] E16_Inf  = 15'h7c00;
+
+  localparam logic [31:0] E32_NaN  = 32'h7fc00000;
+  localparam logic [31:0] E32_pInf = 32'h7f800000;
+  localparam logic [31:0] E32_mInf = 32'hff800000;
+  localparam logic [30:0] E32_Max  = 31'h7f7fffff;
+  localparam logic [30:0] E32_Inf  = 31'hff800000;
 
 
-localparam int unsigned LUT_BITS     = 7;
-localparam int unsigned E16_BITS     = 16;
-localparam int unsigned E32_BITS     = 32;
-localparam int unsigned E64_BITS     = 64;
+  localparam logic [63:0] E64_NaN  = 64'h7ff8000000000000;
+  localparam logic [63:0] E64_pInf = 64'h7ff0000000000000;
+  localparam logic [63:0] E64_mInf = 64'hfff0000000000000;
+  localparam logic [62:0] E64_Max  = 63'h7fefffffffffffff;
+  localparam logic [62:0] E64_Inf  = 63'h7ff0000000000000;
 
-localparam int unsigned EXP_BITS_E16  = 5;
-localparam int unsigned EXP_BITS_E32  = 8;
-localparam int unsigned EXP_BITS_E64  = 11;
-
-localparam int unsigned VF_TYPE_SEL_BITS  = 10;
-
-localparam logic [4:0]  E16_2xB     = 5'd30;
-localparam logic [7:0]  E32_2xB     = 8'd254;
-localparam logic [10:0] E64_2xB     = 11'd2046;
-
-localparam logic [15:0] E16_NaN   = 16'h7e00;
-localparam logic [15:0] E16_pInf  = 16'h7c00;
-localparam logic [15:0] E16_mInf  = 16'hfc00;
-localparam logic [14:0] E16_Max   = 15'h7bff;
-localparam logic [14:0] E16_Inf   = 15'h7c00;
-
-localparam int unsigned E32_NaN   = 32'h7fc00000;
-localparam int unsigned E32_pInf  = 32'h7f800000;
-localparam int unsigned E32_mInf  = 32'hff800000;
-localparam logic [30:0] E32_Max   = 31'h7f7fffff;
-localparam logic [30:0] E32_Inf  =  31'hff800000;
-
-
-localparam logic [63:0] E64_NaN   = 64'h7ff8000000000000;
-localparam logic [63:0] E64_pInf  = 64'h7ff0000000000000;
-localparam logic [63:0] E64_mInf  = 64'hfff0000000000000;
-localparam logic [62:0] E64_Max   = 63'h7fefffffffffffff;
-localparam logic [62:0] E64_Inf   = 63'h7ff0000000000000;
-
-
+  // Structure containing 5 bit flag and desired output
  typedef struct packed {
   fpnew_pkg::status_t ex_flag;
   fp16_t              vf7_e16;
-  } vf7_flag_out_e16;
+ } vf7_flag_out_e16;
 
   typedef struct packed {
   fpnew_pkg::status_t ex_flag;
@@ -1059,520 +1069,505 @@ localparam logic [62:0] E64_Inf   = 63'h7ff0000000000000;
   fp64_t              vf7_e64;
   } vf7_flag_out_e64;
 
-  ///////////////////////////
-  //  VFREC7 Look Up Table //
-  //////////////////////////
-
+  // vfrec7 LUT
   function automatic logic [LUT_BITS-1:0] vfrec7_lut(logic [LUT_BITS-1:0] vfrec7_lut_select);
-      logic [LUT_BITS-1:0] vfrec7_lut_out;
-      unique case (vfrec7_lut_select)
-          7'd0  : vfrec7_lut_out=7'd127;
-          7'd1  : vfrec7_lut_out=7'd125;
-          7'd2  : vfrec7_lut_out=7'd123;
-          7'd3  : vfrec7_lut_out=7'd121;
-          7'd4  : vfrec7_lut_out=7'd119;
-          7'd5  : vfrec7_lut_out=7'd117;
-          7'd6  : vfrec7_lut_out=7'd116;
-          7'd7  : vfrec7_lut_out=7'd114;
-          7'd8  : vfrec7_lut_out=7'd112;
-          7'd9  : vfrec7_lut_out=7'd110;
-          7'd10 : vfrec7_lut_out=7'd109;
-          7'd11 : vfrec7_lut_out=7'd107;
-          7'd12 : vfrec7_lut_out=7'd105;
-          7'd13 : vfrec7_lut_out=7'd104;
-          7'd14 : vfrec7_lut_out=7'd102;
-          7'd15 : vfrec7_lut_out=7'd100;
-          7'd16 : vfrec7_lut_out=7'd99;
-          7'd17 : vfrec7_lut_out=7'd97;
-          7'd18 : vfrec7_lut_out=7'd96;
-          7'd19 : vfrec7_lut_out=7'd94;
-          7'd20 : vfrec7_lut_out=7'd93;
-          7'd21 : vfrec7_lut_out=7'd91;
-          7'd22 : vfrec7_lut_out=7'd90;
-          7'd23 : vfrec7_lut_out=7'd88;
-          7'd24 : vfrec7_lut_out=7'd87;
-          7'd25 : vfrec7_lut_out=7'd85;
-          7'd26 : vfrec7_lut_out=7'd84;
-          7'd27 : vfrec7_lut_out=7'd83;
-          7'd28 : vfrec7_lut_out=7'd81;
-          7'd29 : vfrec7_lut_out=7'd80;
-          7'd30 : vfrec7_lut_out=7'd79;
-          7'd31 : vfrec7_lut_out=7'd77;
-          7'd32 : vfrec7_lut_out=7'd76;
-          7'd33 : vfrec7_lut_out=7'd75;
-          7'd34 : vfrec7_lut_out=7'd74;
-          7'd35 : vfrec7_lut_out=7'd72;
-          7'd36 : vfrec7_lut_out=7'd71;
-          7'd37 : vfrec7_lut_out=7'd70;
-          7'd38 : vfrec7_lut_out=7'd69;
-          7'd39 : vfrec7_lut_out=7'd68;
-          7'd40 : vfrec7_lut_out=7'd66;
-          7'd41 : vfrec7_lut_out=7'd65;
-          7'd42 : vfrec7_lut_out=7'd64;
-          7'd43 : vfrec7_lut_out=7'd63;
-          7'd44 : vfrec7_lut_out=7'd62;
-          7'd45 : vfrec7_lut_out=7'd61;
-          7'd46 : vfrec7_lut_out=7'd60;
-          7'd47 : vfrec7_lut_out=7'd59;
-          7'd48 : vfrec7_lut_out=7'd58;
-          7'd49 : vfrec7_lut_out=7'd57;
-          7'd50 : vfrec7_lut_out=7'd56;
-          7'd51 : vfrec7_lut_out=7'd55;
-          7'd52 : vfrec7_lut_out=7'd54;
-          7'd53 : vfrec7_lut_out=7'd53;
-          7'd54 : vfrec7_lut_out=7'd52;
-          7'd55 : vfrec7_lut_out=7'd51;
-          7'd56 : vfrec7_lut_out=7'd50;
-          7'd57 : vfrec7_lut_out=7'd49;
-          7'd58 : vfrec7_lut_out=7'd48;
-          7'd59 : vfrec7_lut_out=7'd47;
-          7'd60 : vfrec7_lut_out=7'd46;
-          7'd61 : vfrec7_lut_out=7'd45;
-          7'd62 : vfrec7_lut_out=7'd44;
-          7'd63 : vfrec7_lut_out=7'd43;
-          7'd64 : vfrec7_lut_out=7'd42;
-          7'd65 : vfrec7_lut_out=7'd41;
-          7'd66 : vfrec7_lut_out=7'd40;
-          7'd67 : vfrec7_lut_out=7'd40;
-          7'd68 : vfrec7_lut_out=7'd39;
-          7'd69 : vfrec7_lut_out=7'd38;
-          7'd70 : vfrec7_lut_out=7'd37;
-          7'd71 : vfrec7_lut_out=7'd36;
-          7'd72 : vfrec7_lut_out=7'd35;
-          7'd73 : vfrec7_lut_out=7'd35;
-          7'd74 : vfrec7_lut_out=7'd34;
-          7'd75 : vfrec7_lut_out=7'd33;
-          7'd76 : vfrec7_lut_out=7'd32;
-          7'd77 : vfrec7_lut_out=7'd31;
-          7'd78 : vfrec7_lut_out=7'd31;
-          7'd79 : vfrec7_lut_out=7'd30;
-          7'd80 : vfrec7_lut_out=7'd29;
-          7'd81 : vfrec7_lut_out=7'd28;
-          7'd82 : vfrec7_lut_out=7'd28;
-          7'd83 : vfrec7_lut_out=7'd27;
-          7'd84 : vfrec7_lut_out=7'd26;
-          7'd85 : vfrec7_lut_out=7'd25;
-          7'd86 : vfrec7_lut_out=7'd25;
-          7'd87 : vfrec7_lut_out=7'd24;
-          7'd88 : vfrec7_lut_out=7'd23;
-          7'd89 : vfrec7_lut_out=7'd23;
-          7'd90 : vfrec7_lut_out=7'd22;
-          7'd91 : vfrec7_lut_out=7'd21;
-          7'd92 : vfrec7_lut_out=7'd21;
-          7'd93 : vfrec7_lut_out=7'd20;
-          7'd94 : vfrec7_lut_out=7'd19;
-          7'd95 : vfrec7_lut_out=7'd19;
-          7'd96 : vfrec7_lut_out=7'd18;
-          7'd97 : vfrec7_lut_out=7'd17;
-          7'd98 : vfrec7_lut_out=7'd17;
-          7'd99 : vfrec7_lut_out=7'd16;
-          7'd100: vfrec7_lut_out=7'd15;
-          7'd101: vfrec7_lut_out=7'd15;
-          7'd102: vfrec7_lut_out=7'd14;
-          7'd103: vfrec7_lut_out=7'd14;
-          7'd104: vfrec7_lut_out=7'd13;
-          7'd105: vfrec7_lut_out=7'd12;
-          7'd106: vfrec7_lut_out=7'd12;
-          7'd107: vfrec7_lut_out=7'd11;
-          7'd108: vfrec7_lut_out=7'd11;
-          7'd109: vfrec7_lut_out=7'd10;
-          7'd110: vfrec7_lut_out=7'd9;
-          7'd111: vfrec7_lut_out=7'd9;
-          7'd112: vfrec7_lut_out=7'd8;
-          7'd113: vfrec7_lut_out=7'd8;
-          7'd114: vfrec7_lut_out=7'd7;
-          7'd115: vfrec7_lut_out=7'd7;
-          7'd116: vfrec7_lut_out=7'd6;
-          7'd117: vfrec7_lut_out=7'd5;
-          7'd118: vfrec7_lut_out=7'd5;
-          7'd119: vfrec7_lut_out=7'd4;
-          7'd120: vfrec7_lut_out=7'd4;
-          7'd121: vfrec7_lut_out=7'd3;
-          7'd122: vfrec7_lut_out=7'd3;
-          7'd123: vfrec7_lut_out=7'd2;
-          7'd124: vfrec7_lut_out=7'd2;
-          7'd125: vfrec7_lut_out=7'd1;
-          7'd126: vfrec7_lut_out=7'd1;
-          7'd127: vfrec7_lut_out=7'd0;
-      endcase
-      return vfrec7_lut_out;
+    logic [LUT_BITS-1:0] vfrec7_lut_out;
+    unique case (vfrec7_lut_select)
+      7'd0  : vfrec7_lut_out=7'd127;
+      7'd1  : vfrec7_lut_out=7'd125;
+      7'd2  : vfrec7_lut_out=7'd123;
+      7'd3  : vfrec7_lut_out=7'd121;
+      7'd4  : vfrec7_lut_out=7'd119;
+      7'd5  : vfrec7_lut_out=7'd117;
+      7'd6  : vfrec7_lut_out=7'd116;
+      7'd7  : vfrec7_lut_out=7'd114;
+      7'd8  : vfrec7_lut_out=7'd112;
+      7'd9  : vfrec7_lut_out=7'd110;
+      7'd10 : vfrec7_lut_out=7'd109;
+      7'd11 : vfrec7_lut_out=7'd107;
+      7'd12 : vfrec7_lut_out=7'd105;
+      7'd13 : vfrec7_lut_out=7'd104;
+      7'd14 : vfrec7_lut_out=7'd102;
+      7'd15 : vfrec7_lut_out=7'd100;
+      7'd16 : vfrec7_lut_out=7'd99;
+      7'd17 : vfrec7_lut_out=7'd97;
+      7'd18 : vfrec7_lut_out=7'd96;
+      7'd19 : vfrec7_lut_out=7'd94;
+      7'd20 : vfrec7_lut_out=7'd93;
+      7'd21 : vfrec7_lut_out=7'd91;
+      7'd22 : vfrec7_lut_out=7'd90;
+      7'd23 : vfrec7_lut_out=7'd88;
+      7'd24 : vfrec7_lut_out=7'd87;
+      7'd25 : vfrec7_lut_out=7'd85;
+      7'd26 : vfrec7_lut_out=7'd84;
+      7'd27 : vfrec7_lut_out=7'd83;
+      7'd28 : vfrec7_lut_out=7'd81;
+      7'd29 : vfrec7_lut_out=7'd80;
+      7'd30 : vfrec7_lut_out=7'd79;
+      7'd31 : vfrec7_lut_out=7'd77;
+      7'd32 : vfrec7_lut_out=7'd76;
+      7'd33 : vfrec7_lut_out=7'd75;
+      7'd34 : vfrec7_lut_out=7'd74;
+      7'd35 : vfrec7_lut_out=7'd72;
+      7'd36 : vfrec7_lut_out=7'd71;
+      7'd37 : vfrec7_lut_out=7'd70;
+      7'd38 : vfrec7_lut_out=7'd69;
+      7'd39 : vfrec7_lut_out=7'd68;
+      7'd40 : vfrec7_lut_out=7'd66;
+      7'd41 : vfrec7_lut_out=7'd65;
+      7'd42 : vfrec7_lut_out=7'd64;
+      7'd43 : vfrec7_lut_out=7'd63;
+      7'd44 : vfrec7_lut_out=7'd62;
+      7'd45 : vfrec7_lut_out=7'd61;
+      7'd46 : vfrec7_lut_out=7'd60;
+      7'd47 : vfrec7_lut_out=7'd59;
+      7'd48 : vfrec7_lut_out=7'd58;
+      7'd49 : vfrec7_lut_out=7'd57;
+      7'd50 : vfrec7_lut_out=7'd56;
+      7'd51 : vfrec7_lut_out=7'd55;
+      7'd52 : vfrec7_lut_out=7'd54;
+      7'd53 : vfrec7_lut_out=7'd53;
+      7'd54 : vfrec7_lut_out=7'd52;
+      7'd55 : vfrec7_lut_out=7'd51;
+      7'd56 : vfrec7_lut_out=7'd50;
+      7'd57 : vfrec7_lut_out=7'd49;
+      7'd58 : vfrec7_lut_out=7'd48;
+      7'd59 : vfrec7_lut_out=7'd47;
+      7'd60 : vfrec7_lut_out=7'd46;
+      7'd61 : vfrec7_lut_out=7'd45;
+      7'd62 : vfrec7_lut_out=7'd44;
+      7'd63 : vfrec7_lut_out=7'd43;
+      7'd64 : vfrec7_lut_out=7'd42;
+      7'd65 : vfrec7_lut_out=7'd41;
+      7'd66 : vfrec7_lut_out=7'd40;
+      7'd67 : vfrec7_lut_out=7'd40;
+      7'd68 : vfrec7_lut_out=7'd39;
+      7'd69 : vfrec7_lut_out=7'd38;
+      7'd70 : vfrec7_lut_out=7'd37;
+      7'd71 : vfrec7_lut_out=7'd36;
+      7'd72 : vfrec7_lut_out=7'd35;
+      7'd73 : vfrec7_lut_out=7'd35;
+      7'd74 : vfrec7_lut_out=7'd34;
+      7'd75 : vfrec7_lut_out=7'd33;
+      7'd76 : vfrec7_lut_out=7'd32;
+      7'd77 : vfrec7_lut_out=7'd31;
+      7'd78 : vfrec7_lut_out=7'd31;
+      7'd79 : vfrec7_lut_out=7'd30;
+      7'd80 : vfrec7_lut_out=7'd29;
+      7'd81 : vfrec7_lut_out=7'd28;
+      7'd82 : vfrec7_lut_out=7'd28;
+      7'd83 : vfrec7_lut_out=7'd27;
+      7'd84 : vfrec7_lut_out=7'd26;
+      7'd85 : vfrec7_lut_out=7'd25;
+      7'd86 : vfrec7_lut_out=7'd25;
+      7'd87 : vfrec7_lut_out=7'd24;
+      7'd88 : vfrec7_lut_out=7'd23;
+      7'd89 : vfrec7_lut_out=7'd23;
+      7'd90 : vfrec7_lut_out=7'd22;
+      7'd91 : vfrec7_lut_out=7'd21;
+      7'd92 : vfrec7_lut_out=7'd21;
+      7'd93 : vfrec7_lut_out=7'd20;
+      7'd94 : vfrec7_lut_out=7'd19;
+      7'd95 : vfrec7_lut_out=7'd19;
+      7'd96 : vfrec7_lut_out=7'd18;
+      7'd97 : vfrec7_lut_out=7'd17;
+      7'd98 : vfrec7_lut_out=7'd17;
+      7'd99 : vfrec7_lut_out=7'd16;
+      7'd100: vfrec7_lut_out=7'd15;
+      7'd101: vfrec7_lut_out=7'd15;
+      7'd102: vfrec7_lut_out=7'd14;
+      7'd103: vfrec7_lut_out=7'd14;
+      7'd104: vfrec7_lut_out=7'd13;
+      7'd105: vfrec7_lut_out=7'd12;
+      7'd106: vfrec7_lut_out=7'd12;
+      7'd107: vfrec7_lut_out=7'd11;
+      7'd108: vfrec7_lut_out=7'd11;
+      7'd109: vfrec7_lut_out=7'd10;
+      7'd110: vfrec7_lut_out=7'd9;
+      7'd111: vfrec7_lut_out=7'd9;
+      7'd112: vfrec7_lut_out=7'd8;
+      7'd113: vfrec7_lut_out=7'd8;
+      7'd114: vfrec7_lut_out=7'd7;
+      7'd115: vfrec7_lut_out=7'd7;
+      7'd116: vfrec7_lut_out=7'd6;
+      7'd117: vfrec7_lut_out=7'd5;
+      7'd118: vfrec7_lut_out=7'd5;
+      7'd119: vfrec7_lut_out=7'd4;
+      7'd120: vfrec7_lut_out=7'd4;
+      7'd121: vfrec7_lut_out=7'd3;
+      7'd122: vfrec7_lut_out=7'd3;
+      7'd123: vfrec7_lut_out=7'd2;
+      7'd124: vfrec7_lut_out=7'd2;
+      7'd125: vfrec7_lut_out=7'd1;
+      7'd126: vfrec7_lut_out=7'd1;
+      7'd127: vfrec7_lut_out=7'd0;
+      default: vfrec7_lut_out=7'd0;
+    endcase
+    return vfrec7_lut_out;
   endfunction : vfrec7_lut
 
+  // vfrec7 result (sew: 16 bit)
+  function automatic vf7_flag_out_e16 vfrec7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay, fpnew_pkg::roundmode_e fp_rm_process);
+    vf7_flag_out_e16 vfrec7_o, vfrec7_out;
 
- ////////////////////
-  //  VFREC7 OUTPUT //
-  ////////////////////
+    fp16_t vfrec7_i, vfrec7_n_excep, vfrec7_sub;
 
+    logic select_vfrec7_out;
 
-//for SEW=16
-  function automatic vf7_flag_out_e16 vfrec7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
-     vf7_flag_out_e16 vfrec7_o,
-                    vfrec7_out;
+    logic en_rm;
 
-     fp16_t vfrec7_i,
-            vfrec7_n_excep,
-            vfrec7_sub;
+    vfrec7_o       = 21'd0;
+    vfrec7_out     = 21'd0;
+    vfrec7_i       = 16'd0;
+    vfrec7_n_excep = 16'd0;
+    vfrec7_sub     = 16'd0;
 
-     logic select_vfrec7_out;
-     logic en_rm;
+    en_rm =  fp_rm_process==fpnew_pkg::RTZ
+          ||(fp_rm_process==fpnew_pkg::RDN && ~operand_a_delay[E16_BITS-1])
+          ||(fp_rm_process==fpnew_pkg::RUP &&  operand_a_delay[E16_BITS-1]);
 
-     vfrec7_o       = 21'd0;
-     vfrec7_out     = 21'd0;
-     vfrec7_i       = 16'd0;
-     vfrec7_n_excep = 16'd0;
-     vfrec7_sub     = 16'd0;
+      //subnormal inputs with sig=0.. or sig=1..
+    unique case (operand_a_delay[9])
+      1'b0: begin
+        vfrec7_sub.e = 5'd0 - 5'd1;                    //0 minus number of leading zeros in sig
+        vfrec7_sub.m = {operand_a_delay[7:0], 2'b00};  //left-shifting by 2
+      end
+      1'b1: begin
+        vfrec7_sub.e = 5'd0;                          //0 minus number of leading zeros in sig
+        vfrec7_sub.m = {operand_a_delay[8:0], 1'b0};  //left-shifting by 1
+      end
+    endcase
 
-      en_rm=fp_rm_process==fpnew_pkg::RTZ
-            ||(fp_rm_process==fpnew_pkg::RDN && ~operand_a_delay[E16_BITS-1])
-            ||(fp_rm_process==fpnew_pkg::RUP && operand_a_delay[E16_BITS-1]);
+    unique case (vfpu_result)
+      fpnew_pkg::POSSUBNORM,
+      fpnew_pkg::NEGSUBNORM: begin //SUBNORMAL
+        vfrec7_i.e  = vfrec7_sub.e;
+        vfrec7_i.m  = vfrec7_sub.m;
+      end
+      fpnew_pkg::POSNORM,
+      fpnew_pkg::NEGNORM: begin // NORMAL
+        vfrec7_i.e  = operand_a_delay[14:10];
+        vfrec7_i.m  = operand_a_delay[9:0];
+      end
+      default: begin
+        vfrec7_i.e = 'x;
+        vfrec7_i.m = 'x;
+      end
+    endcase
 
-           //subnormal inputs with sig=0.. or sig=1..
-          unique case (operand_a_delay[9])
-                  1'b0: begin
-                        vfrec7_sub.e = 5'd0-5'd1;                    //0 minus number of leading zeros in sig
-                        vfrec7_sub.m = {operand_a_delay[7:0],2'b00}; //left-shifting by 2
-                  end
-                  1'b1: begin
-                        vfrec7_sub.e = 5'd0;                          //0 minus number of leading zeros in sig
-                        vfrec7_sub.m = {operand_a_delay[8:0],1'b0};  //left-shifting by 1
-                  end
-         endcase
-         unique case (vfpu_result)
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: NEGSUBNORM: begin //SUBNORMAL
-                 vfrec7_i.e  = vfrec7_sub.e;
-                 vfrec7_i.m  = vfrec7_sub.m;
+    unique case (vfpu_result)
+      fpnew_pkg::NEGINF: vfrec7_o.vf7_e16 = {1'b1, 15'd0};
+      fpnew_pkg::POSINF: vfrec7_o.vf7_e16 = 16'd0;
+      fpnew_pkg::SNAN : begin
+        vfrec7_o.vf7_e16    = E16_NaN;
+        vfrec7_o.ex_flag.NV = 1'b1;
+      end
+      fpnew_pkg::QNAN : vfrec7_o.vf7_e16 = E16_NaN;
+      fpnew_pkg::NEGZERO: begin
+        vfrec7_o.vf7_e16    = E16_mInf;
+        vfrec7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSZERO: begin
+        vfrec7_o.vf7_e16    = E16_pInf;
+        vfrec7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSSUBNORM,
+      fpnew_pkg::NEGSUBNORM,
+      fpnew_pkg::POSNORM,
+      fpnew_pkg::NEGNORM: begin
+        //Output exponent can be found by
+        //exp_o = 2*B-1-exp_i
+        //      = 2*B+(~exp_i)
+        vfrec7_n_excep.e = E16_2xB +(~vfrec7_i.e)
+        //Output significand(mantissa) can be found by using lookup table
+        vfrec7_n_excep.m[9:3] = vfrec7_lut(vfrec7_i.m[9:3])
+
+         //if output is subnormal
+         // output exponent is equal to zero
+        unique case (vfrec7_n_excep.e)
+          5'b0_0000: begin
+            vfrec7_o.vf7_e16.e      = 5'b0_0000;
+            vfrec7_o.vf7_e16.m[9:2] = {1'b1, vfrec7_n_excep.m[9:3]}; //concating 1 at MSB
           end
-          fpnew_pkg:: POSNORM,
-          fpnew_pkg:: NEGNORM: begin // NORMAL
-                vfrec7_i.e  = operand_a_delay[14:10];
-                vfrec7_i.m  = operand_a_delay[9:0];
-         end
-         default: begin
-                vfrec7_i.e = 'x;
-                vfrec7_i.m = 'x;
-         end
-         endcase
-       unique case (vfpu_result)
-          fpnew_pkg:: NEGINF:    vfrec7_o.vf7_e16    = {1'b1,15'd0};
-          fpnew_pkg:: POSINF:    vfrec7_o.vf7_e16    = 16'd0;
-          fpnew_pkg:: SNAN : begin
-                                 vfrec7_o.vf7_e16    = E16_NaN;
-                                 vfrec7_o.ex_flag.NV = 1'b1;
-                             end
-          fpnew_pkg:: QNAN :     vfrec7_o.vf7_e16    = E16_NaN;
-          fpnew_pkg:: NEGZERO: begin
-                                 vfrec7_o.vf7_e16    = E16_mInf;
-                                 vfrec7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSZERO: begin
-                                 vfrec7_o.vf7_e16    = E16_pInf;
-                                 vfrec7_o.ex_flag.DZ = 1'b1;
-                               end
-
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: POSNORM,
-          fpnew_pkg:: NEGNORM:
-
-                         begin
-                                //Output exponent can be found by
-                                //exp_o = 2*B-1-exp_i
-                                //      = 2*B+(~exp_i)
-                                vfrec7_n_excep.e = E16_2xB +(~vfrec7_i.e);
-
-                                //Output significand(mantissa) can be found by using lookup table
-                                vfrec7_n_excep.m[9:3] = vfrec7_lut(vfrec7_i.m[9:3]);
-
-                                 //if output is subnormal
-                                 // output exponent is equal to zero
-                                unique case (vfrec7_n_excep.e)
-                                 5'b0_0000 : begin
-                                        vfrec7_o.vf7_e16.e      = 5'b0_0000;
-                                        vfrec7_o.vf7_e16.m[9:2] = {1'b1,vfrec7_n_excep.m[9:3]}; //concating 1 at MSB
-                                 end
-                                 5'b1_1111 : begin
-                                        vfrec7_o.vf7_e16.e      = 5'b0_0000;
-                                        vfrec7_o.vf7_e16.m[9:1] = {2'b01, vfrec7_n_excep.m[9:3]}; //concating 1 at MSB and shiting by 1
-                                     end
-                                default:  begin
-                                        vfrec7_o.vf7_e16.e      =  vfrec7_n_excep.e;
-                                        vfrec7_o.vf7_e16.m[9:3] =  vfrec7_n_excep.m[9:3];
-                                end
-                               endcase
-
-                                 //The output sign equals the input sign.
-                                vfrec7_o.vf7_e16.s = operand_a_delay[15];
-                         end
-         endcase
-            // check if input number is subnormal number  with sig=00..
-         select_vfrec7_out= (operand_a_delay[9:8]==2'b00)
-                          &&(vfpu_result==fpnew_pkg::POSSUBNORM
-                           || vfpu_result==fpnew_pkg::NEGSUBNORM);
-
-
-        unique case (select_vfrec7_out)
-          1'b0:    vfrec7_out    = vfrec7_o;
-          1'b1:  begin
-              // if input number  is subnormal with sig=00.. then
-              // output is equal to infinity or  +-finite value (greatest magnitude)
-              // depending on rounding modes
-               unique case (en_rm)
-                  1'b0:vfrec7_out.vf7_e16 = {vfrec7_o.vf7_e16.s,E16_Inf}; // infinity
-                  1'b1:vfrec7_out.vf7_e16 = {vfrec7_o.vf7_e16.s,E16_Max}; // greatest magnitude
-               endcase
-                 vfrec7_out.ex_flag.NX  = 1'b1;
-                 vfrec7_out.ex_flag.OF  = 1'b1;
+          5'b1_1111: begin
+            vfrec7_o.vf7_e16.e      = 5'b0_0000;
+            vfrec7_o.vf7_e16.m[9:1] = {2'b01, vfrec7_n_excep.m[9:3]}; //concating 1 at MSB and shiting by 1
+          end
+          default: begin
+            vfrec7_o.vf7_e16.e      = vfrec7_n_excep.e;
+            vfrec7_o.vf7_e16.m[9:3] = vfrec7_n_excep.m[9:3];
           end
         endcase
-      return vfrec7_out;
+
+         //The output sign equals the input sign.
+        vfrec7_o.vf7_e16.s = operand_a_delay[15];
+      end
+    endcase
+
+    // check if input number is subnormal number  with sig=00..
+    select_vfrec7_out =  (operand_a_delay[9:8]==2'b00)
+                      && (vfpu_result==fpnew_pkg::POSSUBNORM
+                      ||  vfpu_result==fpnew_pkg::NEGSUBNORM);
+
+    unique case (select_vfrec7_out)
+      1'b0: vfrec7_out = vfrec7_o;
+      1'b1:  begin
+
+        // if input number  is subnormal with sig=00.. then
+        // output is equal to infinity or  +-finite value (greatest magnitude)
+        // depending on rounding modes
+        unique case (en_rm)
+          1'b0: vfrec7_out.vf7_e16 = {vfrec7_o.vf7_e16.s, E16_Inf}; // infinity
+          1'b1: vfrec7_out.vf7_e16 = {vfrec7_o.vf7_e16.s, E16_Max}; // greatest magnitude
+        endcase
+
+        vfrec7_out.ex_flag.NX  = 1'b1;
+        vfrec7_out.ex_flag.OF  = 1'b1;
+      end
+    endcase
+    return vfrec7_out;
   endfunction : vfrec7_fp16
 
-//for SEW=32.....
-  function automatic vf7_flag_out_e32 vfrec7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
-     vf7_flag_out_e32 vfrec7_o,
-                    vfrec7_out;
+  // vfrec7 result (sew: 32 bit)
+  function automatic vf7_flag_out_e32 vfrec7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay, fpnew_pkg::roundmode_e fp_rm_process);
+    vf7_flag_out_e32 vfrec7_o, vfrec7_out;
 
-     fp32_t vfrec7_i,
-            vfrec7_n_excep,
-            vfrec7_sub;
+    fp32_t vfrec7_i, vfrec7_n_excep, vfrec7_sub;
 
-     logic select_vfrec7_out;
-     logic en_rm;
+    logic select_vfrec7_out;
+    logic en_rm;
 
-     vfrec7_o       = 37'd0;
-     vfrec7_out     = 37'd0;
-     vfrec7_i       = 32'd0;
-     vfrec7_n_excep = 32'd0;
-     vfrec7_sub     = 32'd0;
+    vfrec7_o       = 37'd0;
+    vfrec7_out     = 37'd0;
+    vfrec7_i       = 32'd0;
+    vfrec7_n_excep = 32'd0;
+    vfrec7_sub     = 32'd0;
 
-      en_rm=fp_rm_process==fpnew_pkg::RTZ
-            ||(fp_rm_process==fpnew_pkg::RDN && ~operand_a_delay[E32_BITS-1])
-            ||(fp_rm_process==fpnew_pkg::RUP && operand_a_delay[E32_BITS-1]);
+    en_rm =  fp_rm_process==fpnew_pkg::RTZ
+         || (fp_rm_process==fpnew_pkg::RDN && ~operand_a_delay[E32_BITS-1])
+         || (fp_rm_process==fpnew_pkg::RUP &&  operand_a_delay[E32_BITS-1]);
 
-           //subnormal inputs with sig=0.. or sig=1..
-          unique case (operand_a_delay[22])
-                  1'b0: begin
-                        vfrec7_sub.e = 8'd0-8'd1;                    //0 minus number of leading zeros in sig
-                        vfrec7_sub.m = {operand_a_delay[20:0],2'b00}; //left-shifting by 2
-                  end
-                  1'b1: begin
-                        vfrec7_sub.e = 8'd0;                          //0 minus number of leading zeros in sig
-                        vfrec7_sub.m = {operand_a_delay[21:0],1'b0};  //left-shifting by 1
-                  end
-         endcase
-         unique case (vfpu_result)
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: NEGSUBNORM: begin //SUBNORMAL
-                 vfrec7_i.e  = vfrec7_sub.e;
-                 vfrec7_i.m  = vfrec7_sub.m;
+    //subnormal inputs with sig=0.. or sig=1..
+    unique case (operand_a_delay[22])
+      1'b0: begin
+        vfrec7_sub.e = 8'd0-8'd1;                    //0 minus number of leading zeros in sig
+        vfrec7_sub.m = {operand_a_delay[20:0], 2'b00}; //left-shifting by 2
+      end
+      1'b1: begin
+        vfrec7_sub.e = 8'd0;                          //0 minus number of leading zeros in sig
+        vfrec7_sub.m = {operand_a_delay[21:0], 1'b0};  //left-shifting by 1
+      end
+    endcase
+
+    unique case (vfpu_result)
+      fpnew_pkg::POSSUBNORM,
+      fpnew_pkg::NEGSUBNORM: begin //SUBNORMAL
+        vfrec7_i.e  = vfrec7_sub.e;
+        vfrec7_i.m  = vfrec7_sub.m;
+      end
+      fpnew_pkg:: POSNORM,
+      fpnew_pkg:: NEGNORM: begin // NORMAL
+        vfrec7_i.e  = operand_a_delay[30:23];
+        vfrec7_i.m  = operand_a_delay[22:0];
+      end
+      default: begin
+        vfrec7_i.e = 'x;
+        vfrec7_i.m = 'x;
+      end
+    endcase
+
+    unique case (vfpu_result)
+      fpnew_pkg::NEGINF: vfrec7_o.vf7_e32 = {1'b1, 31'd0};
+      fpnew_pkg::POSINF: vfrec7_o.vf7_e32 = 32'd0;
+      fpnew_pkg::SNAN: begin
+        vfrec7_o.vf7_e32    = E32_NaN;
+        vfrec7_o.ex_flag.NV = 1'b1;
+      end
+      fpnew_pkg::QNAN: vfrec7_o.vf7_e32 = E32_NaN;
+      fpnew_pkg::NEGZERO: begin
+        vfrec7_o.vf7_e32    = E32_mInf;
+        vfrec7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSZERO: begin
+        vfrec7_o.vf7_e32    = E32_pInf;
+        vfrec7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSSUBNORM,
+      fpnew_pkg::NEGSUBNORM,
+      fpnew_pkg::POSNORM,
+      fpnew_pkg::NEGNORM: begin
+        //Output exponent can be found by
+        //exp_o = 2*B-1-exp_i
+        //      = 2*B+(~exp_i)
+        vfrec7_n_excep.e = E32_2xB +(~vfrec7_i.e);
+
+        //Output significand(mantissa) can be found by using lookup table
+        vfrec7_n_excep.m[22:16] = vfrec7_lut(vfrec7_i.m[22:16]);
+
+        //if output is subnormal
+        // output exponent is equal to zero
+        unique case (vfrec7_n_excep.e)
+          8'h00 : begin
+            vfrec7_o.vf7_e32.e        = 8'h00;
+            vfrec7_o.vf7_e32.m[22:15] = {1'b1, vfrec7_n_excep.m[22:16]}; //concating 1 at MSB
           end
-          fpnew_pkg:: POSNORM,
-          fpnew_pkg:: NEGNORM: begin // NORMAL
-                vfrec7_i.e  = operand_a_delay[30:23];
-                vfrec7_i.m  = operand_a_delay[22:0];
-         end
-         default: begin
-                vfrec7_i.e = 'x;
-                vfrec7_i.m = 'x;
-         end
-         endcase
-       unique case (vfpu_result)
-          fpnew_pkg:: NEGINF:    vfrec7_o.vf7_e32    = {1'b1,31'd0};
-          fpnew_pkg:: POSINF:    vfrec7_o.vf7_e32    = 32'd0;
-          fpnew_pkg:: SNAN : begin
-                                 vfrec7_o.vf7_e32    = E32_NaN;
-                                 vfrec7_o.ex_flag.NV = 1'b1;
-                             end
-          fpnew_pkg:: QNAN :     vfrec7_o.vf7_e32    = E32_NaN;
-          fpnew_pkg:: NEGZERO: begin
-                                 vfrec7_o.vf7_e32    = E32_mInf;
-                                 vfrec7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSZERO: begin
-                                 vfrec7_o.vf7_e32    = E32_pInf;
-                                 vfrec7_o.ex_flag.DZ = 1'b1;
-                               end
-
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: POSNORM,
-          fpnew_pkg:: NEGNORM:
-
-                         begin
-                                //Output exponent can be found by
-                                //exp_o = 2*B-1-exp_i
-                                //      = 2*B+(~exp_i)
-                                vfrec7_n_excep.e = E32_2xB +(~vfrec7_i.e);
-
-                                //Output significand(mantissa) can be found by using lookup table
-                                vfrec7_n_excep.m[22:16] = vfrec7_lut(vfrec7_i.m[22:16]);
-
-                                 //if output is subnormal
-                                 // output exponent is equal to zero
-                                unique case (vfrec7_n_excep.e)
-                                 8'h00 : begin
-                                        vfrec7_o.vf7_e32.e        = 8'h00;
-                                        vfrec7_o.vf7_e32.m[22:15] = {1'b1,vfrec7_n_excep.m[22:16]}; //concating 1 at MSB
-                                 end
-                                 8'hff : begin
-                                        vfrec7_o.vf7_e32.e        = 8'h00;
-                                        vfrec7_o.vf7_e32.m[22:14] = {2'b01, vfrec7_n_excep.m[22:16]}; //concating 1 at MSB and shiting by 1
-                                     end
-                                default:  begin
-                                        vfrec7_o.vf7_e32.e        =  vfrec7_n_excep.e;
-                                        vfrec7_o.vf7_e32.m[22:15] =  vfrec7_n_excep.m[22:15];
-                                end
-                               endcase
-
-                                 //The output sign equals the input sign.
-                                vfrec7_o.vf7_e32.s = operand_a_delay[31];
-                         end
-         endcase
-            // check if input number is subnormal number  with sig=00..
-         select_vfrec7_out= (operand_a_delay[22:21]==2'b00)
-                          &&(vfpu_result==fpnew_pkg::POSSUBNORM
-                           || vfpu_result==fpnew_pkg::NEGSUBNORM);
-
-
-        unique case (select_vfrec7_out)
-          1'b0:    vfrec7_out    = vfrec7_o;
-          1'b1:  begin
-              // if input number  is subnormal with sig=00.. then
-              // output is equal to infinity or  +-finite value (greatest magnitude)
-              // depending on rounding modes
-               unique case (en_rm)
-                  1'b0:vfrec7_out.vf7_e32 = {vfrec7_o.vf7_e32.s,E32_Inf}; // infinity
-                  1'b1:vfrec7_out.vf7_e32 = {vfrec7_o.vf7_e32.s,E32_Max}; // greatest magnitude
-               endcase
-                 vfrec7_out.ex_flag.NX  = 1'b1;
-                 vfrec7_out.ex_flag.OF  = 1'b1;
+          8'hff : begin
+            vfrec7_o.vf7_e32.e        = 8'h00;
+            vfrec7_o.vf7_e32.m[22:14] = {2'b01, vfrec7_n_excep.m[22:16]}; //concating 1 at MSB and shiting by 1
+          end
+          default:  begin
+            vfrec7_o.vf7_e32.e        = vfrec7_n_excep.e;
+            vfrec7_o.vf7_e32.m[22:15] = vfrec7_n_excep.m[22:15];
           end
         endcase
-      return vfrec7_out;
+
+        //The output sign equals the input sign.
+        vfrec7_o.vf7_e32.s = operand_a_delay[31];
+      end
+    endcase
+
+    // check if input number is subnormal number  with sig=00..
+    select_vfrec7_out = (operand_a_delay[22:21]==2'b00)
+                     && (vfpu_result==fpnew_pkg::POSSUBNORM
+                     ||  vfpu_result==fpnew_pkg::NEGSUBNORM);
+
+    unique case (select_vfrec7_out)
+      1'b0: vfrec7_out = vfrec7_o;
+      1'b1: begin
+        // if input number  is subnormal with sig=00.. then
+        // output is equal to infinity or  +-finite value (greatest magnitude)
+        // depending on rounding modes
+        unique case (en_rm)
+          1'b0: vfrec7_out.vf7_e32 = {vfrec7_o.vf7_e32.s, E32_Inf}; // infinity
+          1'b1: vfrec7_out.vf7_e32 = {vfrec7_o.vf7_e32.s, E32_Max}; // greatest magnitude
+        endcase
+
+        vfrec7_out.ex_flag.NX  = 1'b1;
+        vfrec7_out.ex_flag.OF  = 1'b1;
+      end
+    endcase
+    return vfrec7_out;
   endfunction : vfrec7_fp32
 
-//for SEW=64
+  // vfrec7 result (sew: 64 bit)
   function automatic vf7_flag_out_e64 vfrec7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
-     vf7_flag_out_e64 vfrec7_o,
-                    vfrec7_out;
+    vf7_flag_out_e64 vfrec7_o, vfrec7_out;
 
-     fp64_t vfrec7_i,
-            vfrec7_n_excep,
-            vfrec7_sub;
+    fp64_t vfrec7_i, vfrec7_n_excep, vfrec7_sub;
 
-     logic select_vfrec7_out;
-     logic en_rm;
+    logic select_vfrec7_out;
+    logic en_rm;
 
-     vfrec7_o       = 69'd0;
-     vfrec7_out     = 69'd0;
-     vfrec7_i       = 64'd0;
-     vfrec7_n_excep = 64'd0;
-     vfrec7_sub     = 64'd0;
+    vfrec7_o       = 69'd0;
+    vfrec7_out     = 69'd0;
+    vfrec7_i       = 64'd0;
+    vfrec7_n_excep = 64'd0;
+    vfrec7_sub     = 64'd0;
 
-      en_rm=fp_rm_process==fpnew_pkg::RTZ
-            ||(fp_rm_process==fpnew_pkg::RDN && ~operand_a_delay[E64_BITS-1])
-            ||(fp_rm_process==fpnew_pkg::RUP && operand_a_delay[E64_BITS-1]);
+    en_rm =  fp_rm_process==fpnew_pkg::RTZ
+         || (fp_rm_process==fpnew_pkg::RDN && ~operand_a_delay[E64_BITS-1])
+         || (fp_rm_process==fpnew_pkg::RUP &&  operand_a_delay[E64_BITS-1]);
 
-           //subnormal inputs with sig=0.. or sig=1..
-          unique case (operand_a_delay[51])
-                  1'b0: begin
-                        vfrec7_sub.e = 11'd0-11'd1;                    //0 minus number of leading zeros in sig
-                        vfrec7_sub.m = {operand_a_delay[49:0],2'b00}; //left-shifting by 2
-                  end
-                  1'b1: begin
-                        vfrec7_sub.e = 11'd0;                          //0 minus number of leading zeros in sig
-                        vfrec7_sub.m = {operand_a_delay[50:0],1'b0};  //left-shifting by 1
-                  end
-         endcase
-         unique case (vfpu_result)
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: NEGSUBNORM: begin //SUBNORMAL
-                 vfrec7_i.e  = vfrec7_sub.e;
-                 vfrec7_i.m  = vfrec7_sub.m;
+    //subnormal inputs with sig=0.. or sig=1..
+    unique case (operand_a_delay[51])
+      1'b0: begin
+        vfrec7_sub.e = 11'd0-11'd1;                    //0 minus number of leading zeros in sig
+        vfrec7_sub.m = {operand_a_delay[49:0], 2'b00}; //left-shifting by 2
+      end
+      1'b1: begin
+        vfrec7_sub.e = 11'd0;                          //0 minus number of leading zeros in sig
+        vfrec7_sub.m = {operand_a_delay[50:0], 1'b0};  //left-shifting by 1
+      end
+    endcase
+
+    unique case (vfpu_result)
+      fpnew_pkg::POSSUBNORM,
+      fpnew_pkg::NEGSUBNORM: begin //SUBNORMAL
+        vfrec7_i.e  = vfrec7_sub.e;
+        vfrec7_i.m  = vfrec7_sub.m;
+      end
+      fpnew_pkg::POSNORM,
+      fpnew_pkg::NEGNORM: begin // NORMAL
+        vfrec7_i.e  = operand_a_delay[62:52];
+        vfrec7_i.m  = operand_a_delay[51:0];
+      end
+      default: begin
+        vfrec7_i.e = 'x;
+        vfrec7_i.m = 'x;
+      end
+    endcase
+
+    unique case (vfpu_result)
+      fpnew_pkg::NEGINF: vfrec7_o.vf7_e64 = {1'b1, 63'd0};
+      fpnew_pkg::POSINF: vfrec7_o.vf7_e64 = 64'd0;
+      fpnew_pkg::SNAN: begin
+        vfrec7_o.vf7_e64    = E64_NaN;
+        vfrec7_o.ex_flag.NV = 1'b1;
+      end
+      fpnew_pkg::QNAN : vfrec7_o.vf7_e64 = E64_NaN;
+      fpnew_pkg::NEGZERO: begin
+        vfrec7_o.vf7_e64    = E64_mInf;
+        vfrec7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg:: POSZERO: begin
+        vfrec7_o.vf7_e64    = E64_pInf;
+        vfrec7_o.ex_flag.DZ = 1'b1;
+      end
+      fpnew_pkg::POSSUBNORM,
+      fpnew_pkg::NEGSUBNORM,
+      fpnew_pkg::POSNORM,
+      fpnew_pkg::NEGNORM: begin
+        //Output exponent can be found by
+        //exp_o = 2*B-1-exp_i
+        //      = 2*B+(~exp_i)
+        vfrec7_n_excep.e = E64_2xB +(~vfrec7_i.e);
+
+        //Output significand(mantissa) can be found by using lookup table
+        vfrec7_n_excep.m[51:45] = vfrec7_lut(vfrec7_i.m[51:45]);
+
+          //if output is subnormal
+          // output exponent is equal to zero
+        unique case (vfrec7_n_excep.e)
+          11'h000 : begin
+            vfrec7_o.vf7_e64.e        = 11'h000;
+            vfrec7_o.vf7_e64.m[51:44] = {1'b1, vfrec7_n_excep.m[51:45]}; //concating 1 at MSB
           end
-          fpnew_pkg:: POSNORM,
-          fpnew_pkg:: NEGNORM: begin // NORMAL
-                vfrec7_i.e  = operand_a_delay[62:52];
-                vfrec7_i.m  = operand_a_delay[51:0];
-         end
-         default: begin
-                vfrec7_i.e = 'x;
-                vfrec7_i.m = 'x;
-         end
-         endcase
-       unique case (vfpu_result)
-          fpnew_pkg:: NEGINF:    vfrec7_o.vf7_e64    = {1'b1,63'd0};
-          fpnew_pkg:: POSINF:    vfrec7_o.vf7_e64    = 64'd0;
-          fpnew_pkg:: SNAN : begin
-                                 vfrec7_o.vf7_e64    = E64_NaN;
-                                 vfrec7_o.ex_flag.NV = 1'b1;
-                             end
-          fpnew_pkg:: QNAN :     vfrec7_o.vf7_e64    = E64_NaN;
-          fpnew_pkg:: NEGZERO: begin
-                                 vfrec7_o.vf7_e64    = E64_mInf;
-                                 vfrec7_o.ex_flag.DZ = 1'b1;
-                               end
-          fpnew_pkg:: POSZERO: begin
-                                 vfrec7_o.vf7_e64    = E64_pInf;
-                                 vfrec7_o.ex_flag.DZ = 1'b1;
-                               end
-
-          fpnew_pkg:: POSSUBNORM,
-          fpnew_pkg:: NEGSUBNORM,
-          fpnew_pkg:: POSNORM,
-          fpnew_pkg:: NEGNORM:
-                         begin
-                                //Output exponent can be found by
-                                //exp_o = 2*B-1-exp_i
-                                //      = 2*B+(~exp_i)
-                                vfrec7_n_excep.e = E64_2xB +(~vfrec7_i.e);
-
-                                //Output significand(mantissa) can be found by using lookup table
-                                vfrec7_n_excep.m[51:45] = vfrec7_lut(vfrec7_i.m[51:45]);
-
-                                 //if output is subnormal
-                                 // output exponent is equal to zero
-                                unique case (vfrec7_n_excep.e)
-                                 11'h000 : begin
-                                        vfrec7_o.vf7_e64.e        = 11'h000;
-                                        vfrec7_o.vf7_e64.m[51:44] = {1'b1,vfrec7_n_excep.m[51:45]}; //concating 1 at MSB
-                                 end
-                                 11'h7ff: begin
-                                        vfrec7_o.vf7_e64.e        = 11'h000;
-                                        vfrec7_o.vf7_e64.m[51:43] = {2'b01, vfrec7_n_excep.m[51:45]}; //concating 1 at MSB and shiting by 1
-                                     end
-                                default:  begin
-                                        vfrec7_o.vf7_e64.e      =  vfrec7_n_excep.e;
-                                        vfrec7_o.vf7_e64.m[51:45] =  vfrec7_n_excep.m[51:45];
-                                end
-                               endcase
-
-                                 //The output sign equals the input sign.
-                                vfrec7_o.vf7_e64.s = operand_a_delay[63];
-                         end
-         endcase
-            // check if input number is subnormal number  with sig=00..
-         select_vfrec7_out= (operand_a_delay[51:50]==2'b00)
-                          &&(vfpu_result==fpnew_pkg::POSSUBNORM
-                           || vfpu_result==fpnew_pkg::NEGSUBNORM);
-
-
-        unique case (select_vfrec7_out)
-          1'b0:    vfrec7_out    = vfrec7_o;
-          1'b1:  begin
-              // if input number  is subnormal with sig=00.. then
-              // output is equal to infinity or  +-finite value (greatest magnitude)
-              // depending on rounding modes
-               unique case (en_rm)
-                  1'b0:vfrec7_out.vf7_e64 = {vfrec7_o.vf7_e64.s,E64_Inf}; // infinity
-                  1'b1:vfrec7_out.vf7_e64 = {vfrec7_o.vf7_e64.s,E64_Max}; // greatest magnitude
-               endcase
-                 vfrec7_out.ex_flag.NX  = 1'b1;
-                 vfrec7_out.ex_flag.OF  = 1'b1;
+          11'h7ff: begin
+            vfrec7_o.vf7_e64.e        = 11'h000;
+            vfrec7_o.vf7_e64.m[51:43] = {2'b01, vfrec7_n_excep.m[51:45]}; //concating 1 at MSB and shiting by 1
+          end
+          default:begin
+            vfrec7_o.vf7_e64.e        = vfrec7_n_excep.e;
+            vfrec7_o.vf7_e64.m[51:45] = vfrec7_n_excep.m[51:45];
           end
         endcase
-      return vfrec7_out;
+
+        //The output sign equals the input sign.
+        vfrec7_o.vf7_e64.s = operand_a_delay[63];
+      end
+    endcase
+
+    // check if input number is subnormal number  with sig=00..
+    select_vfrec7_out = (operand_a_delay[51:50]==2'b00)
+                     && (vfpu_result==fpnew_pkg::POSSUBNORM
+                     ||  vfpu_result==fpnew_pkg::NEGSUBNORM);
+
+    unique case (select_vfrec7_out)
+      1'b0: vfrec7_out = vfrec7_o;
+      1'b1: begin
+        // if input number  is subnormal with sig=00.. then
+        // output is equal to infinity or  +-finite value (greatest magnitude)
+        // depending on rounding modes
+        unique case (en_rm)
+          1'b0:vfrec7_out.vf7_e64 = {vfrec7_o.vf7_e64.s, E64_Inf}; // infinity
+          1'b1:vfrec7_out.vf7_e64 = {vfrec7_o.vf7_e64.s, E64_Max}; // greatest magnitude
+        endcase
+
+        vfrec7_out.ex_flag.NX  = 1'b1;
+        vfrec7_out.ex_flag.OF  = 1'b1;
+      end
+    endcase
+    return vfrec7_out;
   endfunction : vfrec7_fp64
 
 endpackage : ara_pkg

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1008,9 +1008,7 @@ package ara_pkg;
 
 
 
-  ///////////////////////////
-  //  VFREC7 Look Up Table //
-  //////////////////////////
+
 localparam int unsigned LUT_BITS     = 7;
 localparam int unsigned E16_BITS     = 16;
 localparam int unsigned E32_BITS     = 32;
@@ -1049,18 +1047,21 @@ localparam logic [62:0] E64_Inf   = 63'h7ff0000000000000;
  typedef struct packed {
   fpnew_pkg::status_t ex_flag;
   fp16_t              vf7_e16;
-  } vf7_struct_e16;
+  } vf7_flag_out_e16;
 
   typedef struct packed {
   fpnew_pkg::status_t ex_flag;
   fp32_t              vf7_e32;
-  } vf7_struct_e32;
+  } vf7_flag_out_e32;
 
  typedef struct packed {
   fpnew_pkg::status_t ex_flag;
   fp64_t              vf7_e64;
-  } vf7_struct_e64;
+  } vf7_flag_out_e64;
 
+  ///////////////////////////
+  //  VFREC7 Look Up Table //
+  //////////////////////////
 
   function automatic logic [LUT_BITS-1:0] vfrec7_lut(logic [LUT_BITS-1:0] vfrec7_lut_select);
       logic [LUT_BITS-1:0] vfrec7_lut_out;
@@ -1204,8 +1205,8 @@ localparam logic [62:0] E64_Inf   = 63'h7ff0000000000000;
 
 
 //for SEW=16
-  function automatic vf7_struct_e16 vfrec7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
-     vf7_struct_e16 vfrec7_o,
+  function automatic vf7_flag_out_e16 vfrec7_fp16(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E16_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
+     vf7_flag_out_e16 vfrec7_o,
                     vfrec7_out;
 
      fp16_t vfrec7_i,
@@ -1328,8 +1329,8 @@ localparam logic [62:0] E64_Inf   = 63'h7ff0000000000000;
   endfunction : vfrec7_fp16
 
 //for SEW=32.....
-  function automatic vf7_struct_e32 vfrec7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
-     vf7_struct_e32 vfrec7_o,
+  function automatic vf7_flag_out_e32 vfrec7_fp32(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E32_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
+     vf7_flag_out_e32 vfrec7_o,
                     vfrec7_out;
 
      fp32_t vfrec7_i,
@@ -1452,8 +1453,8 @@ localparam logic [62:0] E64_Inf   = 63'h7ff0000000000000;
   endfunction : vfrec7_fp32
 
 //for SEW=64
-  function automatic vf7_struct_e64 vfrec7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
-     vf7_struct_e64 vfrec7_o,
+  function automatic vf7_flag_out_e64 vfrec7_fp64(logic [VF_TYPE_SEL_BITS-1:0] vfpu_result, logic [E64_BITS-1:0] operand_a_delay,fpnew_pkg::roundmode_e fp_rm_process);
+     vf7_flag_out_e64 vfrec7_o,
                     vfrec7_out;
 
      fp64_t vfrec7_i,

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -124,7 +124,7 @@ package ara_pkg;
     VDIVU, VDIV, VREMU, VREM,
     // FPU
     VFADD, VFSUB, VFRSUB, VFMUL, VFDIV, VFRDIV, VFMACC, VFNMACC, VFMSAC, VFNMSAC, VFMADD, VFNMADD, VFMSUB,
-    VFNMSUB, VFSQRT, VFMIN, VFMAX, VFCLASS, VFSGNJ, VFSGNJN, VFSGNJX, VFCVTXUF, VFCVTXF, VFCVTFXU, VFCVTFX,
+    VFNMSUB, VFSQRT, VFMIN, VFMAX, VFREC7, VFCLASS, VFSGNJ, VFSGNJN, VFSGNJX, VFCVTXUF, VFCVTXF, VFCVTFXU, VFCVTFX,
     VFCVTRTZXUF, VFCVTRTZXF, VFCVTFF,
     // Floating-point reductions
     VFREDUSUM, VFREDOSUM, VFREDMIN, VFREDMAX, VFWREDUSUM, VFWREDOSUM,
@@ -1006,4 +1006,276 @@ package ara_pkg;
     logic is_load;
   } addrgen_axi_req_t;
 
+
+
+  ///////////////////////////
+  //  VFREC7 Look Up Table //
+  //////////////////////////
+
+  function automatic logic [6:0] vfrec7_lut(logic [6:0] vfrec7_lut_select);
+      logic [6:0] vfrec7_lut_out;
+      unique case (vfrec7_lut_select)
+          7'd0  : vfrec7_lut_out=7'd127;
+          7'd1  : vfrec7_lut_out=7'd125;
+          7'd2  : vfrec7_lut_out=7'd123;
+          7'd3  : vfrec7_lut_out=7'd121;
+          7'd4  : vfrec7_lut_out=7'd119;
+          7'd5  : vfrec7_lut_out=7'd117;
+          7'd6  : vfrec7_lut_out=7'd116;
+          7'd7  : vfrec7_lut_out=7'd114;
+          7'd8  : vfrec7_lut_out=7'd112;
+          7'd9  : vfrec7_lut_out=7'd110;
+          7'd10 : vfrec7_lut_out=7'd109;
+          7'd11 : vfrec7_lut_out=7'd107;
+          7'd12 : vfrec7_lut_out=7'd105;
+          7'd13 : vfrec7_lut_out=7'd104;
+          7'd14 : vfrec7_lut_out=7'd102;
+          7'd15 : vfrec7_lut_out=7'd100;
+          7'd16 : vfrec7_lut_out=7'd99;
+          7'd17 : vfrec7_lut_out=7'd97;
+          7'd18 : vfrec7_lut_out=7'd96;
+          7'd19 : vfrec7_lut_out=7'd94;
+          7'd20 : vfrec7_lut_out=7'd93;
+          7'd21 : vfrec7_lut_out=7'd91;
+          7'd22 : vfrec7_lut_out=7'd90;
+          7'd23 : vfrec7_lut_out=7'd88;
+          7'd24 : vfrec7_lut_out=7'd87;
+          7'd25 : vfrec7_lut_out=7'd85;
+          7'd26 : vfrec7_lut_out=7'd84;
+          7'd27 : vfrec7_lut_out=7'd83;
+          7'd28 : vfrec7_lut_out=7'd81;
+          7'd29 : vfrec7_lut_out=7'd80;
+          7'd30 : vfrec7_lut_out=7'd79;
+          7'd31 : vfrec7_lut_out=7'd77;
+          7'd32 : vfrec7_lut_out=7'd76;
+          7'd33 : vfrec7_lut_out=7'd75;
+          7'd34 : vfrec7_lut_out=7'd74;
+          7'd35 : vfrec7_lut_out=7'd72;
+          7'd36 : vfrec7_lut_out=7'd71;
+          7'd37 : vfrec7_lut_out=7'd70;
+          7'd38 : vfrec7_lut_out=7'd69;
+          7'd39 : vfrec7_lut_out=7'd68;
+          7'd40 : vfrec7_lut_out=7'd66;
+          7'd41 : vfrec7_lut_out=7'd65;
+          7'd42 : vfrec7_lut_out=7'd64;
+          7'd43 : vfrec7_lut_out=7'd63;
+          7'd44 : vfrec7_lut_out=7'd62;
+          7'd45 : vfrec7_lut_out=7'd61;
+          7'd46 : vfrec7_lut_out=7'd60;
+          7'd47 : vfrec7_lut_out=7'd59;
+          7'd48 : vfrec7_lut_out=7'd58;
+          7'd49 : vfrec7_lut_out=7'd57;
+          7'd50 : vfrec7_lut_out=7'd56;
+          7'd51 : vfrec7_lut_out=7'd55;
+          7'd52 : vfrec7_lut_out=7'd54;
+          7'd53 : vfrec7_lut_out=7'd53;
+          7'd54 : vfrec7_lut_out=7'd52;
+          7'd55 : vfrec7_lut_out=7'd51;
+          7'd56 : vfrec7_lut_out=7'd50;
+          7'd57 : vfrec7_lut_out=7'd49;
+          7'd58 : vfrec7_lut_out=7'd48;
+          7'd59 : vfrec7_lut_out=7'd47;
+          7'd60 : vfrec7_lut_out=7'd46;
+          7'd61 : vfrec7_lut_out=7'd45;
+          7'd62 : vfrec7_lut_out=7'd44;
+          7'd63 : vfrec7_lut_out=7'd43;
+          7'd64 : vfrec7_lut_out=7'd42;
+          7'd65 : vfrec7_lut_out=7'd41;
+          7'd66 : vfrec7_lut_out=7'd40;
+          7'd67 : vfrec7_lut_out=7'd40;
+          7'd68 : vfrec7_lut_out=7'd39;
+          7'd69 : vfrec7_lut_out=7'd38;
+          7'd70 : vfrec7_lut_out=7'd37;
+          7'd71 : vfrec7_lut_out=7'd36;
+          7'd72 : vfrec7_lut_out=7'd35;
+          7'd73 : vfrec7_lut_out=7'd35;
+          7'd74 : vfrec7_lut_out=7'd34;
+          7'd75 : vfrec7_lut_out=7'd33;
+          7'd76 : vfrec7_lut_out=7'd32;
+          7'd77 : vfrec7_lut_out=7'd31;
+          7'd78 : vfrec7_lut_out=7'd31;
+          7'd79 : vfrec7_lut_out=7'd30;
+          7'd80 : vfrec7_lut_out=7'd29;
+          7'd81 : vfrec7_lut_out=7'd28;
+          7'd82 : vfrec7_lut_out=7'd28;
+          7'd83 : vfrec7_lut_out=7'd27;
+          7'd84 : vfrec7_lut_out=7'd26;
+          7'd85 : vfrec7_lut_out=7'd25;
+          7'd86 : vfrec7_lut_out=7'd25;
+          7'd87 : vfrec7_lut_out=7'd24;
+          7'd88 : vfrec7_lut_out=7'd23;
+          7'd89 : vfrec7_lut_out=7'd23;
+          7'd90 : vfrec7_lut_out=7'd22;
+          7'd91 : vfrec7_lut_out=7'd21;
+          7'd92 : vfrec7_lut_out=7'd21;
+          7'd93 : vfrec7_lut_out=7'd20;
+          7'd94 : vfrec7_lut_out=7'd19;
+          7'd95 : vfrec7_lut_out=7'd19;
+          7'd96 : vfrec7_lut_out=7'd18;
+          7'd97 : vfrec7_lut_out=7'd17;
+          7'd98 : vfrec7_lut_out=7'd17;
+          7'd99 : vfrec7_lut_out=7'd16;
+          7'd100: vfrec7_lut_out=7'd15;
+          7'd101: vfrec7_lut_out=7'd15;
+          7'd102: vfrec7_lut_out=7'd14;
+          7'd103: vfrec7_lut_out=7'd14;
+          7'd104: vfrec7_lut_out=7'd13;
+          7'd105: vfrec7_lut_out=7'd12;
+          7'd106: vfrec7_lut_out=7'd12;
+          7'd107: vfrec7_lut_out=7'd11;
+          7'd108: vfrec7_lut_out=7'd11;
+          7'd109: vfrec7_lut_out=7'd10;
+          7'd110: vfrec7_lut_out=7'd9;
+          7'd111: vfrec7_lut_out=7'd9;
+          7'd112: vfrec7_lut_out=7'd8;
+          7'd113: vfrec7_lut_out=7'd8;
+          7'd114: vfrec7_lut_out=7'd7;
+          7'd115: vfrec7_lut_out=7'd7;
+          7'd116: vfrec7_lut_out=7'd6;
+          7'd117: vfrec7_lut_out=7'd5;
+          7'd118: vfrec7_lut_out=7'd5;
+          7'd119: vfrec7_lut_out=7'd4;
+          7'd120: vfrec7_lut_out=7'd4;
+          7'd121: vfrec7_lut_out=7'd3;
+          7'd122: vfrec7_lut_out=7'd3;
+          7'd123: vfrec7_lut_out=7'd2;
+          7'd124: vfrec7_lut_out=7'd2;
+          7'd125: vfrec7_lut_out=7'd1;
+          7'd126: vfrec7_lut_out=7'd1;
+          7'd127: vfrec7_lut_out=7'd0;
+      endcase
+      return vfrec7_lut_out;
+  endfunction : vfrec7_lut
+
+   ////////////////////
+  //  VFREC7 OUTPUT //
+  ////////////////////
+
+ //for SEW=16
+
+  function automatic logic [16:0] vfrec7_fp16(logic [9:0] vfpu_result, logic [15:0] operand_a_delay);
+     logic [15:0] vfrec7_result;
+        unique case (vfpu_result[9:0])
+          fpnew_pkg:: NEGINF, 
+          fpnew_pkg:: POSINF:    vfrec7_result={operand_a_delay [15],15'b0};
+          fpnew_pkg:: NEGZERO:   vfrec7_result=16'hfc00;
+          fpnew_pkg:: POSZERO:   vfrec7_result=16'h7c00;
+          fpnew_pkg:: SNAN,
+          fpnew_pkg:: QNAN :     vfrec7_result=16'h7e00;
+          fpnew_pkg:: NEGSUBNORM,
+          fpnew_pkg:: POSSUBNORM: 
+                        begin
+                                     //Exponent   //exp_o =2*B-1-exp_i = 2*B+(~exp_i)
+                                vfrec7_result[14:10]= 5'd30 +(~operand_a_delay[14:10]);  
+                                    //Significand 7bits
+                                vfrec7_result[9:3]= vfrec7_lut(operand_a_delay[8:2]);
+                                    //Sign
+                                 vfrec7_result[15] =  operand_a_delay [15];
+                        end
+          fpnew_pkg:: POSNORM,
+          fpnew_pkg:: NEGNORM:   
+                       begin
+                                     //Exponent   //exp_o =2*B-1-exp_i = 2*B+(~exp_i)
+                               vfrec7_result[14:10]= 5'd30 +(~operand_a_delay[14:10]);  
+                                   //Significand 7bits
+                               vfrec7_result[9:3]= vfrec7_lut(operand_a_delay[9:3]);
+                                // check for Subnormal output
+                               unique case (vfrec7_result[14:10])
+                                5'b0_0000  :  vfrec7_result[9:2]={1'b1, vfrec7_result[9:3]};   
+                                5'b1_0000  : begin
+                                        vfrec7_result[14:10]=5'b0_0000 ;
+                                        vfrec7_result[9:1]={2'b01, vfrec7_result[9:3]};       
+                                     end
+                               endcase
+                                   //Sign
+                               vfrec7_result[15] = operand_a_delay[15];
+                        end 
+         endcase
+      return vfrec7_result;
+  endfunction : vfrec7_fp16
+//for SEW=32
+  function automatic logic [31:0] vfrec7_fp32(logic [9:0] vfpu_result, logic [31:0] operand_a_delay);
+     logic [31:0] vfrec7_result;
+      unique case (vfpu_result[9:0])
+          fpnew_pkg:: NEGINF, 
+          fpnew_pkg:: POSINF:    vfrec7_result={operand_a_delay [31],31'b0};
+          fpnew_pkg:: SNAN,
+          fpnew_pkg:: QNAN :     vfrec7_result= 32'h7fc00000;
+          fpnew_pkg:: NEGZERO:   vfrec7_result=32'hff800000;
+          fpnew_pkg:: POSZERO:   vfrec7_result=32'h7f800000;
+          fpnew_pkg:: NEGSUBNORM,
+          fpnew_pkg:: POSSUBNORM: 
+                         begin
+                                      //Exponent   //exp_o =2*B-1-exp_i = 2*B+(~exp_i)
+                                 vfrec7_result[30:23]= 8'd254 +(~operand_a_delay[30:23]);  
+                                     //Significand 7bits
+                                 vfrec7_result[22:16]= vfrec7_lut(operand_a_delay[21:15]);
+                                     //Sign
+                                  vfrec7_result[31] =operand_a_delay [31];
+                         end
+          fpnew_pkg:: POSNORM,
+          fpnew_pkg:: NEGNORM:   
+                         begin
+                                      //Exponent   //exp_o =2*B-1-exp_i = 2*B+(~exp_i)
+                                 vfrec7_result[30:23]= 8'd254 +(~operand_a_delay[30:23]);
+                                     //Significand 7bits
+                                 vfrec7_result[22:16]= vfrec7_lut(operand_a_delay[22:16]);
+                                    // check for Subnormal output
+                                    unique case (vfrec7_result[30:23])
+                                     8'h00: vfrec7_result[22:15]={1'b1,vfrec7_result[22:16]}; 
+                                     8'hff: begin
+                                           vfrec7_result[30:23]=8'h00;
+                                           vfrec7_result[22:14]={2'b01,vfrec7_result[22:16]}; 
+                                          end
+                                    endcase
+                                     //Sign
+                                  vfrec7_result[31] =operand_a_delay [31];
+                          end 
+         endcase
+      return vfrec7_result;
+  endfunction : vfrec7_fp32
+
+// for SEW=64
+
+  function automatic elen_t vfrec7_fp64(logic [9:0] vfpu_result, elen_t operand_a_delay);
+              elen_t vfrec7_result;
+                  unique case (vfpu_result[9:0])
+                fpnew_pkg:: NEGINF, 
+                fpnew_pkg:: POSINF:    vfrec7_result[63:0]={operand_a_delay [63],63'b0};
+                fpnew_pkg:: NEGZERO:   vfrec7_result[63:0]=64'hfff0000000000000;
+                fpnew_pkg:: POSZERO:   vfrec7_result[63:0]=64'h7ff0000000000000;
+                fpnew_pkg:: SNAN,
+                fpnew_pkg:: QNAN :     vfrec7_result[63:0]=64'h7ff8000000000000;
+                fpnew_pkg:: NEGSUBNORM,
+                fpnew_pkg:: POSSUBNORM: 
+                            begin
+                                         //Exponent   //exp_o =2*B-1-exp_i = 2*B+(~exp_i)
+                                    vfrec7_result[62:52]= 11'd2046 +(~operand_a_delay[62:52]);  
+                                        //Significand 7bits
+                                    vfrec7_result[51:45]= vfrec7_lut(operand_a_delay[50:44]);
+                                        //Sign
+                                     vfrec7_result[63] =operand_a_delay [63];
+                            end
+                fpnew_pkg:: POSNORM,
+                fpnew_pkg:: NEGNORM:   
+                             begin
+                                          //Exponent   //exp_o =2*B-1-exp_i = 2*B+(~exp_i)
+                                     vfrec7_result[62:52]= 11'd2046 +(~operand_a_delay[62:52]);  
+                                         //Significand 7bits
+                                     vfrec7_result[51:45]= vfrec7_lut(operand_a_delay[51:45]);
+                                       // check for Subnormal output
+                                    unique case (vfrec7_result[62:52])
+                                     11'b000_0000_0000  :  vfrec7_result[51:44]={1'b1, vfrec7_result[51:45]}; 
+                                     11'b111_1111_1111  : begin
+                                             vfrec7_result[62:52]=11'b000_0000_0000;
+                                             vfrec7_result[51:43]={2'b01, vfrec7_result[51:45]};             
+                                          end
+                                    endcase
+                                         //Sign
+                                      vfrec7_result[63] =operand_a_delay [63];
+                              end 
+                  endcase
+         return vfrec7_result;
+  endfunction : vfrec7_fp64
+  
 endpackage : ara_pkg

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1278,9 +1278,9 @@ package ara_pkg;
         //Output exponent can be found by
         //exp_o = 2*B-1-exp_i
         //      = 2*B+(~exp_i)
-        vfrec7_n_excep.e = E16_2xB +(~vfrec7_i.e)
+        vfrec7_n_excep.e = E16_2xB +(~vfrec7_i.e);
         //Output significand(mantissa) can be found by using lookup table
-        vfrec7_n_excep.m[9:3] = vfrec7_lut(vfrec7_i.m[9:3])
+        vfrec7_n_excep.m[9:3] = vfrec7_lut(vfrec7_i.m[9:3]);
 
          //if output is subnormal
          // output exponent is equal to zero

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -11,8 +11,10 @@ module ara import ara_pkg::*; #(
     parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    // External support for vfrec7, vfrsqrt7, rounding-toward-odd
+    parameter  fpext_support_e        FPExtSupport = FPExtSupportEnable,
     // Support for fixed-point data types
-    parameter  logic                  FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e        FixPtSupport = FixedPointEnable,
     // AXI Interface
     parameter  int           unsigned AxiDataWidth = 0,
     parameter  int           unsigned AxiAddrWidth = 0,
@@ -236,6 +238,7 @@ module ara import ara_pkg::*; #(
     lane #(
       .NrLanes     (NrLanes     ),
       .FPUSupport  (FPUSupport  ),
+      .FPExtSupport(FPExtSupport),
       .FixPtSupport(FixPtSupport)
     ) i_lane (
       .clk_i                           (clk_i                               ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1979,6 +1979,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                     unique case (insn.varith_type.rs1)
                       5'b00000: ara_req_d.op = ara_pkg::VFSQRT;
                       5'b10000: ara_req_d.op = ara_pkg::VFCLASS;
+                      5'b00101: ara_req_d.op = ara_pkg::VFREC7;
                       default : illegal_insn = 1'b1;
                     endcase
 

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -11,8 +11,10 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    // External support for vfrec7, vfrsqrt7, rounding-toward-odd
+    parameter  fpext_support_e        FPExtSupport = FPExtSupportEnable,
     // Support for fixed-point data types
-    parameter  logic                  FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e        FixPtSupport = FixedPointEnable,
     // AXI Interface
     parameter  int           unsigned AxiDataWidth = 32*NrLanes,
     parameter  int           unsigned AxiAddrWidth = 64,
@@ -455,6 +457,7 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   ara_system #(
     .NrLanes           (NrLanes              ),
     .FPUSupport        (FPUSupport           ),
+    .FPExtSupport      (FPExtSupport         ),
     .FixPtSupport      (FixPtSupport         ),
     .ArianeCfg         (ArianeAraConfig      ),
     .AxiAddrWidth      (AxiAddrWidth         ),

--- a/hardware/src/ara_system.sv
+++ b/hardware/src/ara_system.sv
@@ -11,8 +11,10 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
     parameter int                      unsigned NrLanes            = 0,                               // Number of parallel vector lanes.
     // Support for floating-point data types
     parameter fpu_support_e                     FPUSupport         = FPUSupportHalfSingleDouble,
+    // External support for vfrec7, vfrsqrt7, rounding-toward-odd
+    parameter fpext_support_e                   FPExtSupport       = FPExtSupportEnable,
     // Support for fixed-point data types
-    parameter  logic                            FixPtSupport       = FixedPointEnable,
+    parameter fixpt_support_e                   FixPtSupport       = FixedPointEnable,
     // Ariane configuration
     parameter ariane_pkg::ariane_cfg_t          ArianeCfg          = ariane_pkg::ArianeDefaultConfig,
     // AXI Interface
@@ -186,6 +188,8 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
   ara #(
     .NrLanes     (NrLanes         ),
     .FPUSupport  (FPUSupport      ),
+    .FPExtSupport(FPExtSupport    ),
+    .FixPtSupport(FixPtSupport    ),
     .AxiDataWidth(AxiWideDataWidth),
     .AxiAddrWidth(AxiAddrWidth    ),
     .axi_ar_t    (ara_axi_ar_t    ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -13,8 +13,10 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int           unsigned NrLanes         = 1, // Number of lanes
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport      = FPUSupportHalfSingleDouble,
+    // External support for vfrec7, vfrsqrt7, rounding-toward-odd
+    parameter  fpext_support_e        FPExtSupport    = FPExtSupportEnable,
     // Support for fixed-point data types
-    parameter  logic                  FixPtSupport    = FixedPointEnable,
+    parameter  fixpt_support_e        FixPtSupport    = FixedPointEnable,
     // Dependant parameters. DO NOT CHANGE!
     // VRF Parameters
     localparam int           unsigned MaxVLenPerLane  = VLEN / NrLanes,       // In bits
@@ -354,6 +356,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   vector_fus_stage #(
     .NrLanes     (NrLanes     ),
     .FPUSupport  (FPUSupport  ),
+    .FPExtSupport(FPExtSupport),
     .FixPtSupport(FixPtSupport),
     .vaddr_t     (vaddr_t     )
   ) i_vfus (

--- a/hardware/src/lane/simd_alu.sv
+++ b/hardware/src/lane/simd_alu.sv
@@ -8,11 +8,11 @@
 
 module simd_alu import ara_pkg::*; import rvv_pkg::*; #(
     // Support for fixed-point data types
-    parameter  logic         FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e FixPtSupport = FixedPointEnable,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int  unsigned DataWidth    = $bits(elen_t),
-    localparam int  unsigned StrbWidth    = DataWidth/8,
-    localparam type          strb_t       = logic [StrbWidth-1:0]
+    localparam int    unsigned DataWidth    = $bits(elen_t),
+    localparam int    unsigned StrbWidth    = DataWidth/8,
+    localparam type            strb_t       = logic [StrbWidth-1:0]
   ) (
     input  elen_t      operand_a_i,
     input  elen_t      operand_b_i,

--- a/hardware/src/lane/simd_mul.sv
+++ b/hardware/src/lane/simd_mul.sv
@@ -11,14 +11,14 @@
 
 module simd_mul import ara_pkg::*; import rvv_pkg::*; #(
     // Support for fixed-point data types
-    parameter  logic          FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e FixPtSupport = FixedPointEnable,
     // SIMD-multiplier parameters
-    parameter  int   unsigned NumPipeRegs  = 0,
-    parameter  vew_e          ElementWidth = EW64,
+    parameter  int    unsigned NumPipeRegs  = 0,
+    parameter  vew_e           ElementWidth = EW64,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int   unsigned DataWidth    = $bits(elen_t),
-    localparam int   unsigned StrbWidth    = DataWidth/8,
-    localparam type           strb_t       = logic [DataWidth/8-1:0]
+    localparam int    unsigned DataWidth    = $bits(elen_t),
+    localparam int    unsigned StrbWidth    = DataWidth/8,
+    localparam type            strb_t       = logic [DataWidth/8-1:0]
   ) (
     input  logic       clk_i,
     input  logic       rst_ni,

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -8,15 +8,15 @@
 // in a SIMD fashion, always operating on 64 bits.
 
 module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
-    parameter  int  unsigned NrLanes      = 0,
+    parameter  int    unsigned NrLanes      = 0,
     // Support for fixed-point data types
-    parameter  logic         FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e FixPtSupport = FixedPointEnable,
     // Type used to address vector register file elements
-    parameter  type          vaddr_t      = logic,
+    parameter  type            vaddr_t      = logic,
     // Dependant parameters. DO NOT CHANGE!
-    localparam int  unsigned DataWidth    = $bits(elen_t),
-    localparam int  unsigned StrbWidth    = DataWidth/8,
-    localparam type          strb_t       = logic [StrbWidth-1:0]
+    localparam int    unsigned DataWidth    = $bits(elen_t),
+    localparam int    unsigned StrbWidth    = DataWidth/8,
+    localparam type            strb_t       = logic [StrbWidth-1:0]
   ) (
     input  logic                         clk_i,
     input  logic                         rst_ni,

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -11,8 +11,10 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     parameter  int           unsigned NrLanes      = 0,
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    // External support for vfrec7, vfrsqrt7, rounding-toward-odd
+    parameter  fpext_support_e        FPExtSupport = FPExtSupportEnable,
     // Support for fixed-point data types
-    parameter  logic                  FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e        FixPtSupport = FixedPointEnable,
     // Type used to address vector register file elements
     parameter  type                   vaddr_t      = logic,
     // Dependant parameters. DO NOT CHANGE!
@@ -145,6 +147,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
   vmfpu #(
     .NrLanes   (NrLanes   ),
     .FPUSupport(FPUSupport),
+    .FPExtSupport(FPExtSupport),
     .FixPtSupport(FixPtSupport),
     .vaddr_t   (vaddr_t   )
   ) i_vmfpu (

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -944,7 +944,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
      assign operand_a_d[i+1]   = operand_a_q[i];
 
       `FF(operand_a_q[i], operand_a_d[i], '0, clk_i, rst_ni);
-         end
+   end
 
    assign operand_a_delay = operand_a_d[LatFNonComp];
    assign   fp_rm_process = vinsn_processing_q.fp_rm;

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -922,7 +922,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     );
     elen_t operand_a_delay, vfrec7_result;
     // register for delay of operand_a
-    always_ff @(posedge clk_i or negedge rst_ni) 
+    always_ff @(posedge clk_i or negedge rst_ni)
     begin
          if (!rst_ni) begin
                 operand_a_delay <= 64'b0;
@@ -930,10 +930,9 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
                 operand_a_delay <=operand_a ;
          end
     end
-      
-    always_comb begin: fpu_result_processing_p
-          vfrec7_result=64'b0;   //vfrec7 output
 
+    always_comb begin: fpu_result_processing_p
+                        //  vfrec7
          unique case (vinsn_processing_q.vtype.vsew)
             EW16:begin
                 vfrec7_result[15:0] =vfrec7_fp16(vfpu_result[9:0]  ,operand_a_delay[15:0] );
@@ -941,15 +940,16 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
                 vfrec7_result[47:32]=vfrec7_fp16(vfpu_result[41:32],operand_a_delay[47:32]);
                 vfrec7_result[63:48]=vfrec7_fp16(vfpu_result[57:48],operand_a_delay[63:48]);
               end
-            EW32: 
-              begin 
+            EW32:
+              begin
                 vfrec7_result[31:0 ] =vfrec7_fp32(vfpu_result[9:0] ,operand_a_delay[31:0] );
-                vfrec7_result[63:32]=vfrec7_fp32(vfpu_result[41:32],operand_a_delay[63:32]);
-             end
-            EW64: 
+                vfrec7_result[63:32]= vfrec7_fp32(vfpu_result[41:32],operand_a_delay[63:32]);
+              end
+            EW64:
               begin
              vfrec7_result=vfrec7_fp64(vfpu_result[9:0],operand_a_delay);
              end
+             default:;
          endcase
 
       // Forward the result

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -920,30 +920,34 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       .out_ready_i   (vfpu_out_ready),
       .busy_o        (/* Unused */  )
     );
-elen_t operand_a_delay,
-       vfrec7_result_o;
-fpu_mask_t vfpu_flag_mask;
+   elen_t operand_a_delay,
+          vfrec7_result_o;
+   fpu_mask_t vfpu_flag_mask;
 
-vf7_struct_e16 vfrec7_out_e16[4];
-vf7_struct_e32 vfrec7_out_e32[2];
-vf7_struct_e64 vfrec7_out_e64;
+   vf7_flag_out_e16 vfrec7_out_e16[4];
+   vf7_flag_out_e32 vfrec7_out_e32[2];
+   vf7_flag_out_e64 vfrec7_out_e64[1];
 
-status_t    vfrec7_ex_flag;
-roundmode_e fp_rm_process;
+   status_t    vfrec7_ex_flag;
+   roundmode_e fp_rm_process;
+
+   elen_t [LatFNonComp-1:0] operand_a_q;
+   elen_t [LatFNonComp:0]   operand_a_d;
 
 
-    // register for delay of operand_a
-    always_ff @(posedge clk_i or negedge rst_ni)
-    begin
-         if (!rst_ni) begin
-                operand_a_delay <= 64'b0;
-                 vfpu_flag_mask <= 4'b0;
-         end else begin
-                operand_a_delay <=operand_a ;
-                vfpu_flag_mask  <=vfpu_simd_mask;
+   //Delay for vfpu mask
+   `FF(vfpu_flag_mask,vfpu_simd_mask,'0,clk_i,rst_ni);
+
+   //Pipeline for operand_a
+   assign operand_a_d[0]   = operand_a;
+   for (genvar i = 0; i < LatFNonComp; i++) begin
+     assign operand_a_d[i+1]   = operand_a_q[i];
+
+      `FF(operand_a_q[i], operand_a_d[i], '0, clk_i, rst_ni);
          end
-    end
-    assign   fp_rm_process = vinsn_processing_q.fp_rm;
+
+   assign operand_a_delay = operand_a_d[LatFNonComp];
+   assign   fp_rm_process = vinsn_processing_q.fp_rm;
 
 
     always_comb begin: fpu_result_processing_p
@@ -951,32 +955,31 @@ roundmode_e fp_rm_process;
                    //vfrec7
       unique case (vinsn_processing_q.vtype.vsew)
          EW16: begin
-             vfrec7_out_e16[0] = vfrec7_fp16(vfpu_result[9:0]  ,operand_a_delay[15:0] ,fp_rm_process);
-             vfrec7_out_e16[1] = vfrec7_fp16(vfpu_result[25:16],operand_a_delay[31:16],fp_rm_process);
-             vfrec7_out_e16[2] = vfrec7_fp16(vfpu_result[41:32],operand_a_delay[47:32],fp_rm_process);
-             vfrec7_out_e16[3] = vfrec7_fp16(vfpu_result[57:48],operand_a_delay[63:48],fp_rm_process);
+          for (int h = 0; h < 4; h++)  vfrec7_out_e16[h] =
+           vfrec7_fp16(vfpu_result[h*16 +: 10], operand_a_delay[h*16 +: 16], fp_rm_process);
 
-             vfrec7_result_o = {vfrec7_out_e16[3].vf7_e16,vfrec7_out_e16[2].vf7_e16,vfrec7_out_e16[1].vf7_e16,vfrec7_out_e16[0].vf7_e16};
-             vfrec7_ex_flag  = (vfrec7_out_e16[3].ex_flag   & {5{vfpu_flag_mask[3]}})
+           vfrec7_result_o = {vfrec7_out_e16[3].vf7_e16,vfrec7_out_e16[2].vf7_e16,vfrec7_out_e16[1].vf7_e16,vfrec7_out_e16[0].vf7_e16};
+           vfrec7_ex_flag  = (vfrec7_out_e16[3].ex_flag   & {5{vfpu_flag_mask[3]}})
                                  | (vfrec7_out_e16[2].ex_flag & {5{vfpu_flag_mask[2]}})
                                  | (vfrec7_out_e16[1].ex_flag & {5{vfpu_flag_mask[1]}})
                                  | (vfrec7_out_e16[0].ex_flag & {5{vfpu_flag_mask[0]}});
 
          end
          EW32: begin
-             vfrec7_out_e32[0] = vfrec7_fp32(vfpu_result[9:0] ,operand_a_delay[31:0]  ,fp_rm_process);
-             vfrec7_out_e32[1] = vfrec7_fp32(vfpu_result[41:32],operand_a_delay[63:32],fp_rm_process);
+          for (int w = 0; w < 2; w++) vfrec7_out_e32[w] =
+            vfrec7_fp32(vfpu_result[w*32 +: 10], operand_a_delay[w*32 +: 32], fp_rm_process);
 
-             vfrec7_result_o = {vfrec7_out_e32[1].vf7_e32,vfrec7_out_e32[0].vf7_e32};
-             vfrec7_ex_flag  = (vfrec7_out_e32[1].ex_flag & {5{vfpu_flag_mask[2]}} )
+            vfrec7_result_o = {vfrec7_out_e32[1].vf7_e32,vfrec7_out_e32[0].vf7_e32};
+            vfrec7_ex_flag  = (vfrec7_out_e32[1].ex_flag & {5{vfpu_flag_mask[2]}} )
                                  | (vfrec7_out_e32[0].ex_flag & {5{vfpu_flag_mask[0]}});
 
          end
          EW64: begin
-            vfrec7_out_e64 = vfrec7_fp64(vfpu_result[9:0],operand_a_delay[63:0],fp_rm_process);
+                      for (int d = 0; d < 1; d++) vfrec7_out_e64[d] =
+            vfrec7_fp64(vfpu_result[d*64 +: 10], operand_a_delay[d*64 +: 64], fp_rm_process);
 
-             vfrec7_result_o  =  vfrec7_out_e64.vf7_e64;
-             vfrec7_ex_flag   =  vfrec7_out_e64.ex_flag & {5{vfpu_flag_mask[0]}};
+             vfrec7_result_o  =  vfrec7_out_e64[0].vf7_e64;
+             vfrec7_ex_flag   =  vfrec7_out_e64[0].ex_flag & {5{vfpu_flag_mask[0]}};
          end
          default: vfrec7_result_o='x;
       endcase


### PR DESCRIPTION
vfrec7 is a unary vector-vector instruction that returns an estimate of 1/x accurate to 7 bit.
### Input
- Exceptional cases are according to table.
- For the non-exceptional cases:
  #### Normal
   - If the input is normal, normalized input exponent is equal to the input exponent and normalized input significand(mantissa) is equal to the input significand.
  #### Subnormal
  - If the input is subnormal, normalized input exponent is equal to 0 minus the number of leading zeros in the signifcand and the normalized input significand is given by shifting the input significand left by 1 minus the normalized input exponent.
  - For normalization only two MSBs bits of significand are considered for counting the number of leading zeros, all other bits are ignored according to table.
  - If the significand=01..., the number of leading zeros is 1. So, the normalized input exponent is equal to 0 minus 1 and the normalized input significand is given by shifting the input significand left by 2.
  - If the significand=1...., the number of leading zeros is 0. So, the normalized input exponent is equal to 0 and the normalized input significand is given by shifting the input significand left by 1.
  - If the significand=00..., the output is fixed either infinity or maximum magnitude depending upon rounding mode.
### Output
- Normalized output exponent can be found by:
                exp_o = 2*B-1-exp_i 
                         where B is exponent bias.
- Normalized output 7-bit significand can be found by using lookup table.
- The address of lookup table is found by the seven MSBs of the normalized input significand.
- The remainder of the result significand is zero.
- The output sign equals the input sign.
  #### Normal
  - If the output is normal, then the output exponent equals the normalized output exponent, and the output significand equals the normalized output significand.
  #### Subnormal
  - If the output is subnormal,then the output exponent is 0, and the output significand is given by concatenating a 1 bit to the left of the normalized output significand, then shifting that quantity right by 1 minus the normalized output exponent.
## Changelog

### Fixed

- N/A

### Added

- Added support for vfrec7 instruction
- Added tests for vfrec7 instruction

### Changed

- N/A

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.