### PR TITLE
ara_soc: Upgrade axi to apb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 	path = toolchain/riscv-llvm
 	url = https://github.com/llvm/llvm-project.git
 	ignore = dirty
+[submodule "hardware/deps/apb"]
+	path = hardware/deps/apb
+	url = https://github.com/pulp-platform/apb.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -1,5 +1,12 @@
 ---
 packages:
+  apb:
+    revision: 77ddf073f194d44b9119949d2421be59789e69ae
+    version: 0.2.4
+    source:
+      Git: https://github.com/pulp-platform/apb.git
+    dependencies:
+    - common_cells
   axi:
     revision: 442ff3375710513623f95944d66cc2bd09b2f155
     version: 0.29.1

--- a/Bender.yml
+++ b/Bender.yml
@@ -12,6 +12,7 @@ dependencies:
   common_cells:       { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.22.1 }
   cva6:               { git: "https://github.com/pulp-platform/cva6.git",               rev: acc_port   }
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.1  }
+  apb:                { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4  }
 
 workspace:
   checkout_dir: "hardware/deps"


### PR DESCRIPTION
axi2apb_64_32 has been deprecated. Replace it with the up-to-date axi and apb IPs.
