### PR TITLE
[CI] Update sphinx.yml to publish GitHub-pages from main branch

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -16,7 +16,7 @@ jobs:
         path: docs/build/html/
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
-      if: github.ref == 'refs/heads/readthedocs'
+      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/build/html


### PR DESCRIPTION
This PR fixes the issues of rendering Html pages of documentation from the main branch. After the merge of PR #199, the documentation pages will render from the main. sphinx.yml file build and deploy the Html files automatically (on push) on the gh-pages branch. GitHub page settings are shown below. 
![capture](https://user-images.githubusercontent.com/108278466/214218318-39cd582f-525d-4799-b1ca-13cd89bc95c4.png)
After these changes and merge of this PR, the expected docs URL will be https://pulp-platform.github.io/ara/

## Changelog

### Fixed

- Updates sphinx.yml file.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
