### PR TITLE
[HW] Fix issue in vector widening floating-point arithmetic instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix masku handshake. All the lanes should handshake together in input
  - Start solving `sldu` counter widths warnings
  - Fix `vslideup` wrong counter trimming
+ - Fix the bug in widening arithmetic instructions i.e added functionality to handle subnormal numbers and special cases
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix masku handshake. All the lanes should handshake together in input
  - Start solving `sldu` counter widths warnings
  - Fix `vslideup` wrong counter trimming
- - Fix the bug in widening arithmetic instructions i.e added functionality to handle subnormal numbers and special cases
+ - Fix the bug in vector widening floating-point arithmetic instructions i.e added functionality to handle subnormal numbers and special cases
 
 ### Added
 

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -373,7 +373,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
 
                 fp16[e] = ibuf_operand[8*select + 32*e +: 16];
 
-                fp16_temp.m = (fp16[e].e == '0 && fp16[e].m != '0) ? fp16[e].m << (5'd1 + {1'd0, lzc_count16[e]}) : fp16[e].m;
+                fp16_temp.m = ((fp16[e].e == '0) && (fp16[e].m != '0)) ? fp16[e].m << (5'd1 + {1'd0, lzc_count16[e]}) : fp16[e].m;
 
                 fp32_exp = (fp16[e].m == '0) ? '0 : 8'd112 - {4'd0, lzc_count16[e]};  //127 - 15 = 112
 
@@ -387,7 +387,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
 
                 // If the input is NaN, output a quiet NaN mantissa.
                 // Otherwise, append trailing zeros to the mantissa.
-                fp32_o.m = (fp16[e].e == '1 && fp16[e].e != '0 ) ? {1'b1, 22'b0} : {fp16_temp.m, 13'b0};
+                fp32_o.m = ((fp16[e].e == '1) && (fp16[e].m != '0) ) ? {1'b1, 22'b0} : {fp16_temp.m, 13'b0};
 
                 conv_operand[32*e +: 32] = fp32_o;
               end
@@ -400,7 +400,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
 
               fp32  = ibuf_operand[8*select +: 32];
 
-              fp32_temp.m = (fp32.e == '0 && fp32.m != '0) ? fp32.m << (8'd1 + {3'd0, lzc_count32}) : fp32.m;
+              fp32_temp.m = ((fp32.e == '0) && (fp32.m != '0)) ? fp32.m << (8'd1 + {3'd0, lzc_count32}) : fp32.m;
 
               fp64_exp = (fp32.m == '0) ? '0 : 11'd896 - {6'd0, lzc_count32}; //1023 - 127 = 896
 
@@ -414,7 +414,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
 
               // If the input is NaN, output a quiet NaN mantissa.
               // Otherwise, append trailing zeros to the mantissa.
-              fp64.m = (fp32.e == '1 && fp32.m != '0) ? {1'b1, 51'b0} : {fp32_temp.m, 29'b0};
+              fp64.m = ((fp32.e == '1) && (fp32.m != '0)) ? {1'b1, 51'b0} : {fp32_temp.m, 29'b0};
 
               conv_operand = fp64;
             end

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -149,13 +149,6 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   // Helper to fill with neutral values the last packet
   logic incomplete_packet, last_packet;
 
-  // To convert subnormal numbers to normalized form in floating-point numbers,
-  // it is necessary to determine the number of leading zeros in the mantissa.
-  // This is typically accomplished using a lzc (leading zero count) module,
-  // which can accurately count the number of leading zeros in a given number.
-  // By knowing the number of leading zeros in the mantissa, we can properly
-  // adjust the exponent and shift the binary point to achieve a normalized
-  // representation of the number.
 
   logic [3:0] lzc_count16[2];
   logic [4:0] lzc_count32;
@@ -163,27 +156,37 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   fp16_t fp16[2];
   fp32_t fp32;
 
-  // sew: 16-bit
-  for (genvar i = 0; i < 2; i = i + 1) begin
-    lzc #(
-      .WIDTH(10),
-      .MODE (1 )
-    ) leading_zero_e16_i (
-       .in_i    ( fp16[i].m         ),
-       .cnt_o   ( lzc_count16[i] ),
-       .empty_o ( /*Unused*/     )
-    );
-  end
+  if (FPUSupport != FPUSupportNone) begin
+   // To convert subnormal numbers to normalized form in floating-point numbers,
+   // it is necessary to determine the number of leading zeros in the mantissa.
+   // This is typically accomplished using a lzc (leading zero count) module,
+   // which can accurately count the number of leading zeros in a given number.
+   // By knowing the number of leading zeros in the mantissa, we can properly
+   // adjust the exponent and shift the binary point to achieve a normalized
+   // representation of the number.
 
-  // sew: 32-bit
-  lzc #(
-     .WIDTH (23),
-     .MODE  (1 )
-   ) leading_zero_e32(
-     .in_i    ( fp32.m      ),
-     .cnt_o   ( lzc_count32 ),
-     .empty_o ( /*Unused*/  )
-   );
+    // sew: 16-bit
+    for (genvar i = 0; i < 2; i = i + 1) begin
+      lzc #(
+        .WIDTH(10),
+        .MODE (1 )
+      ) leading_zero_e16_i (
+         .in_i    ( fp16[i].m      ),
+         .cnt_o   ( lzc_count16[i] ),
+         .empty_o ( /*Unused*/     )
+      );
+    end
+
+    // sew: 32-bit
+    lzc #(
+       .WIDTH (23),
+       .MODE  (1 )
+     ) leading_zero_e32(
+       .in_i    ( fp32.m      ),
+       .cnt_o   ( lzc_count32 ),
+       .empty_o ( /*Unused*/  )
+     );
+  end
 
   always_comb begin: type_conversion
     // Shuffle the input operand


### PR DESCRIPTION
Resolved the issue [ #221](https://github.com/pulp-platform/ara/issues/221#issue-1625014386).


## Changelog

### Fixed

- Fixed the bug in vector widening floating-point arithmetic instructions i.e added functionality to handle subnormal numbers and special cases

### Added

- N/A

### Changed

- N/A

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.

