### PR TITLE
Ara mmu support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,7 @@ jobs:
   simulate:
     runs-on: ubuntu-20.04
     strategy:
+    fail-fast: false
       matrix:
         app:        [hello_world, imatmul, fmatmul, iconv2d, fconv2d, fconv3d, jacobi2d, dropout, fft, dwt, exp, softmax, dotproduct, fdotproduct, pathfinder, roi_align]
         ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
@@ -318,6 +319,7 @@ jobs:
   riscv-tests-simv:
     runs-on: ubuntu-20.04
     strategy:
+    fail-fast: false
       matrix:
         ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["compile-ara", "compile-riscv-tests"]
@@ -450,6 +452,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-20.04
     strategy:
+    fail-fast: false
       matrix:
         ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["compile-ara", "compile-apps"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
   simulate:
     runs-on: ubuntu-20.04
     strategy:
-    fail-fast: false
+      fail-fast: false
       matrix:
         app:        [hello_world, imatmul, fmatmul, iconv2d, fconv2d, fconv3d, jacobi2d, dropout, fft, dwt, exp, softmax, dotproduct, fdotproduct, pathfinder, roi_align]
         ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
@@ -319,7 +319,7 @@ jobs:
   riscv-tests-simv:
     runs-on: ubuntu-20.04
     strategy:
-    fail-fast: false
+      fail-fast: false
       matrix:
         ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["compile-ara", "compile-riscv-tests"]
@@ -452,7 +452,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-20.04
     strategy:
-    fail-fast: false
+      fail-fast: false
       matrix:
         ara_config: [2_lanes, 4_lanes, 8_lanes, 16_lanes]
     needs: ["compile-ara", "compile-apps"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,7 +23,7 @@
 	url = https://github.com/pulp-platform/common_verification.git
 [submodule "hardware/deps/cva6"]
 	path = hardware/deps/cva6
-	url = https://github.com/pulp-platform/cva6.git
+	url = https://github.com/10x-Engineers/cva6-pulp.git
 [submodule "toolchain/newlib"]
 	path = toolchain/newlib
 	url = https://sourceware.org/git/newlib-cygwin.git

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -108,7 +108,15 @@ module ara import ara_pkg::*; #(
     .core_st_pending_o (core_st_pending ),
     .load_complete_i   (load_complete   ),
     .store_complete_i  (store_complete  ),
-    .store_pending_i   (store_pending   )
+    .store_pending_i   (store_pending   ),
+    //Interface with address generator
+    .ara_mmu_req_i      (ara_mmu_req    ),
+    .ara_vaddr_i        (ara_vaddr      ),
+    .ara_is_store_i     (ara_is_store   ),
+
+    .ara_mmu_valid_o    (ara_mmu_valid  ),
+    .ara_paddr_o        (ara_paddr      ),
+    .ara_exception_o    (ara_exception  )
   );
 
   /////////////////
@@ -307,6 +315,14 @@ module ara import ara_pkg::*; #(
   logic vldu_mask_ready;
   logic vstu_mask_ready;
 
+  logic                   ara_mmu_req;
+  logic [riscv::VLEN-1:0] ara_vaddr;
+  logic                   ara_is_store;
+
+  logic                   ara_mmu_valid;
+  logic [riscv::PLEN-1:0] ara_paddr;
+  ariane_pkg::exception_t ara_exception;
+
   vlsu #(
     .NrLanes     (NrLanes     ),
     .AxiDataWidth(AxiDataWidth),
@@ -354,6 +370,14 @@ module ara import ara_pkg::*; #(
     .addrgen_operand_target_fu_i(sldu_addrgen_operand_target_fu                        ),
     .addrgen_operand_valid_i    (sldu_addrgen_operand_valid                            ),
     .addrgen_operand_ready_o    (addrgen_operand_ready                                 ),
+    // MMU interface
+    .ara_mmu_req_o              (ara_mmu_req                                           ),
+    .ara_vaddr_o                (ara_vaddr                                             ),
+    .ara_is_store_o             (ara_is_store                                          ),
+
+    .ara_mmu_valid_i            (ara_mmu_valid                                         ),
+    .ara_paddr_i                (ara_paddr                                             ),
+    .ara_exception_i            (ara_exception                                         ),
     // Load unit
     .ldu_result_req_o           (ldu_result_req                                        ),
     .ldu_result_addr_o          (ldu_result_addr                                       ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -40,7 +40,15 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     output logic                                 core_st_pending_o,
     input  logic                                 load_complete_i,
     input  logic                                 store_complete_i,
-    input  logic                                 store_pending_i
+    input  logic                                 store_pending_i,
+
+    //Interface with address generator
+    input  logic                                  ara_mmu_req_i,
+    input  logic [riscv::VLEN-1:0]                ara_vaddr_i,
+    input  logic                                  ara_is_store_i,
+    output logic                                  ara_mmu_valid_o,
+    output logic [riscv::PLEN-1:0]                ara_paddr_o,
+    output ariane_pkg::exception_t                ara_exception_o
   );
 
   import cf_math_pkg::idx_width;
@@ -48,6 +56,11 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
   `include "common_cells/registers.svh"
 
   assign core_st_pending_o = acc_req_i.store_pending;
+
+  //MMU Interface
+  assign ara_mmu_valid_o = acc_req_i.mmu_valid;
+  assign ara_paddr_o     = acc_req_i.paddr;
+  assign ara_exception_o = acc_req_i.exception;
 
   ////////////
   //  CSRs  //
@@ -279,6 +292,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       store_complete: store_zero_vl | store_complete_q,
       store_pending : store_pending_i,
       fflags_valid  : |fflags_ex_valid_i,
+      mmu_req       : ara_mmu_req_i,
+      vaddr         : ara_vaddr_i,
+      is_store      : ara_is_store_i,
       default       : '0
     };
 

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -502,7 +502,9 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
         end
       end
       AXI_ADDRGEN_WAIT_MMU: begin
+        ara_mmu_req_o = 1'b1;
         if(ara_mmu_valid_i) begin
+          ara_mmu_req_o = 1'b0;
           axi_addrgen_state_d = core_st_pending_i ? AXI_ADDRGEN_WAITING : AXI_ADDRGEN_REQUESTING;
           ara_paddr_d = ara_paddr;
 
@@ -558,6 +560,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
           end
           else begin
             axi_addrgen_state_d = AXI_ADDRGEN_WAITING;
+            ara_mmu_req_o = 1'b0;
         end
         end
       end

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -486,7 +486,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     case (axi_addrgen_state_q)
       AXI_ADDRGEN_IDLE: begin
         if (addrgen_req_valid) begin
-          axi_addrgen_d       = addrgen_req; 
+          axi_addrgen_d       = addrgen_req;
           axi_addrgen_state_d = AXI_ADDRGEN_WAIT_MMU;
           if (state_q != ADDRGEN_IDX_OP) begin
             ara_mmu_req_o = 1'b1;
@@ -620,7 +620,6 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
         if (axi_addrgen_queue_empty || (axi_addrgen_req_o.is_load && axi_addrgen_q.is_load) ||
             (~axi_addrgen_req_o.is_load && ~axi_addrgen_q.is_load)) begin
           if (!axi_addrgen_queue_full && axi_ax_ready) begin
-            
             if (axi_addrgen_q.is_burst) begin
 
               /////////////////////////
@@ -684,7 +683,6 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
                 ((aligned_end_addr_q[11:0] - ara_paddr_q[11:0] + 1)
                   >> int'(axi_addrgen_q.vew)))
                 axi_addrgen_d.len = 0;
-              
 
               // Finished generating AXI requests
               if (axi_addrgen_d.len == 0) begin
@@ -762,7 +760,6 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
                 ara_vaddr_o = {ara_paddr_d};
                 axi_addrgen_state_d = AXI_ADDRGEN_WAIT_MMU;
               end
-              
             end else begin
 
               //////////////////////

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -66,7 +66,15 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     output elen_t     [NrLanes-1:0] ldu_result_wdata_o,
     output strb_t     [NrLanes-1:0] ldu_result_be_o,
     input  logic      [NrLanes-1:0] ldu_result_gnt_i,
-    input  logic      [NrLanes-1:0] ldu_result_final_gnt_i
+    input  logic      [NrLanes-1:0] ldu_result_final_gnt_i,
+    // MMU interface
+    output logic                          ara_mmu_req_o,
+    output logic [riscv::VLEN-1:0]        ara_vaddr_o,
+    output logic                          ara_is_store_o,
+
+    input logic                           ara_mmu_valid_i,
+    input logic [riscv::PLEN-1:0]         ara_paddr_i,
+    input ariane_pkg::exception_t         ara_exception_i
   );
 
   ///////////////////
@@ -140,6 +148,14 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .addrgen_operand_target_fu_i(addrgen_operand_target_fu_i),
     .addrgen_operand_valid_i    (addrgen_operand_valid_i    ),
     .addrgen_operand_ready_o    (addrgen_operand_ready_o    ),
+    // MMU interface
+    .ara_mmu_req_o              (ara_mmu_req_o              ),
+    .ara_vaddr_o                (ara_vaddr_o                ),
+    .ara_is_store_o             (ara_is_store_o             ),
+
+    .ara_mmu_valid_i            (ara_mmu_valid_i            ),
+    .ara_paddr_i                (ara_paddr_i                ),
+    .ara_exception_i            (ara_exception_i            ),
     // Interface with the load/store units
     .axi_addrgen_req_o          (axi_addrgen_req            ),
     .axi_addrgen_req_valid_o    (axi_addrgen_req_valid      ),


### PR DESCRIPTION
This PR is adding the MMU support in ARA.

## Changelog

### Added

- Memory Management Unit Support is added to ARA

### Changed

- Address generator unit of ARA has been changes to send request to ariane's MMU for address translation
- Aribter is added in CVA6's Load store unit to arbitrate the scalar and vector translation requests
- The hash of CVA6 is updated to the hash of [branch](https://github.com/10x-Engineers/cva6-pulp/tree/ara-mmu-support) having the interface for the ARA MMU request

## Checklist

- [x] Automated tests pass
- [ ] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
