### PR TITLE
[SW] Roll-back to Verilator v4.214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Almost align all the vector/matrix sizes in `benchmark.sh`
  - Generate data for `fmatmul` at compile time
  - SIMD multipliers are now power gated
+ - Roll-back to Verilator v4.214
 
 ## 2.2.0 - 2021-11-02
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ LLVM_INSTALL_DIR        ?= ${INSTALL_DIR}/riscv-llvm
 ISA_SIM_INSTALL_DIR     ?= ${INSTALL_DIR}/riscv-isa-sim
 ISA_SIM_MOD_INSTALL_DIR ?= ${INSTALL_DIR}/riscv-isa-sim-mod
 VERIL_INSTALL_DIR       ?= ${INSTALL_DIR}/verilator
-VERIL_VERSION           ?= v4.226
+VERIL_VERSION           ?= v4.214
 
 CMAKE ?= cmake
 


### PR DESCRIPTION
Verilator v4.226 raises unexpected errors at runtime.

## Changelog

### Changed

- Roll-back to Verilator v4.214

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed