### PR TITLE
[HW] Hotfix for Opqueue buffer depths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Remove unintentional latches from `valu`, `simd_mul`, `lane_sequencer`
  - Fix `vxsat` CSR update in `dispatcher`
  - Fix parameter passing through the hierarchy for fixed point support
+ - Decouple `cmdBuffer` and `dataBuffer` depths in opQueues
 
 ### Added
 
@@ -160,6 +161,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Generate data for `fmatmul` at compile time
  - SIMD multipliers are now power gated
  - Roll-back to Verilator v4.214
+ - Parametrize `addrgen` queue depth
 
 ## 2.2.0 - 2021-11-02
 

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -93,6 +93,7 @@ package ara_pkg;
   localparam int unsigned ValuInsnQueueDepth = 4;
   localparam int unsigned VlduInsnQueueDepth = 4;
   localparam int unsigned VstuInsnQueueDepth = 4;
+  localparam int unsigned VaddrgenInsnQueueDepth = 4;
   localparam int unsigned SlduInsnQueueDepth = 2;
   localparam int unsigned NoneInsnQueueDepth = 1;
   // Ara supports MaskuInsnQueueDepth = 1 only.

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -9,7 +9,8 @@
 // need it.
 
 module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
-    parameter  int           unsigned BufferDepth    = 2,
+    parameter  int           unsigned CmdBufDepth    = 2,
+    parameter  int           unsigned DataBufDepth   = 2,
     parameter  int           unsigned NrSlaves       = 1,
     parameter  int           unsigned NrLanes        = 0,
     // Support for floating-point data types
@@ -52,7 +53,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   logic               cmd_pop;
 
   fifo_v3 #(
-    .DEPTH(BufferDepth        ),
+    .DEPTH(CmdBufDepth        ),
     .dtype(operand_queue_cmd_t)
   ) i_cmd_buffer (
     .clk_i     (clk_i                    ),
@@ -79,8 +80,8 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   logic  ibuf_pop;
 
   fifo_v3 #(
-    .DEPTH     (BufferDepth),
-    .DATA_WIDTH(DataWidth  )
+    .DEPTH     (DataBufDepth),
+    .DATA_WIDTH(DataWidth   )
   ) i_input_buffer (
     .clk_i     (clk_i          ),
     .rst_ni    (rst_ni         ),
@@ -98,7 +99,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
 
   // We used a credit based system, to ensure that the FIFO is always
   // able to accept a request.
-  logic [idx_width(BufferDepth):0] ibuf_usage_d, ibuf_usage_q;
+  logic [idx_width(DataBufDepth):0] ibuf_usage_d, ibuf_usage_q;
 
   always_comb begin: p_ibuf_usage
     // Maintain state
@@ -110,7 +111,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     if (ibuf_pop) ibuf_usage_d -= 1;
 
     // Are we ready?
-    operand_queue_ready_o = (ibuf_usage_q != BufferDepth);
+    operand_queue_ready_o = (ibuf_usage_q != DataBufDepth);
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin: p_ibuf_usage_ff

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -52,14 +52,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ///////////
 
   operand_queue #(
-    .BufferDepth   (5         ),
-    .FPUSupport    (FPUSupport),
-    .NrLanes       (NrLanes   ),
-    .SupportIntExt2(1'b1      ),
-    .SupportIntExt4(1'b1      ),
-    .SupportIntExt8(1'b1      ),
-    .SupportReduct (1'b1      ),
-    .SupportNtrVal (1'b0      )
+    .CmdBufDepth   (ValuInsnQueueDepth),
+    .DataBufDepth  (5                 ),
+    .FPUSupport    (FPUSupport        ),
+    .NrLanes       (NrLanes           ),
+    .SupportIntExt2(1'b1              ),
+    .SupportIntExt4(1'b1              ),
+    .SupportIntExt8(1'b1              ),
+    .SupportReduct (1'b1              ),
+    .SupportNtrVal (1'b0              )
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -77,14 +78,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .BufferDepth   (5         ),
-    .FPUSupport    (FPUSupport),
-    .NrLanes       (NrLanes   ),
-    .SupportIntExt2(1'b1      ),
-    .SupportIntExt4(1'b1      ),
-    .SupportIntExt8(1'b1      ),
-    .SupportReduct (1'b1      ),
-    .SupportNtrVal (1'b1      )
+    .CmdBufDepth   (ValuInsnQueueDepth),
+    .DataBufDepth  (5                 ),
+    .FPUSupport    (FPUSupport        ),
+    .NrLanes       (NrLanes           ),
+    .SupportIntExt2(1'b1              ),
+    .SupportIntExt4(1'b1              ),
+    .SupportIntExt8(1'b1              ),
+    .SupportReduct (1'b1              ),
+    .SupportNtrVal (1'b1              )
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -106,12 +108,13 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   //////////////////////
 
   operand_queue #(
-    .BufferDepth   (5         ),
-    .FPUSupport    (FPUSupport),
-    .NrLanes       (NrLanes   ),
-    .SupportIntExt2(1'b1      ),
-    .SupportReduct (1'b1      ),
-    .SupportNtrVal (1'b0      )
+    .CmdBufDepth   (MfpuInsnQueueDepth ),
+    .DataBufDepth  (5                  ),
+    .FPUSupport    (FPUSupport         ),
+    .NrLanes       (NrLanes            ),
+    .SupportIntExt2(1'b1               ),
+    .SupportReduct (1'b1               ),
+    .SupportNtrVal (1'b0               )
   ) i_operand_queue_mfpu_a (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -129,12 +132,13 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .BufferDepth   (5         ),
-    .FPUSupport    (FPUSupport),
-    .NrLanes       (NrLanes   ),
-    .SupportIntExt2(1'b1      ),
-    .SupportReduct (1'b1      ),
-    .SupportNtrVal (1'b1      )
+    .CmdBufDepth   (MfpuInsnQueueDepth ),
+    .DataBufDepth  (5                  ),
+    .FPUSupport    (FPUSupport         ),
+    .NrLanes       (NrLanes            ),
+    .SupportIntExt2(1'b1               ),
+    .SupportReduct (1'b1               ),
+    .SupportNtrVal (1'b1               )
   ) i_operand_queue_mfpu_b (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -152,12 +156,13 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .BufferDepth   (5         ),
-    .FPUSupport    (FPUSupport),
-    .NrLanes       (NrLanes   ),
-    .SupportIntExt2(1'b1      ),
-    .SupportReduct (1'b1      ),
-    .SupportNtrVal (1'b1      )
+    .CmdBufDepth   (MfpuInsnQueueDepth ),
+    .DataBufDepth  (5                  ),
+    .FPUSupport    (FPUSupport         ),
+    .NrLanes       (NrLanes            ),
+    .SupportIntExt2(1'b1               ),
+    .SupportReduct (1'b1               ),
+    .SupportNtrVal (1'b1               )
   ) i_operand_queue_mfpu_c (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -179,9 +184,10 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ///////////////////////
 
   operand_queue #(
-    .BufferDepth(2         ),
-    .FPUSupport (FPUSupport),
-    .NrLanes    (NrLanes   )
+    .CmdBufDepth   (VstuInsnQueueDepth + MaskuInsnQueueDepth),
+    .DataBufDepth  (2                                       ),
+    .FPUSupport    (FPUSupport                              ),
+    .NrLanes       (NrLanes                                 )
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
@@ -203,9 +209,10 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
    ****************/
 
   operand_queue #(
-    .BufferDepth(2         ),
-    .FPUSupport (FPUSupport),
-    .NrLanes    (NrLanes   )
+    .CmdBufDepth   (VlduInsnQueueDepth),
+    .DataBufDepth  (2                 ),
+    .FPUSupport    (FPUSupport        ),
+    .NrLanes       (NrLanes           )
   ) i_operand_queue_slide_addrgen_a (
     .clk_i                    (clk_i                                         ),
     .rst_ni                   (rst_ni                                        ),
@@ -227,11 +234,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   /////////////////
 
   operand_queue #(
-    .BufferDepth(1         ),
-    .FPUSupport (FPUSupport),
-    .SupportIntExt2(1'b1),
-    .SupportIntExt4(1'b1),
-    .SupportIntExt8(1'b1),
+    .CmdBufDepth   (MaskuInsnQueueDepth),
+    .DataBufDepth  (1                  ),
+    .FPUSupport    (FPUSupport         ),
+    .SupportIntExt2(1'b1               ),
+    .SupportIntExt4(1'b1               ),
+    .SupportIntExt8(1'b1               ),
     .NrLanes    (NrLanes   )
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),
@@ -250,8 +258,9 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .BufferDepth(1         ),
-    .NrLanes    (NrLanes   )
+    .CmdBufDepth   (MaskuInsnQueueDepth),
+    .DataBufDepth  (1                  ),
+    .NrLanes       (NrLanes            )
   ) i_operand_queue_mask_m (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -89,8 +89,8 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
   logic             axi_addrgen_queue_empty;
 
   fifo_v3 #(
-    .DEPTH(4                ),
-    .dtype(addrgen_axi_req_t)
+    .DEPTH(VaddrgenInsnQueueDepth),
+    .dtype(addrgen_axi_req_t     )
   ) i_addrgen_req_queue (
     .clk_i     (clk_i                                                    ),
     .rst_ni    (rst_ni                                                   ),


### PR DESCRIPTION
Opqueues should have two different depths, one for the control (how many instructions can be buffered), and one for the data (how many 64-bit packets can be buffered).

## Changelog

### Fixed

- Decouple `cmdBuffer` and `dataBuffer` depths in opQueues

### Changed

- Parametrize `addrgen` queue depth

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
