### PR TITLE
Ara Virtual Memory support

### DIFF
--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -6,7 +6,8 @@
 // Description:
 // Ara's top-level, interfacing with Ariane.
 
-module ara import ara_pkg::*; #(
+module ara import ara_pkg::*; 
+    import ariane_pkg::exception_t;#(
     // RVV Parameters
     parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
     // Support for floating-point data types
@@ -31,22 +32,31 @@ module ara import ara_pkg::*; #(
     localparam int           unsigned NrPEs        = NrLanes + 4
   ) (
     // Clock and Reset
-    input  logic              clk_i,
-    input  logic              rst_ni,
+    input  logic                    clk_i,
+    input  logic                    rst_ni,
     // Scan chain
-    input  logic              scan_enable_i,
-    input  logic              scan_data_i,
-    output logic              scan_data_o,
+    input  logic                    scan_enable_i,
+    input  logic                    scan_data_i,
+    output logic                    scan_data_o,
     // Interface with Ariane
-    input  accelerator_req_t  acc_req_i,
-    input  logic              acc_req_valid_i,
-    output logic              acc_req_ready_o,
-    output accelerator_resp_t acc_resp_o,
-    output logic              acc_resp_valid_o,
-    input  logic              acc_resp_ready_i,
+    input  accelerator_req_t        acc_req_i,
+    input  logic                    acc_req_valid_i,
+    output logic                    acc_req_ready_o,
+    output accelerator_resp_t       acc_resp_o,
+    output logic                    acc_resp_valid_o,
+    input  logic                    acc_resp_ready_i,
+    // MMU interface
+    output exception_t              ara_misaligned_ex_o,
+    output logic                    ara_mmu_req_o,
+    output  logic [riscv::VLEN-1:0] ara_vaddr_o,
+    output  logic                   ara_is_store_o,
+
+    input logic                     ara_mmu_valid_i,
+    input logic [riscv::PLEN-1:0]   ara_paddr_i,
+    input exception_t               ara_exception_i,
     // AXI interface
-    output axi_req_t          axi_req_o,
-    input  axi_resp_t         axi_resp_i
+    output axi_req_t                axi_req_o,
+    input  axi_resp_t               axi_resp_i
   );
 
   import cf_math_pkg::idx_width;
@@ -362,6 +372,14 @@ module ara import ara_pkg::*; #(
     .addrgen_operand_target_fu_i(sldu_addrgen_operand_target_fu                        ),
     .addrgen_operand_valid_i    (sldu_addrgen_operand_valid                            ),
     .addrgen_operand_ready_o    (addrgen_operand_ready                                 ),
+    //Interface with MMU
+    .ara_misaligned_ex_o                                                                ,
+    .ara_mmu_req_o                                                                      ,
+    .ara_vaddr_o                                                                        ,
+    .ara_is_store_o                                                                     ,
+    .ara_mmu_valid_i                                                                    ,
+    .ara_paddr_i                                                                        ,
+    .ara_exception_i                                                                    ,
     // Load unit
     .ldu_result_req_o           (ldu_result_req                                        ),
     .ldu_result_addr_o          (ldu_result_addr                                       ),

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -481,6 +481,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*;
     axi_ar_valid_o = 1'b0;
     axi_aw_o       = '0;
     axi_aw_valid_o = 1'b0;
+    ara_mmu_req_o  = '0;
     ara_paddr_d    = ara_paddr_q;
 
     case (axi_addrgen_state_q)
@@ -544,7 +545,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*;
             aligned_end_addr_d        = {aligned_start_addr_d[AxiAddrWidth-1:12], 12'hFFF};
             aligned_next_start_addr_d = {                       next_2page_msb_d, 12'h000};
           end
-        end else if (state_q == ADDRGEN_IDX_OP) begin
+        end else if (state_q == ADDRGEN_IDX_OP&&idx_addr_valid_q) begin
           if(!core_st_pending_i) begin
             ara_mmu_req_o       = 1'b1;
             ara_misaligned_ex_o = '0;
@@ -793,7 +794,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*;
                 // AR Channel
                 if (axi_addrgen_q.is_load) begin
                   axi_ar_o = '{
-                    addr   : ara_paddr_q,
+                    addr   : ara_paddr,
                     len    : 0,
                     size   : axi_addrgen_q.vew,
                     cache  : CACHE_MODIFIABLE,
@@ -805,7 +806,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*;
                 // AW Channel
                 else begin
                   axi_aw_o = '{
-                    addr   : ara_paddr_q,
+                    addr   : ara_paddr,
                     len    : 0,
                     size   : axi_addrgen_q.vew,
                     cache  : CACHE_MODIFIABLE,
@@ -816,7 +817,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*;
                 end
                 // Send this request to the load/store units
                 axi_addrgen_queue = '{
-                  addr   : ara_paddr_q,
+                  addr   : ara_paddr,
                   size   : axi_addrgen_q.vew,
                   len    : 0,
                   is_load: axi_addrgen_q.is_load
@@ -885,3 +886,4 @@ module addrgen import ara_pkg::*; import rvv_pkg::*;
   end
 
 endmodule : addrgen
+

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -8,7 +8,8 @@
 // loads and vector stores. There are no guarantees regarding concurrency
 // and coherence with Ariane's own load/store unit.
 
-module vlsu import ara_pkg::*; import rvv_pkg::*; #(
+module vlsu import ara_pkg::*; import rvv_pkg::*; 
+    import ariane_pkg::exception_t;#(
     parameter  int  unsigned NrLanes = 0,
     parameter  type          vaddr_t = logic,  // Type used to address vector register file elements
     // AXI Interface parameters
@@ -54,6 +55,14 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     input  target_fu_e[NrLanes-1:0] addrgen_operand_target_fu_i,
     input  logic      [NrLanes-1:0] addrgen_operand_valid_i,
     output logic                    addrgen_operand_ready_o,
+    output exception_t              ara_misaligned_ex_o,
+    output logic                    ara_mmu_req_o,
+    output  logic [riscv::VLEN-1:0] ara_vaddr_o,
+    output  logic                   ara_is_store_o,
+
+    input logic                     ara_mmu_valid_i,
+    input logic [riscv::PLEN-1:0]   ara_paddr_i,
+    input exception_t               ara_exception_i,
     // Interface with the Mask unit
     input  strb_t     [NrLanes-1:0] mask_i,
     input  logic      [NrLanes-1:0] mask_valid_i,
@@ -140,6 +149,14 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .addrgen_operand_target_fu_i(addrgen_operand_target_fu_i),
     .addrgen_operand_valid_i    (addrgen_operand_valid_i    ),
     .addrgen_operand_ready_o    (addrgen_operand_ready_o    ),
+    //Interface with MMU
+    .ara_misaligned_ex_o,
+    .ara_mmu_req_o,
+    .ara_vaddr_o,
+    .ara_is_store_o,
+    .ara_mmu_valid_i,
+    .ara_paddr_i,
+    .ara_exception_i,
     // Interface with the load/store units
     .axi_addrgen_req_o          (axi_addrgen_req            ),
     .axi_addrgen_req_valid_o    (axi_addrgen_req_valid      ),


### PR DESCRIPTION
This is the Draft PR of adding virtual memory support in ARA by sharing MMU of cva6

## Changelog

- Corrected the exceptional handling path 
- Added the port from ARA's Address Generator Unit to CVA6 MMU

### Fixed

- Corrected the exceptional handling path

### Added

- Added the port from ARA's Address Generator Unit to CVA6 MMU

### Changed

- Modified Address Generator AXI REQ FSM
