### PR TITLE
Fix vnclip vnclipu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Start solving `sldu` counter widths warnings
  - Fix `vslideup` wrong counter trimming
  - Reset gating registers before the integer multipliers in `vmfpu`
+ - Fix narrowing for `vnclip` and `vnclipu`
 
 ### Added
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -221,7 +221,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
   // it produces only EEW/2 per cycle.
   function automatic logic narrowing(ara_op_e op);
     narrowing = 1'b0;
-    if (op inside {VNSRA, VNSRL})
+    if (op inside {VNSRA, VNSRL, VNCLIP, VNCLIPU})
       narrowing = 1'b1;
   endfunction : narrowing
 


### PR DESCRIPTION
Hello,

as #163 mentions the `vnclip` and `vnclipu` are not working properly. I also observed this problem when testing this instruction. 5979a98570ad6122e07c8c5f1705b5003df1b0b0 fixes this problem by adding `vnclip` and `vnclipu` to the `narrowing( ... )` function.

## Changelog

### Fixed

- Fix narrowing for `vnclip` and `vnclipu`

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed