### PR TITLE
[HW] :bug: Hotfix to reshuffling engine and FPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix `vxsat` CSR update in `dispatcher`
  - Fix parameter passing through the hierarchy for fixed point support
  - Decouple `cmdBuffer` and `dataBuffer` depths in opQueues
+ - Avoid handshaking wrong results in VMFPU
+ - Fix eew reshuffle for mask logical operations
+ - Fix eew reshuffle for `vmv.v.v` operations
 
 ### Added
 

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1364,6 +1364,7 @@ package ara_pkg;
         vfrec7_sub.e = 8'd0;                          //0 minus number of leading zeros in sig
         vfrec7_sub.m = {operand_a_delay[21:0], 1'b0};  //left-shifting by 1
       end
+      default;
     endcase
 
     unique case (vfpu_result)
@@ -1431,6 +1432,7 @@ package ara_pkg;
         //The output sign equals the input sign.
         vfrec7_o.vf7_e32.s = operand_a_delay[31];
       end
+      default:;
     endcase
 
     // check if input number is subnormal number  with sig=00..

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -1243,6 +1243,7 @@ package ara_pkg;
         vfrec7_sub.e = 5'd0;                          //0 minus number of leading zeros in sig
         vfrec7_sub.m = {operand_a_delay[8:0], 1'b0};  //left-shifting by 1
       end
+      default:;
     endcase
 
     unique case (vfpu_result)
@@ -1309,6 +1310,7 @@ package ara_pkg;
          //The output sign equals the input sign.
         vfrec7_o.vf7_e16.s = operand_a_delay[15];
       end
+      default:;
     endcase
 
     // check if input number is subnormal number  with sig=00..
@@ -1326,11 +1328,13 @@ package ara_pkg;
         unique case (en_rm)
           1'b0: vfrec7_out.vf7_e16 = {vfrec7_o.vf7_e16.s, E16_Inf}; // infinity
           1'b1: vfrec7_out.vf7_e16 = {vfrec7_o.vf7_e16.s, E16_Max}; // greatest magnitude
+          default:;
         endcase
 
         vfrec7_out.ex_flag.NX  = 1'b1;
         vfrec7_out.ex_flag.OF  = 1'b1;
       end
+      default:;
     endcase
     return vfrec7_out;
   endfunction : vfrec7_fp16
@@ -1364,7 +1368,7 @@ package ara_pkg;
         vfrec7_sub.e = 8'd0;                          //0 minus number of leading zeros in sig
         vfrec7_sub.m = {operand_a_delay[21:0], 1'b0};  //left-shifting by 1
       end
-      default;
+      default:;
     endcase
 
     unique case (vfpu_result)
@@ -1449,11 +1453,13 @@ package ara_pkg;
         unique case (en_rm)
           1'b0: vfrec7_out.vf7_e32 = {vfrec7_o.vf7_e32.s, E32_Inf}; // infinity
           1'b1: vfrec7_out.vf7_e32 = {vfrec7_o.vf7_e32.s, E32_Max}; // greatest magnitude
+          default:;
         endcase
 
         vfrec7_out.ex_flag.NX  = 1'b1;
         vfrec7_out.ex_flag.OF  = 1'b1;
       end
+      default:;
     endcase
     return vfrec7_out;
   endfunction : vfrec7_fp32
@@ -1487,6 +1493,7 @@ package ara_pkg;
         vfrec7_sub.e = 11'd0;                          //0 minus number of leading zeros in sig
         vfrec7_sub.m = {operand_a_delay[50:0], 1'b0};  //left-shifting by 1
       end
+      default:;
     endcase
 
     unique case (vfpu_result)
@@ -1554,6 +1561,7 @@ package ara_pkg;
         //The output sign equals the input sign.
         vfrec7_o.vf7_e64.s = operand_a_delay[63];
       end
+      default:;
     endcase
 
     // check if input number is subnormal number  with sig=00..
@@ -1570,11 +1578,13 @@ package ara_pkg;
         unique case (en_rm)
           1'b0:vfrec7_out.vf7_e64 = {vfrec7_o.vf7_e64.s, E64_Inf}; // infinity
           1'b1:vfrec7_out.vf7_e64 = {vfrec7_o.vf7_e64.s, E64_Max}; // greatest magnitude
+          default:;
         endcase
 
         vfrec7_out.ex_flag.NX  = 1'b1;
         vfrec7_out.ex_flag.OF  = 1'b1;
       end
+      default:;
     endcase
     return vfrec7_out;
   endfunction : vfrec7_fp64

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1258,35 +1258,70 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b001011: ara_req_d.op = ara_pkg::VASUB;
                   6'b011000: begin
                     ara_req_d.op        = ara_pkg::VMANDNOT;
-                    ara_req_d.use_vd_op = 1'b1;
+                    // Prefer mask operation on EW8 encoding
+                    // In mask operations, vs1, vs2, vd should
+                    // have the same encoding.
+                    ara_req_d.eew_vs1    = EW8;
+                    ara_req_d.eew_vs2    = EW8;
+                    ara_req_d.eew_vd_op  = EW8;
+                    ara_req_d.vtype.vsew = EW8;
+                    ara_req_d.use_vd_op  = 1'b1;
                   end
                   6'b011001: begin
-                    ara_req_d.op        = ara_pkg::VMAND;
-                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op         = ara_pkg::VMAND;
+                    ara_req_d.eew_vs1    = EW8;
+                    ara_req_d.eew_vs2    = EW8;
+                    ara_req_d.eew_vd_op  = EW8;
+                    ara_req_d.vtype.vsew = EW8;
+                    ara_req_d.use_vd_op  = 1'b1;
                   end
                   6'b011010: begin
-                    ara_req_d.op        = ara_pkg::VMOR;
-                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op         = ara_pkg::VMOR;
+                    ara_req_d.eew_vs1    = EW8;
+                    ara_req_d.eew_vs2    = EW8;
+                    ara_req_d.eew_vd_op  = EW8;
+                    ara_req_d.vtype.vsew = EW8;
+                    ara_req_d.use_vd_op  = 1'b1;
                   end
                   6'b011011: begin
-                    ara_req_d.op        = ara_pkg::VMXOR;
-                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op         = ara_pkg::VMXOR;
+                    ara_req_d.eew_vs1    = EW8;
+                    ara_req_d.eew_vs2    = EW8;
+                    ara_req_d.eew_vd_op  = EW8;
+                    ara_req_d.vtype.vsew = EW8;
+                    ara_req_d.use_vd_op  = 1'b1;
                   end
                   6'b011100: begin
-                    ara_req_d.op        = ara_pkg::VMORNOT;
-                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op         = ara_pkg::VMORNOT;
+                    ara_req_d.eew_vs1    = EW8;
+                    ara_req_d.eew_vs2    = EW8;
+                    ara_req_d.eew_vd_op  = EW8;
+                    ara_req_d.vtype.vsew = EW8;
+                    ara_req_d.use_vd_op  = 1'b1;
                   end
                   6'b011101: begin
-                    ara_req_d.op        = ara_pkg::VMNAND;
-                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op         = ara_pkg::VMNAND;
+                    ara_req_d.eew_vs1    = EW8;
+                    ara_req_d.eew_vs2    = EW8;
+                    ara_req_d.eew_vd_op  = EW8;
+                    ara_req_d.vtype.vsew = EW8;
+                    ara_req_d.use_vd_op  = 1'b1;
                   end
                   6'b011110: begin
-                    ara_req_d.op        = ara_pkg::VMNOR;
-                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op         = ara_pkg::VMNOR;
+                    ara_req_d.eew_vs1    = EW8;
+                    ara_req_d.eew_vs2    = EW8;
+                    ara_req_d.eew_vd_op  = EW8;
+                    ara_req_d.vtype.vsew = EW8;
+                    ara_req_d.use_vd_op  = 1'b1;
                   end
                   6'b011111: begin
-                    ara_req_d.op        = ara_pkg::VMXNOR;
-                    ara_req_d.use_vd_op = 1'b1;
+                    ara_req_d.op         = ara_pkg::VMXNOR;
+                    ara_req_d.eew_vs1    = EW8;
+                    ara_req_d.eew_vs2    = EW8;
+                    ara_req_d.eew_vd_op  = EW8;
+                    ara_req_d.vtype.vsew = EW8;
+                    ara_req_d.use_vd_op  = 1'b1;
                   end
                   6'b010010: begin // VXUNARY0
                     // These instructions do not use vs1
@@ -3034,7 +3069,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
 
         // Is the instruction an in-lane one and could it be subject to reshuffling?
-        in_lane_op = ara_req_d.op inside {[VADD:VNSRA]} || ara_req_d.op inside {[VREDSUM:VMSBC]};
+        in_lane_op = ara_req_d.op inside {[VADD:VNSRA]} || ara_req_d.op inside {[VREDSUM:VMSBC]} ||
+                     ara_req_d.op inside {[VMANDNOT:VMXNOR]};
         // Annotate which registers need a reshuffle -> |vs1|vs2|vd|
         // Optimization: reshuffle vs1 and vs2 only if the operation is strictly in-lane
         // Optimization: reshuffle vd only if we are not overwriting the whole vector register!

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -618,6 +618,13 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   6'b010111: begin
                     ara_req_d.op      = ara_pkg::VMERGE;
                     ara_req_d.use_vs2 = !insn.varith_type.vm; // vmv.v.v does not use vs2
+                    // With a normal vmv.v.v, copy input eew to output
+                    // to avoid unnecessary reshuffles
+                    if (insn.varith_type.vm) begin
+                      ara_req_d.eew_vs1    = eew_q[ara_req_d.vs1];
+                      ara_req_d.vtype.vsew = eew_q[ara_req_d.vs1];
+                      ara_req_d.vl         = (vl_q << vtype_q.vsew[1:0]) >> ara_req_d.eew_vs1[1:0];
+                    end
                   end
                   6'b100000: ara_req_d.op = ara_pkg::VSADDU;
                   6'b100001: ara_req_d.op = ara_pkg::VSADD;
@@ -3069,7 +3076,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
 
         // Is the instruction an in-lane one and could it be subject to reshuffling?
-        in_lane_op = ara_req_d.op inside {[VADD:VNSRA]} || ara_req_d.op inside {[VREDSUM:VMSBC]} ||
+        in_lane_op = ara_req_d.op inside {[VADD:VMERGE]} || ara_req_d.op inside {[VREDSUM:VMSBC]} ||
                      ara_req_d.op inside {[VMANDNOT:VMXNOR]};
         // Annotate which registers need a reshuffle -> |vs1|vs2|vd|
         // Optimization: reshuffle vs1 and vs2 only if the operation is strictly in-lane

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -1201,9 +1201,9 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     vfpu_in_valid = 1'b0;
 
     // If the result queue is not full, it is ready to accept a result
-    vmul_out_ready = ~result_queue_full;
-    vdiv_out_ready = ~result_queue_full;
-    vfpu_out_ready = ~result_queue_full;
+    vmul_out_ready = ~result_queue_full && (vinsn_processing_q.op inside {[VMUL:VSMUL]});
+    vdiv_out_ready = ~result_queue_full && (vinsn_processing_q.op inside {[VDIVU:VREM]});
+    vfpu_out_ready = ~result_queue_full && (vinsn_processing_q.op inside {[VFADD:VMFGE]});
 
     // Valid of the unit in use (i.e., result queue input valid) is not asserted by default
     unit_out_valid  = 1'b0;
@@ -1383,7 +1383,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
             unit_out_result = vdiv_result;
             unit_out_mask   = vdiv_mask;
           end
-          [VFADD:VFCVTFF], [VMFEQ:VMFGE]: begin
+          [VFADD:VMFGE]: begin
             unit_out_valid  = vfpu_out_valid;
             unit_out_result = vfpu_processed_result;
             unit_out_mask   = vfpu_mask;


### PR DESCRIPTION
1) VMFPU has more than one units, and as soon as the issue phase of an instruction is over, the next one can start. If instruction 1 is a `div` instruction and takes 6 cycles, while instruction 2 is a 8 bit multiplication and takes 1 cycles only, the results can be produced out-of-order. For this reason, the units are handshaked at their output only if the unit is used by `vinsn_processing_q`.
2) The mask unit handles logical mask operations if `vs1`, `vs2`, and `vd` have the same `eew` encoding. Therefore, these operations should be affected by reshuffling. EW8 is preferred for all the mask operations to minimize reshuffling.
3) `vmv.v.v` and `vmerge` need to be affected by reshuffling. To speed up everything, `vmv.v.v` align the working encodings to the `eew` of the source register, to minimize reshufflings.

## Changelog

### Fixed

 - Avoid handshaking wrong results in VMFPU
 - Fix `eew` reshuffle for logical mask operations
 - Fix `eew` reshuffle for `vmv.v.v` operations

## Checklist

- [x] Automated tests pass
- [x] No Frequency degradation
- [x] No IPC degradation
- [x] Changelog updated
- [x] Code style guideline is observed

