### PR TITLE
[HW] Shift popcount logic for vcpop.m instruction to lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Generate data for `fmatmul` at compile time
  - SIMD multipliers are now power gated
  - Roll-back to Verilator v4.214
+ - Shifted popcount logic from mask unit to lanes
 
 ## 2.2.0 - 2021-11-02
 

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -233,6 +233,7 @@ module ara import ara_pkg::*; #(
   strb_t     [NrLanes-1:0]                     masku_result_be;
   logic      [NrLanes-1:0]                     masku_result_gnt;
   logic      [NrLanes-1:0]                     masku_result_final_gnt;
+  elen_t     [NrLanes-1:0]                     vcpop_operand;
 
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
@@ -302,7 +303,8 @@ module ara import ara_pkg::*; #(
       .masku_result_final_gnt_o        (masku_result_final_gnt[lane]        ),
       .mask_i                          (mask[lane]                          ),
       .mask_valid_i                    (mask_valid[lane] & mask_valid_lane  ),
-      .mask_ready_o                    (lane_mask_ready[lane]               )
+      .mask_ready_o                    (lane_mask_ready[lane]               ),
+      .vcpop_operand_o                 (vcpop_operand[lane]                 )
     );
   end: gen_lanes
 
@@ -440,6 +442,7 @@ module ara import ara_pkg::*; #(
     .masku_result_be_o       (masku_result_be                 ),
     .masku_result_gnt_i      (masku_result_gnt                ),
     .masku_result_final_gnt_i(masku_result_final_gnt          ),
+    .vcpop_operand_i         (vcpop_operand                   ),
     // Interface with the VFUs
     .mask_o                  (mask                            ),
     .mask_valid_o            (mask_valid                      ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -89,11 +89,18 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     input  strb_t                                          masku_result_be_i,
     output logic                                           masku_result_gnt_o,
     output logic                                           masku_result_final_gnt_o,
+    output elen_t                                          vcpop_operand_o,
     // Interface between the Mask unit and the VFUs
     input  strb_t                                          mask_i,
     input  logic                                           mask_valid_i,
     output logic                                           mask_ready_o
   );
+
+  // vcpop.m variables
+
+  pe_req_t pe_req;
+
+  assign pe_req = pe_req_i;
 
   /////////////////
   //  Spill Reg  //
@@ -417,6 +424,20 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .mask_i               (mask                                   ),
     .mask_valid_i         (mask_valid                             ),
     .mask_ready_o         (mask_ready                             )
+  );
+
+  //////////////
+  // POPCOUNT //
+  //////////////
+
+  logic [ELEN-1:0] popcount;
+
+  // Population count for vcpop.m instruction
+  popcount #(
+    .INPUT_WIDTH (DataWidth*NrLanes)
+  ) i_popcount (
+    .data_i     ((!pe_req.vm) ? mask_operand_o[2] & mask_operand_o[0] : mask_operand_o[2]),
+    .popcount_o (vcpop_operand_o                                                         )
   );
 
   /********************


### PR DESCRIPTION
Shifted `popcount` logic for `vcpop.m` instruction from mask unit to lanes

## Changelog

### Fixed

- N/A

### Added

- N/A

### Changed

- Shifted `popcount` logic for `vcpop.m` instruction from mask unit to lanes

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
