### PR TITLE
[HW] Generic hotfixes (post-layout simulation)

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -40,6 +40,7 @@ sources:
     - hardware/src/lane/simd_div.sv
     - hardware/src/lane/simd_mul.sv
     - hardware/src/lane/vector_regfile.sv
+    - hardware/src/lane/power_gating_generic.sv
     - hardware/src/masku/masku.sv
     - hardware/src/sldu/sldu.sv
     - hardware/src/vlsu/addrgen.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Support for vector floating-point reciprocal square-root estimate instruction: `vfrsqrt7`
  - Support for vector narrowing floating-point convert instruction: `vfncvt.rod.f.f`
  - Parametrize `vfrec7`, `vfrsqrt7` and `vfncvt.rod.f.f` support
+ - Add guards in the testbench to successfully compile in post-layout simulations
+ - Add VCD dumping features to `imatmul`
+ - `core_id_i` added to the interface of the system
 
 ### Changed
 
@@ -169,6 +172,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - SIMD multipliers are now power gated
  - Roll-back to Verilator v4.214
  - Parametrize `addrgen` queue depth
+ - SIMD-multipliers are now gated singularly depending on VSEW
 
 ## 2.2.0 - 2021-11-02
 

--- a/apps/imatmul/kernel/imatmul.c
+++ b/apps/imatmul/kernel/imatmul.c
@@ -101,6 +101,15 @@ void imatmul_vec_4x4(int64_t *c, const int64_t *a, const int64_t *b,
   unsigned long int n = 0;
 
   while (n < N) {
+#ifdef VCD_DUMP
+    // Start dumping VCD
+    if (n == 8)
+      event_trigger = +1;
+    // Stop dumping VCD
+    if (n == 12)
+      event_trigger = -1;
+#endif
+
     // Calculate pointer to the matrix A
     a = a_ + ++n;
 
@@ -226,6 +235,15 @@ void imatmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b,
   unsigned long int n = 0;
 
   while (n < N) {
+#ifdef VCD_DUMP
+    // Start dumping VCD
+    if (n == 8)
+      event_trigger = +1;
+    // Stop dumping VCD
+    if (n == 12)
+      event_trigger = -1;
+#endif
+
     // Calculate pointer to the matrix A
     a = a_ + ++n;
 

--- a/apps/imatmul/kernel/imatmul.h
+++ b/apps/imatmul/kernel/imatmul.h
@@ -40,4 +40,6 @@ void imatmul_vec_8x8_slice_init();
 void imatmul_vec_8x8(int64_t *c, const int64_t *a, const int64_t *b,
                      const unsigned long int n, const unsigned long int p);
 
+extern int64_t event_trigger;
+
 #endif

--- a/apps/imatmul/main.c
+++ b/apps/imatmul/main.c
@@ -62,7 +62,12 @@ int main() {
   printf("\n");
   printf("\n");
 
+#ifdef VCD_DUMP
+  // Measure only the full-size matmul
+  for (uint64_t s = M; s <= M; s *= 2) {
+#else
   for (int s = 4; s <= M; s *= 2) {
+#endif
     printf("\n");
     printf("------------------------------------------------------------\n");
     printf("Calculating a (%d x %d) x (%d x %d) matrix multiplication...\n", s,

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -429,6 +429,10 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
   //  System  //
   //////////////
 
+  logic [2:0] hart_id;
+
+  assign hart_id = '0;
+
   localparam ariane_pkg::ariane_cfg_t ArianeAraConfig = '{
     RASDepth             : 2,
     BTBEntries           : 32,
@@ -492,6 +496,7 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     .clk_i        (clk_i                    ),
     .rst_ni       (rst_ni                   ),
     .boot_addr_i  (DRAMBase                 ), // start fetching from DRAM
+    .hart_id_i    (hart_id                  ),
     .scan_enable_i(1'b0                     ),
     .scan_data_i  (1'b0                     ),
     .scan_data_o  (/* Unconnected */        ),

--- a/hardware/src/ara_system.sv
+++ b/hardware/src/ara_system.sv
@@ -47,6 +47,7 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
     input  logic                    clk_i,
     input  logic                    rst_ni,
     input  logic             [63:0] boot_addr_i,
+    input                     [2:0] hart_id_i,
     // Scan chain
     input  logic                    scan_enable_i,
     input  logic                    scan_data_i,
@@ -87,6 +88,10 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
   logic                                 inval_valid;
   logic                                 inval_ready;
 
+  // Support max 8 cores, for now
+  logic [63:0] hart_id;
+  assign hart_id = {'0, hart_id_i};
+
 `ifdef IDEAL_DISPATCHER
   // Perfect dispatcher to Ara
   accel_dispatcher_ideal i_accel_dispatcher_ideal (
@@ -106,7 +111,7 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
     .clk_i            (clk_i                 ),
     .rst_ni           (rst_ni                ),
     .boot_addr_i      (boot_addr_i           ),
-    .hart_id_i        ('0                    ),
+    .hart_id_i        (hart_id               ),
     .irq_i            ('0                    ),
     .ipi_i            ('0                    ),
     .time_irq_i       ('0                    ),

--- a/hardware/src/lane/power_gating_generic.sv
+++ b/hardware/src/lane/power_gating_generic.sv
@@ -1,0 +1,24 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors: Matteo Perotti <mperotti@iis.ee.ethz.ch>
+// Description:
+// Technology-agnostic replacement for a glitch-free gating combinatorial cell
+
+module power_gating_generic #(
+  parameter type         T = logic,
+  parameter int  NO_GLITCH = 0
+) (
+  input  T     in_i,
+  input  logic en_i,
+  output T     out_o
+);
+
+  T en_wide;
+
+  // Gate with an AND
+  assign en_wide = en_i ? T'('1) : T'('0);
+  assign out_o   = T'(in_i & en_wide);
+
+endmodule

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -138,6 +138,8 @@ module ara_tb;
     end
   end : dram_init
 
+`ifndef TARGET_GATESIM
+
   /*************************
    *  PRINT STORED VALUES  *
    *************************/
@@ -183,6 +185,8 @@ module ara_tb;
           if (ara_w_strb[b])
             $fdisplay(fd, "%0x", ara_w[b*8 +: 8]);
 
+`endif
+
   /*********
    *  EOC  *
    *********/
@@ -193,11 +197,15 @@ module ara_tb;
         $warning("Core Test ", $sformatf("*** FAILED *** (tohost = %0d)", (exit >> 1)));
       end else begin
         // Print vector HW runtime
+`ifndef TARGET_GATESIM
         $display("[hw-cycles]: %d", int'(dut.runtime_buf_q));
+`endif
         $info("Core Test ", $sformatf("*** SUCCESS *** (tohost = %0d)", (exit >> 1)));
       end
 
+`ifndef TARGET_GATESIM
       $fclose(fd);
+`endif
       $finish(exit >> 1);
     end
   end

--- a/hardware/tb/ara_testharness.sv
+++ b/hardware/tb/ara_testharness.sv
@@ -108,6 +108,8 @@ module ara_testharness #(
     .pslverr_o(uart_pslverr)
   );
 
+`ifndef TARGET_GATESIM
+
   /***************
    *  V_RUNTIME  *
    ***************/
@@ -202,4 +204,5 @@ module ara_testharness #(
     end
   end
 
+`endif
 endmodule : ara_testharness


### PR DESCRIPTION


## Changelog


### Added

- Add guards in the testbench to successfully compile in post-layout simulations.
- Add VCD dumping features to `imatmul`.
- `core_id_i` added to the interface of the system.

### Changed

- SIMD-multipliers are now gated singularly depending on VSEW.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed