### PR TITLE
[hardware] NaN-box the scalar value before forwarding back to CVA6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix `vslideup` wrong counter trimming
  - Reset gating registers before the integer multipliers in `vmfpu`
  - Fix narrowing for `vnclip` and `vnclipu`
+ - NaN-box the scalar value before forwarding back to CVA6
 
 ### Added
 


### PR DESCRIPTION
The floating-point scalar moves did not NaN-box the scalar forwarded back to CVA6 for 32- and 16-bit values.
Now they do.

## Changelog

### Fixed

- Fix scalar-NaN boxing for floating-point scalar moves.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

