### PR TITLE
[SW] Fix kernel performance calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,7 +579,7 @@ jobs:
         for kernel in fdotproduct dotproduct; do
           > ${kernel}.benchmark
           for nr_lanes in 2 4 8 16; do
-            cat ${kernel}_${nr_lanes}.benchmark >> ${kernel}.benchmark
+            cat ${kernel}_${nr_lanes}_bar_plots.benchmark >> ${kernel}.benchmark
           done
           python scripts/process_dotp.py ${kernel} ${kernel}.benchmark ${kernel}
           tar -cvf ${kernel}.tar $(find . -name "${kernel}_*.png")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
+
+### Fixed
+
+ - Fix dump vtrace script for vsetvli instructions without x0 (ideal dispatcher)
+ - Fix Pathfinder and FFT performance
+
+### Added
+
+ - Plot kernels-Vl performance plot
+ - Print I$/D$ stall metrics
+
+### Changed
+
+ - Optimize Jacobi2d
+ - Benchmark only the vector kernel in roi_align
+ - Improve cache warming functions
+ - [f]dotproduct works on the vector length in elements
+ - Optimize DWT
+ - Fix pathfinder performance
+
+## 3.0.0 - 2023-09-08
 
 ### Fixed
 

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -64,12 +64,15 @@ patch-spike-crt0: $(spike_env_dir)/benchmarks/common/crt.S
 
 # Only some applications need to generate and then compile the data file
 # Generate a dummy data file for applications that do not need it
+ifeq ($(old_data),1)
+else
 define app_gen_data_template
 .PHONY: $1/data.S
 $1/data.S:
 	cd $1 && if [ -d script ]; then ${PYTHON} script/gen_data.py $(subst ",,$(def_args_$1)) > data.S ; else touch data.S; fi
 endef
 $(foreach app,$(APPS),$(eval $(call app_gen_data_template,$(app))))
+endif
 
 define vector_trace_template
 ideal_dispatcher/vtrace/$1.vtrace: bin/$1.spike $(VTRACE_SCRIPTS)

--- a/apps/benchmarks/benchmark/dotproduct.bmark
+++ b/apps/benchmarks/benchmark/dotproduct.bmark
@@ -71,47 +71,35 @@ int main() {
 #endif
 
   uint64_t v_sw_runtime;
+  size_t avl = vsize;
 
   HW_CNT_READY;
   // This benchmark is executed for one dtype only to ensure the same initial conditions.
   // If not, Ara would reshuffle some registers because of different EEWs and this would
   // lead to artificial slow-down
   if (sizeof(r) == 8) {
-    size_t avl = vsize >> 3;
     start_timer();
     res64_v = dotp_v64b(v64a, v64b, avl);
     stop_timer();
-    v_sw_runtime = get_timer();
-    // [kernel]: lanes vsize vsew cycles
-    printf("[dotproduct]: %u %u %u\n", NR_LANES, vsize, 8);
   } else
   if (sizeof(r) == 4) {
-    size_t avl = vsize >> 2;
     start_timer();
     res32_v = dotp_v32b(v32a, v32b, avl);
     stop_timer();
-    v_sw_runtime = get_timer();
-    // [kernel]: lanes vsize vsew cycles
-    printf("[dotproduct]: %u %u %u\n", NR_LANES, vsize, 4);
   } else
   if (sizeof(r) == 2) {
-    size_t avl = vsize >> 1;
     start_timer();
     res16_v = dotp_v16b(v16a, v16b, avl);
     stop_timer();
-    v_sw_runtime = get_timer();
-    // [kernel]: lanes vsize vsew cycles
-    printf("[dotproduct]: %u %u %u\n", NR_LANES, vsize, 2);
   } else
   if (sizeof(r) == 1) {
-    size_t avl = vsize >> 0;
     start_timer();
     res8_v = dotp_v8b(v8a, v8b, avl);
     stop_timer();
-    v_sw_runtime = get_timer();
-    // [kernel]: lanes vsize vsew cycles
-    printf("[dotproduct]: %u %u %u\n", NR_LANES, vsize, 1);
   }
+
+  v_sw_runtime = get_timer();
+  printf("[sw-cycles]: %ld\n", v_sw_runtime);
 
   return 0;
 }

--- a/apps/benchmarks/benchmark/fconv3d.bmark
+++ b/apps/benchmarks/benchmark/fconv3d.bmark
@@ -40,8 +40,17 @@ extern int64_t CH;
 extern int64_t F;
 
 void warm_caches(uint64_t heat) {
+  volatile double buf;
+
   for (uint64_t k = 0; k < heat; ++k)
     fconv3d_CHx7x7(o, i, f, M, N, CH, F);
+// The following artificial warming ensures, with a larger cache,
+// not to experience any cache misses
+#ifdef AD_HOC_WARMING
+  for (uint64_t k = 0; k < F*F*CH; ++k)
+    buf = (volatile double) *(&(f[k]));
+  fconv3d_CHx7x7_warm(o, i, f, M, N, CH, F);
+#endif
 }
 
 int main() {

--- a/apps/benchmarks/benchmark/fdotproduct.bmark
+++ b/apps/benchmarks/benchmark/fdotproduct.bmark
@@ -68,38 +68,30 @@ int main() {
 #endif
 
   uint64_t v_sw_runtime;
+  size_t avl = vsize;
 
   HW_CNT_READY;
   // This benchmark is executed for one dtype only to ensure the same initial conditions.
   // If not, Ara would reshuffle some registers because of different EEWs and this would
   // lead to artificial slow-down
   if (sizeof(r) == 8) {
-    size_t avl = vsize >> 3;
     start_timer();
     res64_v = fdotp_v64b(v64a, v64b, avl);
     stop_timer();
-    v_sw_runtime = get_timer();
-    // [kernel]: lanes vsize vsew cycles
-    printf("[fdotproduct]: %u %u %u\n", NR_LANES, vsize, 8);
   } else
   if (sizeof(r) == 4) {
-    size_t avl = vsize >> 2;
     start_timer();
     res32_v = fdotp_v32b(v32a, v32b, avl);
     stop_timer();
-    v_sw_runtime = get_timer();
-    // [kernel]: lanes vsize vsew cycles
-    printf("[fdotproduct]: %u %u %u\n", NR_LANES, vsize, 4);
   } else
   if (sizeof(r) == 2) {
-    size_t avl = vsize >> 1;
     start_timer();
     res16_v = fdotp_v16b(v16a, v16b, avl);
     stop_timer();
-    v_sw_runtime = get_timer();
-    // [kernel]: lanes vsize vsew cycles
-    printf("[fdotproduct]: %u %u %u\n", NR_LANES, vsize, 2);
   }
+
+  v_sw_runtime = get_timer();
+  printf("[sw-cycles]: %ld\n", v_sw_runtime);
 
   return 0;
 }

--- a/apps/benchmarks/benchmark/fmatmul.bmark
+++ b/apps/benchmarks/benchmark/fmatmul.bmark
@@ -42,12 +42,14 @@ void warm_caches(uint64_t heat) {
 
   for (uint64_t k = 0; k < heat; ++k)
     fmatmul(c, a, b, M, N, P);
+#ifdef AD_HOC_WARMING
     // Vector stores have invalidated the A mtx cache lines!
     // Fetch them again
     for (int m = 0; m < M; ++m) {
       buf = (volatile double) *a_;
       a_ += N;
     }
+#endif
 }
 
 int main() {

--- a/apps/benchmarks/benchmark/fmatmul.bmark
+++ b/apps/benchmarks/benchmark/fmatmul.bmark
@@ -37,8 +37,17 @@ extern double b[] __attribute__((aligned(32 * NR_LANES), section(".l2")));
 extern double c[] __attribute__((aligned(32 * NR_LANES), section(".l2")));
 
 void warm_caches(uint64_t heat) {
+  volatile double *a_ = a;
+  volatile double buf;
+
   for (uint64_t k = 0; k < heat; ++k)
     fmatmul(c, a, b, M, N, P);
+    // Vector stores have invalidated the A mtx cache lines!
+    // Fetch them again
+    for (int m = 0; m < M; ++m) {
+      buf = (volatile double) *a_;
+      a_ += N;
+    }
 }
 
 int main() {

--- a/apps/benchmarks/benchmark/jacobi2d.bmark
+++ b/apps/benchmarks/benchmark/jacobi2d.bmark
@@ -102,8 +102,15 @@ extern DATA_TYPE A_s[] __attribute__((aligned(4 * NR_LANES), section(".l2")));
 extern DATA_TYPE B_s[] __attribute__((aligned(4 * NR_LANES), section(".l2")));
 
 void warm_caches(uint64_t heat, DATA_TYPE* A_fixed_v, DATA_TYPE* B_fixed_v) {
+
+  volatile double buf;
+
   for (uint64_t k = 0; k < heat; ++k)
     j2d_v(R, C, A_fixed_v, B_fixed_v, TSTEPS);
+#ifdef AD_HOC_WARMING
+  for (uint64_t k = 0; k < R*C; ++k)
+    buf = (volatile double)* &(A_fixed_v[k]);
+#endif
 }
 
 int main() {
@@ -117,7 +124,7 @@ int main() {
 
 #ifndef SPIKE
   // Warm-up caches
-  warm_caches(WARM_CACHES_ITER, A_fixed_s, B_fixed_s);
+  warm_caches(WARM_CACHES_ITER, A_fixed_v, B_fixed_s);
 #endif
 
   // Measure vector kernel execution

--- a/apps/benchmarks/benchmark/roi_align.bmark
+++ b/apps/benchmarks/benchmark/roi_align.bmark
@@ -42,10 +42,7 @@ extern float crops_data_vec[];
 
 void warm_caches(uint64_t heat) {
   for (uint64_t k = 0; k < heat; ++k)
-    CropAndResizePerBox_BHWC_vec(image_data, BATCH_SIZE, DEPTH, IMAGE_HEIGHT,
-                               IMAGE_WIDTH, boxes_data, box_index_data, 0,
-                               N_BOXES, crops_data, CROP_HEIGHT, CROP_WIDTH,
-                               EXTRAPOLATION_VALUE);
+    roi_align_fake_kernel_asm(image_data, crops_data_vec, 0, 0, 0, 0, DEPTH);
 }
 
 int main() {
@@ -60,10 +57,7 @@ int main() {
   // Vector benchmark
   HW_CNT_READY;
   start_timer();
-  CropAndResizePerBox_BHWC_vec(image_data, BATCH_SIZE, DEPTH, IMAGE_HEIGHT,
-                               IMAGE_WIDTH, boxes_data, box_index_data, 0,
-                               N_BOXES, crops_data_vec, CROP_HEIGHT, CROP_WIDTH,
-                               EXTRAPOLATION_VALUE);
+  roi_align_fake_kernel_asm(image_data, crops_data_vec, 0, 0, 0, 0, DEPTH);
   stop_timer();
 
   runtime = get_timer();

--- a/apps/common/default_args.mk
+++ b/apps/common/default_args.mk
@@ -1,31 +1,31 @@
 # Default app parameters
 
 # Matrix sizes
-def_args_imatmul     = "128 128 128"
-def_args_fmatmul     = "128 128 128"
+def_args_imatmul     ?= "128 128 128"
+def_args_fmatmul     ?= "128 128 128"
 # Matrix size, filter size
-def_args_iconv2d     = "112 7"
-def_args_fconv2d     = "112 7"
-def_args_fconv3d     = "112 7"
+def_args_iconv2d     ?= "112 7"
+def_args_fconv2d     ?= "112 7"
+def_args_fconv3d     ?= "112 7"
 # Vector size
-def_args_fdotproduct = "512"
+def_args_fdotproduct ?= "512"
 # Vector size
-def_args_dotproduct  = "512"
+def_args_dotproduct  ?= "512"
 # Matrix padded size 0, matrix padded size 1, onlyvec
-def_args_jacobi2d    = "130 130"
+def_args_jacobi2d    ?= "130 130"
 # Vector size
-def_args_dropout     = "1024"
+def_args_dropout     ?= "1024"
 # Vector size, data-type
-def_args_fft         = "64 float32"
+def_args_fft         ?= "64 float32"
 # Vector size
-def_args_dwt         = "512"
+def_args_dwt         ?= "512"
 # Vector size
-def_args_exp         = "512"
-def_args_cos         = "512"
-def_args_log         = "512"
+def_args_exp         ?= "128"
+def_args_cos         ?= "512"
+def_args_log         ?= "512"
 # Channels and Inner size
-def_args_softmax     = "3 256"
+def_args_softmax     ?= "3 256"
 # Number of steps and width of the vector
-def_args_pathfinder  = "1 1024 64"
+def_args_pathfinder  ?= "1 1024 64"
 # Batch_size, depth, height, width, n_boxes (in total), crop_h, crop_w
-def_args_roi_align   = "1 32 4 4 4 2 2"
+def_args_roi_align   ?= "1 32 4 4 4 2 2"

--- a/apps/common/runtime.mk
+++ b/apps/common/runtime.mk
@@ -65,8 +65,10 @@ SPIKE_CCFLAGS ?= -DPREALLOCATE=1 -DSPIKE=1 $(SPIKE_INC)
 SPIKE_LDFLAGS ?= -nostdlib -T$(spike_env_dir)/benchmarks/common/test.ld
 RISCV_SIM     ?= $(ISA_SIM_INSTALL_DIR)/bin/spike
 RISCV_SIM_MOD ?= $(ISA_SIM_MOD_INSTALL_DIR)/bin/spike
-RISCV_SIM_OPT ?= --isa=rv64gcv_zfh --varch="vlen:4096,elen:64"
-RISCV_SIM_MOD_OPT ?= --isa=rv64gcv_zfh --varch="vlen:4096,elen:64" -d
+# VLEN should be lower or equal than 4096 because of spike restrictions
+vlen_spike := $(shell vlen=$$(grep vlen $(ARA_DIR)/config/$(config).mk | cut -d" " -f3) && echo "$$(( $$vlen < 4096 ? $$vlen : 4096 ))")
+RISCV_SIM_OPT ?= --isa=rv64gcv_zfh --varch="vlen:$(vlen_spike),elen:64"
+RISCV_SIM_MOD_OPT ?= --isa=rv64gcv_zfh --varch="vlen:$(vlen_spike),elen:64" -d
 
 # Python
 PYTHON ?= python3

--- a/apps/dotproduct/script/gen_data.py
+++ b/apps/dotproduct/script/gen_data.py
@@ -40,10 +40,10 @@ else:
   # Default: no stripmine
   vsize = 64
 
-avl64 = int(vsize / 8)
-avl32 = int(vsize / 4)
-avl16 = int(vsize / 2)
-avl8  = int(vsize / 1)
+avl64 = int(vsize)
+avl32 = int(vsize)
+avl16 = int(vsize)
+avl8  = int(vsize)
 
 # Create the vectors
 v64a = np.random.randint(-2**(50), high=2**(50)-1, size=avl64, dtype=np.int64)

--- a/apps/dwt/kernel/wavelet.c
+++ b/apps/dwt/kernel/wavelet.c
@@ -21,8 +21,8 @@
 #include <stdio.h>
 
 // Reduce scalar code overhead for problems that can fit with LMUL == 4.
-// The worst case if with 2 lanes, in which the problem size should be lower than
-// 2k float numbers.
+// The worst case if with 2 lanes, in which the problem size should be lower
+// than 2k float numbers.
 #define SMALL_PROBLEM
 
 extern int64_t event_trigger;
@@ -110,10 +110,9 @@ static inline void dwt_step_vector(const gsl_wavelet *w, float *samples,
     // Segment load the vectors. ToDo: check if vl/2 is correct
     vlseg2e32_v_f32m4(sample_vec_0, sample_vec_1, samples_r, vl / 2);
 #else
-    // Strided load (inefficient!)
-    sample_vec_0 = vlse32_v_f32m4(samples_r, 2 * sizeof(*samples_r), vl / 2);
-    sample_vec_1 =
-        vlse32_v_f32m4(samples_r + 1, 2 * sizeof(*samples_r), vl / 2);
+  // Strided load (inefficient!)
+  sample_vec_0 = vlse32_v_f32m4(samples_r, 2 * sizeof(*samples_r), vl / 2);
+  sample_vec_1 = vlse32_v_f32m4(samples_r + 1, 2 * sizeof(*samples_r), vl / 2);
 #endif
 
     // First implementation

--- a/apps/fconv3d/fconv3d.h
+++ b/apps/fconv3d/fconv3d.h
@@ -29,10 +29,10 @@ void fconv3d_CHx7x7_block(double *o, double *i, double *f, int64_t M, int64_t N,
                           int64_t n_, int64_t C, int64_t F);
 
 void fconv3d_CHx7x7_warm(double *o, double *i, double *f, int64_t M, int64_t N,
-                    int64_t C, int64_t F);
+                         int64_t C, int64_t F);
 
 void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
-                          int64_t n_, int64_t C, int64_t F);
+                  int64_t n_, int64_t C, int64_t F);
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 

--- a/apps/fconv3d/fconv3d.h
+++ b/apps/fconv3d/fconv3d.h
@@ -28,6 +28,12 @@ void fconv3d_CHx7x7(double *o, double *i, double *f, int64_t M, int64_t N,
 void fconv3d_CHx7x7_block(double *o, double *i, double *f, int64_t M, int64_t N,
                           int64_t n_, int64_t C, int64_t F);
 
+void fconv3d_CHx7x7_warm(double *o, double *i, double *f, int64_t M, int64_t N,
+                    int64_t C, int64_t F);
+
+void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
+                          int64_t n_, int64_t C, int64_t F);
+
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 // Threshold for FP numbers comparison during the final check

--- a/apps/fconv3d/fconv3d_3x7x7.c
+++ b/apps/fconv3d/fconv3d_3x7x7.c
@@ -76,7 +76,7 @@ void fconv3d_CHx7x7(double *o, double *i, double *f, int64_t M, int64_t N,
 }
 
 void fconv3d_CHx7x7_warm(double *o, double *i, double *f, int64_t M, int64_t N,
-                    int64_t C, int64_t F) {
+                         int64_t C, int64_t F) {
 
   unsigned long int block_size_n;
 
@@ -906,9 +906,8 @@ void fconv3d_CHx7x7_block(double *o, double *i, double *f, int64_t M, int64_t N,
   asm volatile("vse64.v  v28, (%0); add %0, %0, %1" : "+&r"(o) : "r"(ldo));
 }
 
-
 void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
-                          int64_t n_, int64_t C, int64_t F) {
+                  int64_t n_, int64_t C, int64_t F) {
 
   // Helper variables
   int64_t ldo = N << 3;
@@ -1006,7 +1005,6 @@ void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
     i_slide_ptr_1 = i__ + n_ + 1 * (N + F - 1);
     i_slide_ptr_2 = i__ + n_ + 2 * (N + F - 1);
 
-
     // Main kernel, unrolled by 2
     for (int k = 0; k < F / 2; ++k) {
       // Two base indexes because of the unrolling
@@ -1042,7 +1040,6 @@ void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
       asm volatile("vfslide1down.vf v6, v4, %0" ::"f"(*i_slide_ptr_1++));
 
       asm volatile("vfslide1down.vf v10, v8, %0" ::"f"(*i_slide_ptr_2++));
-
     }
 
     // The very last iterations require mixing the instructions with the store
@@ -1058,7 +1055,6 @@ void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
 
   // Reuse preloaded coefficients
   // Buffer the next coefficients for faster use
-
 
   // Bump the input ptr
   i_ += 3 * (N + F - 1);
@@ -1124,42 +1120,40 @@ void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
 
       if (ch != C - 1) {
         int64_t base_idx_0 = (ch + 1) * fch_len;
-
       }
     }
-   }
+  }
 
-    // Bump the input ptr
-    i_ += N + F - 1;
+  // Bump the input ptr
+  i_ += N + F - 1;
 
 #ifdef VCD_DUMP
-    // Stop dumping VCD
-    event_trigger = -1;
+  // Stop dumping VCD
+  event_trigger = -1;
 #endif
 
-    //////////////
-    // UNROLL 1 //
-    //////////////
+  //////////////
+  // UNROLL 1 //
+  //////////////
 
-    // Loop on the channels
-    for (int ch = 0; ch < C; ++ch) {
+  // Loop on the channels
+  for (int ch = 0; ch < C; ++ch) {
 
-      // Point to the first element of the channel ch
-      i__ = i_ + ch * ich_len;
+    // Point to the first element of the channel ch
+    i__ = i_ + ch * ich_len;
 
-      // Start calculating the next pointers to the elements to be slided in
-      i_slide_ptr_1 = i__ + n_;
+    // Start calculating the next pointers to the elements to be slided in
+    i_slide_ptr_1 = i__ + n_;
 
-      for (int k = 0; k < F / 2; ++k) {
-        // Two base indexes because of the unrolling
-        // Point to the first element of the current column (k) of the current
-        // channel (ch) of the filter (f)
-        int64_t base_idx_0 = (2 * k + 2) + (ch * fch_len);
-        // Point to the first element of the current column (k+1) of the current
-        // channel (ch) of the filter (f)
-        int64_t base_idx_1 = (2 * k + 1) + (ch * fch_len);
+    for (int k = 0; k < F / 2; ++k) {
+      // Two base indexes because of the unrolling
+      // Point to the first element of the current column (k) of the current
+      // channel (ch) of the filter (f)
+      int64_t base_idx_0 = (2 * k + 2) + (ch * fch_len);
+      // Point to the first element of the current column (k+1) of the current
+      // channel (ch) of the filter (f)
+      int64_t base_idx_1 = (2 * k + 1) + (ch * fch_len);
     }
-
 
     // Bump the input ptr
     i_ += N + F - 1;
@@ -1196,7 +1190,7 @@ void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
       if ((k | ch) == 0)
         asm volatile("vfmul.vf v28, v0, %0" ::"f"(f[0 + base_idx_0]));
       else
-      asm volatile("vfslide1down.vf v6, v4, %0" ::"f"(*i_slide_ptr_1++));
+        asm volatile("vfslide1down.vf v6, v4, %0" ::"f"(*i_slide_ptr_1++));
       asm volatile("vfslide1down.vf v10, v8, %0" ::"f"(*i_slide_ptr_2++));
       asm volatile("vfslide1down.vf v14, v12, %0" ::"f"(*i_slide_ptr_3++));
 
@@ -1205,9 +1199,7 @@ void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
       asm volatile("vfslide1down.vf v8, v10, %0" ::"f"(*i_slide_ptr_2++));
       asm volatile("vfslide1down.vf v12, v14, %0" ::"f"(*i_slide_ptr_3++));
     }
-
   }
-
 
   // Bump the input ptr
   i_ += 4 * (N + F - 1);
@@ -1250,7 +1242,6 @@ void fconv3d_warm(double *o, double *i, double *f, int64_t M, int64_t N,
     }
   }
 }
-
 
 /*
   ////////////////////

--- a/apps/fdotproduct/script/gen_data.py
+++ b/apps/fdotproduct/script/gen_data.py
@@ -40,9 +40,9 @@ else:
   # Default: no stripmine
   vsize = 64
 
-avl64 = int(vsize / 8)
-avl32 = int(vsize / 4)
-avl16 = int(vsize / 2)
+avl64 = int(vsize)
+avl32 = int(vsize)
+avl16 = int(vsize)
 
 # Create the vectors
 v64a = np.random.rand(avl64).astype(np.float64)

--- a/apps/fft/main.c
+++ b/apps/fft/main.c
@@ -192,7 +192,7 @@ int main() {
   stop_timer();
   runtime = get_timer();
 
-  float perf = (float)10.0 * NFFT * (31 - __builtin_clz(NFFT)) / runtime;
+  float perf = (float)5.0 * NFFT * (31 - __builtin_clz(NFFT)) / runtime;
   float max_perf = 6.0 / 5.0 * NR_LANES * 8.0 / sizeof(float);
 
   printf("Performance: %f. Max perf: %f. Actual performance is %f%% of max.\n",

--- a/apps/ideal_dispatcher/scripts/dump_vtrace.py
+++ b/apps/ideal_dispatcher/scripts/dump_vtrace.py
@@ -123,7 +123,11 @@ def updateRf(regline, reg_width, rf):
 def addRs2(disasm, args):
   rs2 = ''
   if (disasm == 'vsetvl'):
-    print('ERROR: vlse or vsse found, implement addRs2 function!')
+    print('ERROR: vsetlvl, implement addRs2 function!')
+  # Delete return register when vsetvli has nonzero retreg
+  if (disasm == 'vsetvli' and args[0] != 'zero'):
+    del args[0]
+    return ''
   if ('vlse' in disasm or 'vsse' in disasm):
     for reg in xrf:
       if (reg == args[-1]):

--- a/apps/jacobi2d/kernel/jacobi2d.c
+++ b/apps/jacobi2d/kernel/jacobi2d.c
@@ -83,11 +83,13 @@ void j2d_s(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B,
         B[i * c + j] =
             (0.2) * (A[i * c + j] + A[i * c + j - 1] + A[i * c + j + 1] +
                      A[(i + 1) * c + j] + A[(i - 1) * c + j]);
+#ifdef DOUBLE_BUFFERING
     for (uint32_t i = 1; i < r - 1; i++)
       for (uint32_t j = 1; j < c - 1; j++)
         A[i * c + j] =
             (0.2) * (B[i * c + j] + B[i * c + j - 1] + B[i * c + j + 1] +
                      B[(i + 1) * c + j] + B[(i - 1) * c + j]);
+#endif
   }
 }
 
@@ -95,7 +97,9 @@ void j2d_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B,
            uint64_t tsteps) {
   for (uint32_t t = 0; t < tsteps; t++) {
     j2d_kernel_asm_v(r, c, A, B);
+#ifdef DOUBLE_BUFFERING
     j2d_kernel_asm_v(r, c, B, A);
+#endif
   }
 }
 

--- a/apps/jacobi2d/kernel/jacobi2d.c
+++ b/apps/jacobi2d/kernel/jacobi2d.c
@@ -74,6 +74,7 @@ WITH ACCESS OR USE OF THE SOFTWARE.
 // Author: Matteo Perotti, ETH Zurich, <mperotti@iis.ee.ethz.ch>
 
 #include "jacobi2d.h"
+#define DOUBLE_BUFFERING
 
 void j2d_s(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B,
            uint64_t tsteps) {

--- a/apps/jacobi2d/kernel/jacobi2d.c
+++ b/apps/jacobi2d/kernel/jacobi2d.c
@@ -143,6 +143,228 @@ void j2d_kernel_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
 // 1) Preload the coefficients, before each vstore
 // 2) Eliminate WAW and WAR hazards
 // 3) Unroll the loop and use multiple buffers
+// 4) Optimize pointers
+void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
+  DATA_TYPE izq_0, izq_1, izq_2;
+  DATA_TYPE der_0, der_1, der_2;
+  uint32_t size_x = c - 2;
+  uint32_t size_y = r - 2;
+  // Simplify pointer calc
+  uint32_t sc_ptr_0, sc_ptr_1;
+  uint32_t mtx_ptr_0, mtx_ptr_1;
+
+  // Avoid division. 1/5 == 0.2
+  double five_ = 0.2;
+
+  size_t gvl;
+
+  asm volatile("vsetvli %0, %1, e64, m4, ta, ma" : "=r"(gvl) : "r"(size_x));
+
+  for (uint32_t j = 1; j <= size_x; j = j + gvl) {
+    asm volatile("vsetvli %0, %1, e64, m4, ta, ma"
+                 : "=r"(gvl)
+                 : "r"(size_x - j + 1));
+    mtx_ptr_0 = j; // 0 * c + j
+    asm volatile("vle64.v v0, (%0)" ::"r"(&A[mtx_ptr_0])); // v0 top
+    mtx_ptr_1 = j + c; // 1 * c + j
+    asm volatile("vle64.v v4, (%0)" ::"r"(&A[mtx_ptr_1])); // v4 middle
+    mtx_ptr_0 = mtx_ptr_1 + c; // 2 * c + j
+    asm volatile("vle64.v v8, (%0)" ::"r"(&A[mtx_ptr_0])); // v8 bottom
+
+    // Look ahead and load the next coefficients
+    // Do it before vector stores
+    sc_ptr_0 = mtx_ptr_1 - 1; // 1 * c + j - 1
+    izq_0 = A[sc_ptr_0];
+    sc_ptr_1 = mtx_ptr_1 + gvl; // 1 * c + j + gvl
+    der_0 = A[sc_ptr_1];
+
+    // mtx_ptr_0 = 2 * c + j
+    // mtx_ptr_1 = 1 * c + j
+    // sc_ptr_0  = 1 * c + j - 1
+    // sc_ptr_1  = 1 * c + j + gvl
+
+    for (uint32_t i = 1; i <= size_y; i += 3) {
+#ifdef VCD_DUMP
+      // Start dumping VCD
+      if (i == 7)
+        event_trigger = +1;
+      // Stop dumping VCD
+      if (i == 13)
+        event_trigger = -1;
+#endif
+      // mtx_ptr_0 = (i + 1) * c + j
+      // mtx_ptr_1 = i * c + j
+      // sc_ptr_0  = i * c + j - 1
+      // sc_ptr_1  = i * c + j + gvl
+
+      asm volatile("vfslide1up.vf v24, v4, %0" ::"f"(izq_0));
+      asm volatile("vfslide1down.vf v28, v4, %0" ::"f"(der_0));
+      asm volatile("vfadd.vv v12, v4, v0");   // middle - top
+      mtx_ptr_0 += c; // (i + 2) * c + j
+      asm volatile("vfadd.vv v12, v12, v8");  // bottom
+      sc_ptr_0 += c; // (i + 1) * c + j - 1
+      asm volatile("vfadd.vv v12, v12, v24"); // left
+      if ((i + 1) <= size_y) {
+        asm volatile(
+            "vle64.v v0, (%0)" ::"r"(&A[mtx_ptr_0])); // v0 top
+      }
+      asm volatile("vfadd.vv v12, v12, v28"); // right
+      sc_ptr_1 += c; // (i + 1) * c + j + gvl
+      asm volatile("vfmul.vf v12, v12, %0" ::"f"(five_));
+      if ((i + 1) <= size_y) {
+        izq_1 = A[sc_ptr_0];
+        der_1 = A[sc_ptr_1];
+      }
+      asm volatile("vse64.v v12, (%0)" ::"r"(&B[mtx_ptr_1]));
+      mtx_ptr_1 += c; // (i + 1) * c + j
+
+      // mtx_ptr_0 = (i + 2) * c + j
+      // mtx_ptr_1 = (i + 1) * c + j
+      // sc_ptr_0  = (i + 1) * c + j - 1
+      // sc_ptr_1  = (i + 1) * c + j + gvl
+
+      if ((i + 1) <= size_y) {
+        asm volatile("vfslide1up.vf v24, v8, %0" ::"f"(izq_1));
+        asm volatile("vfslide1down.vf v28, v8, %0" ::"f"(der_1));
+        asm volatile("vfadd.vv v16, v4, v8");   // middle - top
+        mtx_ptr_0 += c; // (i + 3) * c + j
+        asm volatile("vfadd.vv v16, v16, v0");  // bottom
+        sc_ptr_0 += c; // (i + 2) * c + j - 1
+        asm volatile("vfadd.vv v16, v16, v24"); // left
+        if ((i + 2) <= size_y) {
+          asm volatile(
+              "vle64.v v4, (%0)" ::"r"(&A[mtx_ptr_0])); // v4 middle
+        }
+        asm volatile("vfadd.vv v16, v16, v28"); // right
+        sc_ptr_1 += c; // (i + 2) * c + j + gvl
+        asm volatile("vfmul.vf v16, v16, %0" ::"f"(five_));
+        if ((i + 2) <= size_y) {
+          izq_2 = A[sc_ptr_0];
+          der_2 = A[sc_ptr_1];
+        }
+        asm volatile("vse64.v v16, (%0)" ::"r"(&B[mtx_ptr_1]));
+        mtx_ptr_1 += c; // (i + 2) * c + j
+
+        // mtx_ptr_0 = (i + 3) * c + j
+        // mtx_ptr_1 = (i + 2) * c + j
+        // sc_ptr_0  = (i + 2) * c + j - 1
+        // sc_ptr_1  = (i + 2) * c + j + gvl
+
+        if ((i + 2) <= size_y) {
+          asm volatile("vfslide1up.vf v24, v0, %0" ::"f"(izq_2));
+          asm volatile("vfslide1down.vf v28, v0, %0" ::"f"(der_2));
+          asm volatile("vfadd.vv v20, v0, v8");   // middle - top
+          mtx_ptr_0 += c; // (i + 4) * c + j
+          asm volatile("vfadd.vv v20, v20, v4");  // bottom
+          sc_ptr_0 += c; // (i + 3) * c + j - 1
+          asm volatile("vfadd.vv v20, v20, v24"); // left
+          if ((i + 3) <= size_y) {
+            asm volatile("vle64.v v8, (%0)" ::"r"(
+                &A[mtx_ptr_0])); // v8 bottom
+          }
+          asm volatile("vfadd.vv v20, v20, v28"); // right
+          sc_ptr_1 += c; // (i + 3) * c + j + gvl
+          asm volatile("vfmul.vf v20, v20, %0" ::"f"(five_));
+          if ((i + 3) <= size_y) {
+            izq_0 = A[sc_ptr_0];
+            der_0 = A[sc_ptr_1];
+          }
+          asm volatile("vse64.v v20, (%0)" ::"r"(&B[mtx_ptr_1]));
+          mtx_ptr_1 += c; // (i + 3) * c + j
+
+          // mtx_ptr_0 = (i + 4) * c + j
+          // mtx_ptr_1 = (i + 3) * c + j
+          // sc_ptr_0  = (i + 3) * c + j - 1
+          // sc_ptr_1  = (i + 3) * c + j + gvl
+        }
+      }
+    }
+  }
+}
+
+// Debug
+inline void output_printfile(uint64_t r, uint64_t c, DATA_TYPE *A) {
+  for (uint32_t i = 0; i < r; i++)
+    for (uint32_t j = 0; j < c; j++) {
+      printf("A[%d][%d] = %f, ", i, j, A[i * c + j]);
+      if (j == c - 1)
+        printf("A[%d][%d] = %f\n", i, j, A[i * c + j]);
+    }
+}
+
+/*
+Intermediate optimization kernel, to better understand the algorithm
+
+void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
+  DATA_TYPE izq, der;
+  uint32_t size_y = r - 2;
+  uint32_t size_x = c - 2;
+
+  // Avoid division. 1/5 == 0.2
+  double five_ = 0.2;
+
+  size_t gvl;
+
+  asm volatile ("vsetvli %0, %1, e64, m1, ta, ma" : "=r" (gvl) : "r" (size_x));
+
+  for (uint32_t j = 1; j <= size_x; j = j + gvl) {
+    asm volatile ("vsetvli %0, %1, e64, m1, ta, ma" : "=r" (gvl) : "r" (size_x -
+j + 1)); asm volatile ("vle64.v v0, (%0)" :: "r" (&A[0*c + j])); // v0 top asm
+volatile ("vle64.v v1, (%0)" :: "r" (&A[1*c + j])); // v1 middle asm volatile
+("vle64.v v2, (%0)" :: "r" (&A[2*c + j])); // v2 bottom
+
+    for (uint32_t i = 1; i <= size_y; i += 3) {
+      if (i != 1) {
+        asm volatile ("vle64.v v2, (%0)" :: "r" (&A[(i+1)*c + j])); // v2 bottom
+      }
+      izq = A[i*c + j - 1];
+      der = A[i*c + j + gvl];
+      asm volatile ("vfslide1up.vf v6, v1, %0" :: "f" (izq));
+      asm volatile ("vfslide1down.vf v7, v1, %0" :: "f" (der));
+      asm volatile ("vfadd.vv v5, v6, v7"); // left, right
+      asm volatile ("vfadd.vv v5, v5, v0"); // top
+      asm volatile ("vfadd.vv v5, v5, v2"); // bottom
+      asm volatile ("vfadd.vv v5, v5, v1"); // middle
+      asm volatile ("vfmul.vf v5, v5, %0" :: "f" (five_));
+      asm volatile ("vse64.v v5, (%0)" :: "r" (&B[i*c + j]));
+
+      asm volatile ("vle64.v v0, (%0)" :: "r" (&A[((i+1)+1)*c + j])); // v0 top
+
+      izq = A[(i+1)*c + j - 1];
+      der = A[(i+1)*c + j + gvl];
+      asm volatile ("vfslide1up.vf v6, v2, %0" :: "f" (izq));
+      asm volatile ("vfslide1down.vf v7, v2, %0" :: "f" (der));
+      asm volatile ("vfadd.vv v5, v6, v7"); // left, right
+      asm volatile ("vfadd.vv v5, v5, v1"); // top
+      asm volatile ("vfadd.vv v5, v5, v0"); // bottom
+      asm volatile ("vfadd.vv v5, v5, v2"); // middle
+      asm volatile ("vfmul.vf v5, v5, %0" :: "f" (five_));
+      asm volatile ("vse64.v v5, (%0)" :: "r" (&B[(i+1)*c + j]));
+
+      asm volatile ("vle64.v v1, (%0)" :: "r" (&A[((i+2)+1)*c + j])); // v1
+middle
+
+      izq = A[(i+2)*c + j - 1];
+      der = A[(i+2)*c + j + gvl];
+      asm volatile ("vfslide1up.vf v6, v0, %0" :: "f" (izq));
+      asm volatile ("vfslide1down.vf v7, v0, %0" :: "f" (der));
+      asm volatile ("vfadd.vv v5, v6, v7"); // left, right
+      asm volatile ("vfadd.vv v5, v5, v2"); // top
+      asm volatile ("vfadd.vv v5, v5, v1"); // bottom
+      asm volatile ("vfadd.vv v5, v5, v0"); // middle
+      asm volatile ("vfmul.vf v5, v5, %0" :: "f" (five_));
+      asm volatile ("vse64.v v5, (%0)" :: "r" (&B[(i+2)*c + j]));
+    }
+  }
+}
+*/
+
+/*
+// Kernel without the pointer optimization
+// Optimized version of the jacobi2d kernel
+// 1) Preload the coefficients, before each vstore
+// 2) Eliminate WAW and WAR hazards
+// 3) Unroll the loop and use multiple buffers
 void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
   DATA_TYPE izq_0, izq_1, izq_2;
   DATA_TYPE der_0, der_1, der_2;
@@ -232,82 +454,6 @@ void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
           asm volatile("vse64.v v20, (%0)" ::"r"(&B[(i + 2) * c + j]));
         }
       }
-    }
-  }
-}
-
-// Debug
-inline void output_printfile(uint64_t r, uint64_t c, DATA_TYPE *A) {
-  for (uint32_t i = 0; i < r; i++)
-    for (uint32_t j = 0; j < c; j++) {
-      printf("A[%d][%d] = %f, ", i, j, A[i * c + j]);
-      if (j == c - 1)
-        printf("A[%d][%d] = %f\n", i, j, A[i * c + j]);
-    }
-}
-
-/*
-Intermediate optimization kernel, to better understand the algorithm
-
-void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
-  DATA_TYPE izq, der;
-  uint32_t size_y = r - 2;
-  uint32_t size_x = c - 2;
-
-  // Avoid division. 1/5 == 0.2
-  double five_ = 0.2;
-
-  size_t gvl;
-
-  asm volatile ("vsetvli %0, %1, e64, m1, ta, ma" : "=r" (gvl) : "r" (size_x));
-
-  for (uint32_t j = 1; j <= size_x; j = j + gvl) {
-    asm volatile ("vsetvli %0, %1, e64, m1, ta, ma" : "=r" (gvl) : "r" (size_x -
-j + 1)); asm volatile ("vle64.v v0, (%0)" :: "r" (&A[0*c + j])); // v0 top asm
-volatile ("vle64.v v1, (%0)" :: "r" (&A[1*c + j])); // v1 middle asm volatile
-("vle64.v v2, (%0)" :: "r" (&A[2*c + j])); // v2 bottom
-
-    for (uint32_t i = 1; i <= size_y; i += 3) {
-      if (i != 1) {
-        asm volatile ("vle64.v v2, (%0)" :: "r" (&A[(i+1)*c + j])); // v2 bottom
-      }
-      izq = A[i*c + j - 1];
-      der = A[i*c + j + gvl];
-      asm volatile ("vfslide1up.vf v6, v1, %0" :: "f" (izq));
-      asm volatile ("vfslide1down.vf v7, v1, %0" :: "f" (der));
-      asm volatile ("vfadd.vv v5, v6, v7"); // left, right
-      asm volatile ("vfadd.vv v5, v5, v0"); // top
-      asm volatile ("vfadd.vv v5, v5, v2"); // bottom
-      asm volatile ("vfadd.vv v5, v5, v1"); // middle
-      asm volatile ("vfmul.vf v5, v5, %0" :: "f" (five_));
-      asm volatile ("vse64.v v5, (%0)" :: "r" (&B[i*c + j]));
-
-      asm volatile ("vle64.v v0, (%0)" :: "r" (&A[((i+1)+1)*c + j])); // v0 top
-
-      izq = A[(i+1)*c + j - 1];
-      der = A[(i+1)*c + j + gvl];
-      asm volatile ("vfslide1up.vf v6, v2, %0" :: "f" (izq));
-      asm volatile ("vfslide1down.vf v7, v2, %0" :: "f" (der));
-      asm volatile ("vfadd.vv v5, v6, v7"); // left, right
-      asm volatile ("vfadd.vv v5, v5, v1"); // top
-      asm volatile ("vfadd.vv v5, v5, v0"); // bottom
-      asm volatile ("vfadd.vv v5, v5, v2"); // middle
-      asm volatile ("vfmul.vf v5, v5, %0" :: "f" (five_));
-      asm volatile ("vse64.v v5, (%0)" :: "r" (&B[(i+1)*c + j]));
-
-      asm volatile ("vle64.v v1, (%0)" :: "r" (&A[((i+2)+1)*c + j])); // v1
-middle
-
-      izq = A[(i+2)*c + j - 1];
-      der = A[(i+2)*c + j + gvl];
-      asm volatile ("vfslide1up.vf v6, v0, %0" :: "f" (izq));
-      asm volatile ("vfslide1down.vf v7, v0, %0" :: "f" (der));
-      asm volatile ("vfadd.vv v5, v6, v7"); // left, right
-      asm volatile ("vfadd.vv v5, v5, v2"); // top
-      asm volatile ("vfadd.vv v5, v5, v1"); // bottom
-      asm volatile ("vfadd.vv v5, v5, v0"); // middle
-      asm volatile ("vfmul.vf v5, v5, %0" :: "f" (five_));
-      asm volatile ("vse64.v v5, (%0)" :: "r" (&B[(i+2)*c + j]));
     }
   }
 }

--- a/apps/jacobi2d/kernel/jacobi2d.c
+++ b/apps/jacobi2d/kernel/jacobi2d.c
@@ -165,11 +165,11 @@ void j2d_kernel_adhoc_warm(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
     asm volatile("vsetvli %0, %1, e64, m4, ta, ma"
                  : "=r"(gvl)
                  : "r"(size_x - j + 1));
-    mtx_ptr_0 = j; // 0 * c + j
+    mtx_ptr_0 = j;                                         // 0 * c + j
     asm volatile("vle64.v v0, (%0)" ::"r"(&A[mtx_ptr_0])); // v0 top
-    mtx_ptr_1 = j + c; // 1 * c + j
+    mtx_ptr_1 = j + c;                                     // 1 * c + j
     asm volatile("vle64.v v4, (%0)" ::"r"(&A[mtx_ptr_1])); // v4 middle
-    mtx_ptr_0 = mtx_ptr_1 + c; // 2 * c + j
+    mtx_ptr_0 = mtx_ptr_1 + c;                             // 2 * c + j
     asm volatile("vle64.v v8, (%0)" ::"r"(&A[mtx_ptr_0])); // v8 bottom
 
     // Look ahead and load the next coefficients
@@ -201,16 +201,15 @@ void j2d_kernel_adhoc_warm(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
       asm volatile("vfslide1up.vf v24, v4, %0" ::"f"(izq_0));
       asm volatile("vfslide1down.vf v28, v4, %0" ::"f"(der_0));
       asm volatile("vfadd.vv v12, v4, v0");   // middle - top
-      mtx_ptr_0 += c; // (i + 2) * c + j
+      mtx_ptr_0 += c;                         // (i + 2) * c + j
       asm volatile("vfadd.vv v12, v12, v8");  // bottom
-      sc_ptr_0 += c; // (i + 1) * c + j - 1
+      sc_ptr_0 += c;                          // (i + 1) * c + j - 1
       asm volatile("vfadd.vv v12, v12, v24"); // left
       if ((i + 1) <= size_y) {
-        asm volatile(
-            "vle64.v v0, (%0)" ::"r"(&A[mtx_ptr_0])); // v0 top
+        asm volatile("vle64.v v0, (%0)" ::"r"(&A[mtx_ptr_0])); // v0 top
       }
       asm volatile("vfadd.vv v12, v12, v28"); // right
-      sc_ptr_1 += c; // (i + 1) * c + j + gvl
+      sc_ptr_1 += c;                          // (i + 1) * c + j + gvl
       asm volatile("vfmul.vf v12, v12, %0" ::"f"(five_));
       if ((i + 1) <= size_y) {
         izq_1 = A[sc_ptr_0];
@@ -228,16 +227,15 @@ void j2d_kernel_adhoc_warm(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
         asm volatile("vfslide1up.vf v24, v8, %0" ::"f"(izq_1));
         asm volatile("vfslide1down.vf v28, v8, %0" ::"f"(der_1));
         asm volatile("vfadd.vv v16, v4, v8");   // middle - top
-        mtx_ptr_0 += c; // (i + 3) * c + j
+        mtx_ptr_0 += c;                         // (i + 3) * c + j
         asm volatile("vfadd.vv v16, v16, v0");  // bottom
-        sc_ptr_0 += c; // (i + 2) * c + j - 1
+        sc_ptr_0 += c;                          // (i + 2) * c + j - 1
         asm volatile("vfadd.vv v16, v16, v24"); // left
         if ((i + 2) <= size_y) {
-          asm volatile(
-              "vle64.v v4, (%0)" ::"r"(&A[mtx_ptr_0])); // v4 middle
+          asm volatile("vle64.v v4, (%0)" ::"r"(&A[mtx_ptr_0])); // v4 middle
         }
         asm volatile("vfadd.vv v16, v16, v28"); // right
-        sc_ptr_1 += c; // (i + 2) * c + j + gvl
+        sc_ptr_1 += c;                          // (i + 2) * c + j + gvl
         asm volatile("vfmul.vf v16, v16, %0" ::"f"(five_));
         if ((i + 2) <= size_y) {
           izq_2 = A[sc_ptr_0];
@@ -255,16 +253,15 @@ void j2d_kernel_adhoc_warm(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
           asm volatile("vfslide1up.vf v24, v0, %0" ::"f"(izq_2));
           asm volatile("vfslide1down.vf v28, v0, %0" ::"f"(der_2));
           asm volatile("vfadd.vv v20, v0, v8");   // middle - top
-          mtx_ptr_0 += c; // (i + 4) * c + j
+          mtx_ptr_0 += c;                         // (i + 4) * c + j
           asm volatile("vfadd.vv v20, v20, v4");  // bottom
-          sc_ptr_0 += c; // (i + 3) * c + j - 1
+          sc_ptr_0 += c;                          // (i + 3) * c + j - 1
           asm volatile("vfadd.vv v20, v20, v24"); // left
           if ((i + 3) <= size_y) {
-            asm volatile("vle64.v v8, (%0)" ::"r"(
-                &A[mtx_ptr_0])); // v8 bottom
+            asm volatile("vle64.v v8, (%0)" ::"r"(&A[mtx_ptr_0])); // v8 bottom
           }
           asm volatile("vfadd.vv v20, v20, v28"); // right
-          sc_ptr_1 += c; // (i + 3) * c + j + gvl
+          sc_ptr_1 += c;                          // (i + 3) * c + j + gvl
           asm volatile("vfmul.vf v20, v20, %0" ::"f"(five_));
           if ((i + 3) <= size_y) {
             izq_0 = A[sc_ptr_0];
@@ -308,11 +305,11 @@ void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
     asm volatile("vsetvli %0, %1, e64, m4, ta, ma"
                  : "=r"(gvl)
                  : "r"(size_x - j + 1));
-    mtx_ptr_0 = j; // 0 * c + j
+    mtx_ptr_0 = j;                                         // 0 * c + j
     asm volatile("vle64.v v0, (%0)" ::"r"(&A[mtx_ptr_0])); // v0 top
-    mtx_ptr_1 = j + c; // 1 * c + j
+    mtx_ptr_1 = j + c;                                     // 1 * c + j
     asm volatile("vle64.v v4, (%0)" ::"r"(&A[mtx_ptr_1])); // v4 middle
-    mtx_ptr_0 = mtx_ptr_1 + c; // 2 * c + j
+    mtx_ptr_0 = mtx_ptr_1 + c;                             // 2 * c + j
     asm volatile("vle64.v v8, (%0)" ::"r"(&A[mtx_ptr_0])); // v8 bottom
 
     // Look ahead and load the next coefficients
@@ -344,16 +341,15 @@ void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
       asm volatile("vfslide1up.vf v24, v4, %0" ::"f"(izq_0));
       asm volatile("vfslide1down.vf v28, v4, %0" ::"f"(der_0));
       asm volatile("vfadd.vv v12, v4, v0");   // middle - top
-      mtx_ptr_0 += c; // (i + 2) * c + j
+      mtx_ptr_0 += c;                         // (i + 2) * c + j
       asm volatile("vfadd.vv v12, v12, v8");  // bottom
-      sc_ptr_0 += c; // (i + 1) * c + j - 1
+      sc_ptr_0 += c;                          // (i + 1) * c + j - 1
       asm volatile("vfadd.vv v12, v12, v24"); // left
       if ((i + 1) <= size_y) {
-        asm volatile(
-            "vle64.v v0, (%0)" ::"r"(&A[mtx_ptr_0])); // v0 top
+        asm volatile("vle64.v v0, (%0)" ::"r"(&A[mtx_ptr_0])); // v0 top
       }
       asm volatile("vfadd.vv v12, v12, v28"); // right
-      sc_ptr_1 += c; // (i + 1) * c + j + gvl
+      sc_ptr_1 += c;                          // (i + 1) * c + j + gvl
       asm volatile("vfmul.vf v12, v12, %0" ::"f"(five_));
       if ((i + 1) <= size_y) {
         izq_1 = A[sc_ptr_0];
@@ -371,16 +367,15 @@ void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
         asm volatile("vfslide1up.vf v24, v8, %0" ::"f"(izq_1));
         asm volatile("vfslide1down.vf v28, v8, %0" ::"f"(der_1));
         asm volatile("vfadd.vv v16, v4, v8");   // middle - top
-        mtx_ptr_0 += c; // (i + 3) * c + j
+        mtx_ptr_0 += c;                         // (i + 3) * c + j
         asm volatile("vfadd.vv v16, v16, v0");  // bottom
-        sc_ptr_0 += c; // (i + 2) * c + j - 1
+        sc_ptr_0 += c;                          // (i + 2) * c + j - 1
         asm volatile("vfadd.vv v16, v16, v24"); // left
         if ((i + 2) <= size_y) {
-          asm volatile(
-              "vle64.v v4, (%0)" ::"r"(&A[mtx_ptr_0])); // v4 middle
+          asm volatile("vle64.v v4, (%0)" ::"r"(&A[mtx_ptr_0])); // v4 middle
         }
         asm volatile("vfadd.vv v16, v16, v28"); // right
-        sc_ptr_1 += c; // (i + 2) * c + j + gvl
+        sc_ptr_1 += c;                          // (i + 2) * c + j + gvl
         asm volatile("vfmul.vf v16, v16, %0" ::"f"(five_));
         if ((i + 2) <= size_y) {
           izq_2 = A[sc_ptr_0];
@@ -398,16 +393,15 @@ void j2d_kernel_asm_v(uint64_t r, uint64_t c, DATA_TYPE *A, DATA_TYPE *B) {
           asm volatile("vfslide1up.vf v24, v0, %0" ::"f"(izq_2));
           asm volatile("vfslide1down.vf v28, v0, %0" ::"f"(der_2));
           asm volatile("vfadd.vv v20, v0, v8");   // middle - top
-          mtx_ptr_0 += c; // (i + 4) * c + j
+          mtx_ptr_0 += c;                         // (i + 4) * c + j
           asm volatile("vfadd.vv v20, v20, v4");  // bottom
-          sc_ptr_0 += c; // (i + 3) * c + j - 1
+          sc_ptr_0 += c;                          // (i + 3) * c + j - 1
           asm volatile("vfadd.vv v20, v20, v24"); // left
           if ((i + 3) <= size_y) {
-            asm volatile("vle64.v v8, (%0)" ::"r"(
-                &A[mtx_ptr_0])); // v8 bottom
+            asm volatile("vle64.v v8, (%0)" ::"r"(&A[mtx_ptr_0])); // v8 bottom
           }
           asm volatile("vfadd.vv v20, v20, v28"); // right
-          sc_ptr_1 += c; // (i + 3) * c + j + gvl
+          sc_ptr_1 += c;                          // (i + 3) * c + j + gvl
           asm volatile("vfmul.vf v20, v20, %0" ::"f"(five_));
           if ((i + 3) <= size_y) {
             izq_0 = A[sc_ptr_0];

--- a/apps/roi_align/kernel/roi_align.c
+++ b/apps/roi_align/kernel/roi_align.c
@@ -507,3 +507,59 @@ void init_crops(float *vec, size_t size) {
   for (unsigned long int i = 0; i < size; ++i)
     vec[i] = 0;
 }
+
+// Roi Align vector kernel
+// Fake just for timing measurements and comparison with Ideal Dispatcher
+void roi_align_fake_kernel_asm(float* pimage, float* crops_data, int left_x_index, int right_x_index, int b, int y, size_t depth) {
+
+  volatile float x_lerp = 0.14135;
+  volatile float y_lerp = 0.4363;
+  volatile int image_channel_elements = 64;
+  volatile int channel_elements = 32;
+  volatile int crop_elements = 5;
+  volatile int crop_width = 3;
+  volatile int tyiw = 9;
+  volatile int byiw = 7;
+  volatile int x = 11;
+  volatile int k = 0;
+  volatile int z = 0;
+
+  size_t vl;
+  size_t avl = depth;
+
+  asm volatile("vsetvli %0, %1, e32, m1, ta, ma" : "=r"(vl) : "r"(avl));
+
+  for (avl = depth; avl > 0; avl -= vl) {
+    asm volatile("vsetvli %0, %1, e32, m1, ta, ma" : "=r"(vl) : "r"(avl));
+    asm volatile("vle32.v v0, (%0)" ::"r"(
+                     &pimage[tyiw + left_x_index])
+                 : "v0"); // top left
+    asm volatile("vle32.v v1, (%0)" ::"r"(
+                     &pimage[tyiw + right_x_index])
+                 : "v1"); // top right
+
+    asm volatile("vfsub.vv v2, v1, v0");                // top
+    asm volatile("vfmadd.vf v2, %0, v0" ::"f"(x_lerp)); // top
+
+    asm volatile("vle32.v v3, (%0)" ::"r"(
+                     &pimage[byiw + left_x_index])
+                 : "v3"); // bottom left
+    asm volatile(
+        "vle32.v v4, (%0)" ::"r"(
+            &pimage[byiw + right_x_index])
+        : "v4"); // bottom right
+
+    asm volatile("vfsub.vv v5, v4, v3");                // bottom
+    asm volatile("vfmadd.vf v5, %0, v3" ::"f"(x_lerp)); // bottom
+
+    asm volatile("vfsub.vv v6, v5, v2");                // bottom
+    asm volatile("vfmadd.vf v6, %0, v2" ::"f"(y_lerp)); // bottom
+
+    asm volatile("vse32.v v6, (%0)" ::"r"(
+        &crops_data[crop_elements * b + y * crop_width + x]));
+
+    // Bump pointers
+    k += vl * image_channel_elements;
+    z += vl * channel_elements;
+  }
+}

--- a/apps/roi_align/kernel/roi_align.h
+++ b/apps/roi_align/kernel/roi_align.h
@@ -56,7 +56,9 @@ int64_t CropAndResizePerBox_BHWC_vec(
     float *crops_data, const int crop_height, const int crop_width,
     const float extrapolation_value);
 
-void roi_align_fake_kernel_asm(float* pimage, float* crops_data, int left_x_index, int right_x_index, int b, int y, size_t depth);
+void roi_align_fake_kernel_asm(float *pimage, float *crops_data,
+                               int left_x_index, int right_x_index, int b,
+                               int y, size_t depth);
 
 // Normalized image
 void init_image(float *vec, size_t size);

--- a/apps/roi_align/kernel/roi_align.h
+++ b/apps/roi_align/kernel/roi_align.h
@@ -56,6 +56,8 @@ int64_t CropAndResizePerBox_BHWC_vec(
     float *crops_data, const int crop_height, const int crop_width,
     const float extrapolation_value);
 
+void roi_align_fake_kernel_asm(float* pimage, float* crops_data, int left_x_index, int right_x_index, int b, int y, size_t depth);
+
 // Normalized image
 void init_image(float *vec, size_t size);
 

--- a/apps/roi_align/main.c
+++ b/apps/roi_align/main.c
@@ -20,6 +20,10 @@
 #include <stdio.h>
 #endif
 
+// Execute only the central kernel with fake data
+// Execute only on the channels
+//#define V_KERNEL_ONLY 1
+
 #define EXTRAPOLATION_VALUE 0
 
 extern uint64_t BATCH_SIZE;
@@ -77,6 +81,8 @@ int main() {
     init_crops(crops_data_vec, BATCH_SIZE * DEPTH * CROP_HEIGHT * CROP_WIDTH);
   */
 
+#ifndef V_KERNEL_ONLY
+
   // Parameters
   printf("BATCH_SIZE = %ld\nDEPTH = %ld\nIMAGE_HEIGHT = %ld\nIMAGE_WIDTH = "
          "%ld\nN_BOXES = %ld\nCROP_HEIGHT = %ld\nCROP_WIDTH = "
@@ -106,7 +112,26 @@ int main() {
   runtime_v = get_timer();
   printf("Vector benchmark complete.\n");
 
+#else
+
+  int left_x_index = 0;
+  int right_x_index = 0;
+  int b = 0;
+  int y = 0;
+
+  printf("Starting vector main kernel...\n");
+  start_timer();
+  roi_align_fake_kernel_asm(image_data, crops_data_vec, left_x_index, right_x_index, b, y, DEPTH);
+  stop_timer();
+  runtime_v = get_timer();
+  printf("Vector benchmark complete.\n");
+
+#endif
+
   printf("The execution took %d cycles.\n", runtime_v);
+
+#ifndef V_KERNEL_ONLY
+
   printf("Vector speedup is %f times over the scalar implementation.\n",
          (float)runtime_s / runtime_v);
 
@@ -122,6 +147,8 @@ int main() {
   } else {
     printf("Passed.\n");
   }
+
+#endif
 
   return 0;
 }

--- a/apps/roi_align/main.c
+++ b/apps/roi_align/main.c
@@ -121,7 +121,8 @@ int main() {
 
   printf("Starting vector main kernel...\n");
   start_timer();
-  roi_align_fake_kernel_asm(image_data, crops_data_vec, left_x_index, right_x_index, b, y, DEPTH);
+  roi_align_fake_kernel_asm(image_data, crops_data_vec, left_x_index,
+                            right_x_index, b, y, DEPTH);
   stop_timer();
   runtime_v = get_timer();
   printf("Vector benchmark complete.\n");

--- a/apps/roi_align/main.c
+++ b/apps/roi_align/main.c
@@ -22,7 +22,7 @@
 
 // Execute only the central kernel with fake data
 // Execute only on the channels
-//#define V_KERNEL_ONLY 1
+#define V_KERNEL_ONLY 1
 
 #define EXTRAPOLATION_VALUE 0
 

--- a/hardware/src/accel_dispatcher_ideal.sv
+++ b/hardware/src/accel_dispatcher_ideal.sv
@@ -131,6 +131,9 @@ module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; (
   always_ff @(posedge clk_i) begin
     if (rst_ni && was_reset && !acc_req_o.req_valid && i_system.i_ara.ara_idle) begin
       $display("[hw-cycles]: %d", int'(perf_cnt_q));
+      $display("[cva6-d$-stalls]: %d", int'(dut.dcache_stall_buf_q));
+      $display("[cva6-i$-stalls]: %d", int'(dut.icache_stall_buf_q));
+      $display("[cva6-sb-full]: %d", int'(dut.sb_full_buf_q));
       $info("Core Test ", $sformatf("*** SUCCESS *** (tohost = %0d)", 0));
       $finish(0);
     end

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -199,6 +199,9 @@ module ara_tb;
         // Print vector HW runtime
 `ifndef TARGET_GATESIM
         $display("[hw-cycles]: %d", int'(dut.runtime_buf_q));
+        $display("[cva6-d$-stalls]: %d", int'(dut.dcache_stall_buf_q));
+        $display("[cva6-i$-stalls]: %d", int'(dut.icache_stall_buf_q));
+        $display("[cva6-sb-full]: %d", int'(dut.sb_full_buf_q));
 `endif
         $info("Core Test ", $sformatf("*** SUCCESS *** (tohost = %0d)", (exit >> 1)));
       end

--- a/hardware/tb/ara_testharness.sv
+++ b/hardware/tb/ara_testharness.sv
@@ -204,5 +204,79 @@ module ara_testharness #(
     end
   end
 
+`ifndef IDEAL_DISPATCHER
+
+  /*******************
+   *  CVA6 PERF CNT  *
+   *******************/
+
+  // Count the number of I$/D$ stalls, and if the scoreboard is
+  // full during the V runtime.
+  // i_ara_soc.i_system.i_ariane.i_perf_counters.l1_dcache_miss_i
+  // i_ara_soc.i_system.i_ariane.i_perf_counters.l1_icache_miss_i
+  // i_ara_soc.i_system.i_ariane.i_perf_counters.sb_full_i
+
+  logic [63:0] dcache_stall_cnt_d, dcache_stall_cnt_q;
+  logic [63:0] icache_stall_cnt_d, icache_stall_cnt_q;
+  logic [63:0] sb_full_cnt_d, sb_full_cnt_q;
+  logic [63:0] dcache_stall_buf_d, dcache_stall_buf_q;
+  logic [63:0] icache_stall_buf_d, icache_stall_buf_q;
+  logic [63:0] sb_full_buf_d, sb_full_buf_q;
+
+  always_comb begin
+    dcache_stall_cnt_d = dcache_stall_cnt_q;
+    icache_stall_cnt_d = icache_stall_cnt_q;
+    sb_full_cnt_d      = sb_full_cnt_q;
+    if (runtime_cnt_en_q && i_ara_soc.i_system.i_ariane.gen_perf_counter.perf_counters_i.l1_dcache_miss_i)
+      dcache_stall_cnt_d += 1;
+    if (runtime_cnt_en_q && i_ara_soc.i_system.i_ariane.gen_perf_counter.perf_counters_i.l1_icache_miss_i)
+      icache_stall_cnt_d += 1;
+    if (runtime_cnt_en_q && i_ara_soc.i_system.i_ariane.gen_perf_counter.perf_counters_i.sb_full_i)
+      sb_full_cnt_d      += 1;
+  end
+
+  // Update logic
+  always_comb begin
+    // Update the internal runtime and reset the update flag
+    if (runtime_to_be_updated_q           &&
+        i_ara_soc.i_system.i_ara.ara_idle &&
+        !i_ara_soc.i_system.i_ara.acc_req_i.req_valid) begin
+      dcache_stall_buf_d = dcache_stall_cnt_q;
+      icache_stall_buf_d = icache_stall_cnt_q;
+      sb_full_buf_d      = sb_full_cnt_q;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      dcache_stall_cnt_q <= '0;
+      icache_stall_cnt_q <= '0;
+      sb_full_cnt_q      <= '0;
+      dcache_stall_buf_q <= '0;
+      icache_stall_buf_q <= '0;
+      sb_full_buf_q      <= '0;
+    end else begin
+      dcache_stall_cnt_q <= dcache_stall_cnt_d;
+      icache_stall_cnt_q <= icache_stall_cnt_d;
+      sb_full_cnt_q      <= sb_full_cnt_d;
+      dcache_stall_buf_q <= dcache_stall_buf_d;
+      icache_stall_buf_q <= icache_stall_buf_d;
+      sb_full_buf_q      <= sb_full_buf_d;
+    end
+  end // always_ff @ (posedge clk_i or negedge rst_ni)
+
+`else
+
+  logic [63:0] dcache_stall_buf_q;
+  logic [63:0] icache_stall_buf_q;
+  logic [63:0] sb_full_buf_q;
+
+  assign dcache_stall_buf_q = '0;
+  assign icache_stall_buf_q = '0;
+  assign sb_full_buf_q      = '0;
+
+`endif
+
+
 `endif
 endmodule : ara_testharness

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -603,11 +603,13 @@ fdotproduct() {
       # Default System
       compile_and_run $kernel "$defines" $tempfile 0                                 || exit
       extract_performance $kernel "$metadata 0" "$args" $tempfile ${kernel}_${nr_lanes}.benchmark  || exit
+      extract_performance_dotp $kernel "$args" $sew $tempfile ${kernel}_${nr_lanes}_bar_plots.benchmark || exit
 
       # Ideal Dispatcher System, if QuestaSim is available
       if [ "$ci" == 0 ]; then
         compile_and_run $kernel "$defines" $tempfile 1                                      || exit
         extract_performance $kernel "$metadata 1" "$args" $tempfile ${kernel}_${nr_lanes}_ideal.benchmark || exit
+        extract_performance_dotp $kernel "$args" $sew $tempfile ${kernel}_${nr_lanes}_ideal_bar_plots.benchmark || exit
         # Verify ID results is non-blocking! Check the report afterwards
         verify_id_results 0 | tee -a ${error_rpt}
       fi
@@ -645,11 +647,13 @@ dotproduct() {
       # Default System
       compile_and_run $kernel "$defines" $tempfile 0                                 || exit
       extract_performance $kernel "$metadata 0" "$args" $tempfile ${kernel}_${nr_lanes}.benchmark  || exit
+      extract_performance_dotp $kernel "$args" $sew $tempfile ${kernel}_${nr_lanes}_bar_plots.benchmark  || exit
 
       # Ideal Dispatcher System, if QuestaSim is available
       if [ "$ci" == 0 ]; then
         compile_and_run $kernel "$defines" $tempfile 1                                      || exit
         extract_performance $kernel "$metadata 1" "$args" $tempfile ${kernel}_${nr_lanes}_ideal.benchmark || exit
+        extract_performance_dotp $kernel "$args" $sew $tempfile ${kernel}_${nr_lanes}_ideal_bar_plots.benchmark || exit
         # Verify ID results is non-blocking! Check the report afterwards
         verify_id_results 0 | tee -a ${error_rpt}
       fi

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -97,6 +97,7 @@ extract_performance() {
     $python ./scripts/check_cycles.py $kernel $hw_cycles $sw_cycles || exit
   fi
   echo "Extracting performance from cycle count"
+  echo "$python ./scripts/performance.py \"$metadata\" \"$args\" $hw_cycles >> $outfile"
   $python ./scripts/performance.py "$metadata" "$args" $hw_cycles >> $outfile || exit
 }
 
@@ -261,6 +262,7 @@ conv2d() {
 
       # Default System
       compile_and_run $kernel "$defines" $tempfile 0                                      || exit
+      echo "extract_performance $kernel \"$metadata 0\" \"$args\" $tempfile ${kernel}_${nr_lanes}.benchmark"
       extract_performance $kernel "$metadata 0" "$args" $tempfile ${kernel}_${nr_lanes}.benchmark || exit
 
       # Ideal Dispatcher System, if QuestaSim is available
@@ -788,10 +790,7 @@ case $1 in
 
   *)
     echo "Benchmarking all the apps."
-    matmul imatmul
     matmul fmatmul
-    conv2d iconv2d
-    conv2d fconv2d
     fconv3d
     jacobi2d
     dropout

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -90,6 +90,12 @@ extract_performance() {
 
   echo "Extracting cycle count measure"
   hw_cycles=$(cat $tempfile | grep "\[hw-cycles\]" | tr -s " " | cut -d: -f 2)
+  echo "Extracting dcache stalls metric"
+  dcache_stalls=$(cat $tempfile | grep "\[cva6-d\$-stalls\]" | tr -s " " | cut -d: -f 2)
+  echo "Extracting icache stalls metric"
+  icache_stalls=$(cat $tempfile | grep "\[cva6-i\$-stalls\]" | tr -s " " | cut -d: -f 2)
+  echo "Extracting scoreboard full metric"
+  sb_full_stalls=$(cat $tempfile | grep "\[cva6-sb-full\]" | tr -s " " | cut -d: -f 2)
   # If we have a SW-cycle count, check that the HW one for improved reliability
   if [[ ! $outfile =~ "ideal" ]]; then
     sw_cycles=$(cat $tempfile | grep "\[sw-cycles\]" | tr -s " " | cut -d: -f 2)
@@ -98,7 +104,7 @@ extract_performance() {
   fi
   echo "Extracting performance from cycle count"
   echo "$python ./scripts/performance.py \"$metadata\" \"$args\" $hw_cycles >> $outfile"
-  $python ./scripts/performance.py "$metadata" "$args" $hw_cycles >> $outfile || exit
+  $python ./scripts/performance.py "$metadata" "$args" $hw_cycles $dcache_stalls $icache_stalls $sb_full_stalls >> $outfile || exit
 }
 
 extract_performance_dotp() {

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -199,6 +199,8 @@ matmul() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   # Measure the following matrix sizes
   for size in 4 8 16 32 64 128; do
@@ -236,6 +238,8 @@ conv2d() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   # Measure the following matrix and filter sizes
   # The input image is also padded, and the max vl is 128
@@ -277,6 +281,8 @@ fconv3d() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   # Measure the following matrix and filter sizes
   # The input image is also padded, and the max vl is 128
@@ -318,6 +324,8 @@ jacobi2d() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for vsize_unpadded in 4 8 16 32 64 128; do
     vsize=$(($vsize_unpadded + 2))
@@ -354,6 +362,8 @@ dropout() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for vsize in 4 8 16 32 64 128 256 512 1024 2048; do
 
@@ -388,6 +398,8 @@ fft() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   # Type should be in the format "floatXY"
   dtype="float32"
@@ -429,6 +441,8 @@ dwt() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for vsize in 4 8 16 32 64 128 256 512; do
 
@@ -464,6 +478,8 @@ exp() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for vsize in 4 8 16 32 64 128 256 512; do
 
@@ -501,6 +517,8 @@ softmax() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for insize in 4 8 16 32 64 128 256 512; do
 
@@ -534,6 +552,8 @@ fdotproduct() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for dtype in double float _Float16; do
     for bsize in 16 32 64 128 256 512 1024 2048 4096; do
@@ -573,6 +593,8 @@ dotproduct() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for dtype in int64_t int32_t int16_t int8_t; do
     for bsize in 16 32 64 128 256 512 1024 2048 4096; do
@@ -615,6 +637,8 @@ pathfinder() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for cols in 4 8 16 32 64 128 256 512 1024; do
     for rows in 64; do
@@ -659,6 +683,8 @@ roi_align() {
   # Log the performance results
   > ${kernel}_${nr_lanes}.benchmark
   > ${kernel}_${nr_lanes}_ideal.benchmark
+  # Init error report
+  echo "kernel: $kernel" >> ${error_rpt}
 
   for depth in 4 8 16 32 64 128 256 512; do
 

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -103,8 +103,13 @@ extract_performance() {
     $python ./scripts/check_cycles.py $kernel $hw_cycles $sw_cycles || exit
   fi
   echo "Extracting performance from cycle count"
-  echo "$python ./scripts/performance.py \"$metadata\" \"$args\" $hw_cycles >> $outfile"
-  $python ./scripts/performance.py "$metadata" "$args" $hw_cycles $dcache_stalls $icache_stalls $sb_full_stalls >> $outfile || exit
+  if [[ "$ci" == 0 ]]; then
+    echo "$python ./scripts/performance.py \"$metadata\" \"$args\" $hw_cycles $dcache_stalls $icache_stalls $sb_full_stalls >> $outfile"
+    $python ./scripts/performance.py "$metadata" "$args" $hw_cycles $dcache_stalls $icache_stalls $sb_full_stalls >> $outfile || exit
+  else
+    echo "$python ./scripts/performance.py \"$metadata\" \"$args\" $hw_cycles >> $outfile"
+    $python ./scripts/performance.py "$metadata" "$args" $hw_cycles >> $outfile || exit
+  fi
 }
 
 extract_performance_dotp() {

--- a/scripts/check_cycles.py
+++ b/scripts/check_cycles.py
@@ -52,6 +52,8 @@ skip_check = {
   'exp'        : 0,
   'softmax'    : 0,
   'pathfinder' : 0,
+  'dotproduct' : 0,
+  'fdotproduct': 0,
   'roi_align'  : 1, # This program has a larger scalar component
 }
 

--- a/scripts/check_cycles.py
+++ b/scripts/check_cycles.py
@@ -36,6 +36,8 @@ threshold = {
   'exp'        : 500,
   'softmax'    : 500,
   'pathfinder' : 500,
+  'dotproduct' : 500,
+  'fdotproduct': 500,
   'roi_align'  : 500,
 }
 

--- a/scripts/format_summary.py
+++ b/scripts/format_summary.py
@@ -1,0 +1,107 @@
+# Ara's plotting library
+
+import numpy as np
+import copy
+import seaborn as sns
+import pandas as pd
+import matplotlib.pylab as plt
+import argparse
+
+# Instantiate the parser
+parser = argparse.ArgumentParser(description=
+'''
+Draw useful plots.
+''')
+
+# Switch
+parser.add_argument('-f', '--infile', action='store',
+                    help=
+'''
+Specify a file that contains all the kernel files with results.
+''')
+
+args = parser.parse_args()
+
+# Roofline plot
+
+# 2 vars - 1 const 1d histogram
+
+# 2d heatmap - vars on x/y-axes - hm() value on z-axis
+# arg1: label vector(y-axis + z-axis)
+# arg2: label vector (x-axis)
+def heatmap(db):
+  titlefont = {'fontname' : 'Garamond'};
+  axisfont  = {'fontname' : 'Garamond'};
+  sns.heatmap(db, cmap="Greens", annot=True)
+  plt.title('Relative kernel performance on maximum achievable', **titlefont)
+  plt.xlabel('Vector Length [elements]', **axisfont)
+  plt.ylabel('Kernel', **axisfont)
+  plt.show()
+
+# Append a new entry to the main database
+def append_entry(lst, template):
+  lst.append(copy.deepcopy(template))
+
+# Update the database
+def update_db(fpath, db, template):
+  with open(fpath, 'r') as fid:
+    for line in fid:
+      append_entry(db, template)
+      elm = line.split()
+      # [token]: lanes vsize sew cycles
+      assert len(elm) == 7
+      db[-1] = {
+        'kernel'     : elm[0],
+        'lanes'      : int(elm[1]),
+        'vsize'      : int(elm[2]),
+        'sew'        : int(elm[3]),
+        'perf'       : float(elm[4]),
+        'max_perf'   : float(elm[5]),
+        'ideal_disp' : int(elm[6]),
+      }
+
+def kernel_list_gen(db):
+  return list(set([d['kernel'] for d in db]))
+
+def vsize_list_gen(db, kernel_list):
+  return sorted(list(set([d0['vsize'] for d0 in db if
+    (len([d1 for d1 in db if d1['vsize'] == d0['vsize']]) == len(kernel_list))])))
+
+def create_db(db, r_label, c_label):
+  pd.DataFrame([[{l : [d['cycles']/d['max_cycles'] for d in db if (d['kernel'], d['size']) == (r, l)]} for l in c_label] for r in r_label])
+
+def main():
+  # Main database (DB)
+  db = list()
+
+  # DB entry template
+  template = {
+    'kernel'     : '',
+    'lanes'      : 0,
+    'vsize'      : 0,
+    'sew'        : 0,
+    'perf'       : 0,
+    'max_perf'   : 0,
+    'ideal_disp' : 0,
+  }
+
+  # Update the database with the information from the input file
+  update_db(args.infile, db, template)
+
+  # Build list of available kernels and common vsizes
+  kernel_list = kernel_list_gen(db)
+  vsize_list  = vsize_list_gen(db, kernel_list)
+
+  # Build relative performance(kernel, vsize) db
+  buf = [{vs : [(entry['perf'] / entry['max_perf']) for k in kernel_list for entry in db if (entry['kernel'], entry['vsize']) == (k, vs)]} for vs in vsize_list];
+  pkv_db = dict()
+  for d in buf:
+    pkv_db.update(d)
+  pkv_db = pd.DataFrame(pkv_db);
+  pkv_db.index = kernel_list;
+  pkv_db.sort_index(axis=0, inplace=True)
+
+  print(pkv_db)
+
+if __name__ == '__main__':
+  main()

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -93,7 +93,7 @@ def pathfinder(args, cycles):
   num_runs = int(args[0])
   cols     = int(args[1])
   rows     = int(args[2])
-  performance = 2 * num_runs * (cols - 1) * (rows - 1) / cycles
+  performance = 3 * num_runs * (cols - 1) * (rows - 1) / cycles
   return [cols, performance]
 def dotproduct(args, cycles):
   size        = int(args[0])

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -62,7 +62,7 @@ def fconv3d(args, cycles):
 def jacobi2d(args, cycles):
   size        = int(args[0])
   trash_0     = args[1]
-  performance = 5 * (size-1) * (size-1) / cycles
+  performance = 2 * 5 * (size-1) * (size-1) / cycles
   return [size, performance]
 def dropout(args, cycles):
   size        = int(args[0])
@@ -71,7 +71,7 @@ def dropout(args, cycles):
 def fft(args, cycles):
   size        = int(args[0])
   dtype       = args[1]
-  performance = 10 * size * np.log2(size) / cycles
+  performance = 5 * size * np.log2(size) / cycles
   return [size, performance]
 def dwt(args, cycles):
   size        = int(args[0])

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -165,7 +165,7 @@ real_maxPerf = {
   'dwt'        : lambda l, s : 4 * l / s,
   'exp'        : lambda l, s : 28/23 * l * 8/s,
   'softmax'    : lambda l, s : 32/25 * l * 8/s,
-  'pathfinder' : lambda l, s : 1/3 * l * 8/s,
+  'pathfinder' : lambda l, s : l * 8/s,
   'dotproduct' : lambda l, s : 4 * l/s,
   'fdotproduct': lambda l, s : 4 * l/s,
   'roi_align'  : lambda l, s : 3/5 * l * 8/s,

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -122,6 +122,41 @@ perfExtr = {
   'roi_align'  : roi_align,
 }
 
+# Maximum performance if Ara's BW can be fully utilized
+ideal_maxPerf = {
+  'imatmul'    : lambda l, s : 2 * l * 8/s,
+  'fmatmul'    : lambda l, s : 2 * l * 8/s,
+  'iconv2d'    : lambda l, s : 2 * l * 8/s,
+  'fconv2d'    : lambda l, s : 2 * l * 8/s,
+  'fconv3d'    : lambda l, s : 2 * l * 8/s,
+  'jacobi2d'   : lambda l, s : l * 8/s,
+  'dropout'    : lambda l, s : 4 * l / (2*s + 1/8),
+  'fft'        : lambda l, s : 6/5 * l * 8/s,
+  'dwt'        : lambda l, s : 4 * l / s,
+  'exp'        : lambda l, s : 28/23 * l * 8/s,
+  'softmax'    : lambda l, s : 32/25 * l * 8/s,
+  'pathfinder' : lambda l, s : l * 8/s,
+  'roi_align'  : lambda l, s : l * 8/s,
+}
+
+# Maximum performance taking into account Ara's limited BW
+# when performing strided/indexed memory accesses
+real_maxPerf = {
+  'imatmul'    : lambda l, s : 2 * l * 8/s,
+  'fmatmul'    : lambda l, s : 2 * l * 8/s,
+  'iconv2d'    : lambda l, s : 2 * l * 8/s,
+  'fconv2d'    : lambda l, s : 2 * l * 8/s,
+  'fconv3d'    : lambda l, s : 2 * l * 8/s,
+  'jacobi2d'   : lambda l, s : l * 8/s,
+  'dropout'    : lambda l, s : 4 * l / (2*s + 1/8),
+  'fft'        : lambda l, s : 6/5 * l * 8/s,
+  'dwt'        : lambda l, s : 1/3 * l * 8/s + 1/3,
+  'exp'        : lambda l, s : 28/23 * l * 8/s,
+  'softmax'    : lambda l, s : 32/25 * l * 8/s,
+  'pathfinder' : lambda l, s : 1/3 * l * 8/s,
+  'roi_align'  : lambda l, s : 3/5 * l * 8/s,
+}
+
 def main():
   kernel   = str(sys.argv[1])
   args     = str(sys.argv[2]).split()
@@ -133,7 +168,11 @@ def main():
     sys.exit('Error: the kernel "' + kernel + '" is not valid')
 
   # Print performance information on file
+#  if args.mode == 'perf':
   print(result[0], result[1])
+#  elif args.mode == 'max_perf':
+#    max_perf = real_maxPerf(kernel)(4, 8);
+#    print(kernel, max_perf)
 
 if __name__ == '__main__':
   main()

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -176,6 +176,9 @@ def main():
   metadata    = str(sys.argv[1]).split()
   args        = str(sys.argv[2]).split()
   cycles      = int(sys.argv[3])
+  dcache_stall= int(sys.argv[4])
+  icache_stall= int(sys.argv[5])
+  sb_full     = int(sys.argv[6])
   # Extract performance information
   try:
     result   = perfExtr[metadata[0]](args, cycles)
@@ -186,7 +189,7 @@ def main():
 
   # Print performance information on file
   # kernel, lanes, vsize, sew, perf, max_perf, ideal_disp
-  print(metadata[0], metadata[1], result[0], metadata[3], result[1], real_max_perf, metadata[4])
+  print(metadata[0], metadata[1], result[0], metadata[3], result[1], real_max_perf, metadata[4], dcache_stall, icache_stall, sb_full)
 
 if __name__ == '__main__':
   main()

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -103,7 +103,7 @@ def roi_align(args, cycles):
   n_boxes = int(args[4])
   crop_h  = int(args[5])
   crop_w  = int(args[6])
-  performance = 9 * batch * depth * n_boxes * crop_h * crop_w / cycles
+  performance = 9 * depth / cycles
   return [depth, performance]
 
 perfExtr = {

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -193,7 +193,8 @@ def main():
   if len(sys.argv) > 4:
     print(metadata[0], metadata[1], result[0], metadata[3], result[1], real_max_perf, metadata[4], dcache_stall, icache_stall, sb_full)
   else:
-    print(metadata[0], metadata[1], result[0], metadata[3], result[1], real_max_perf, metadata[4])
+    # CI run. Print only basic information for the roofline plots
+    print(result[0], result[1])
 
 if __name__ == '__main__':
   main()

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -62,7 +62,7 @@ def fconv3d(args, cycles):
 def jacobi2d(args, cycles):
   size        = int(args[0])
   trash_0     = args[1]
-  performance = 2 * 5 * (size-1) * (size-1) / cycles
+  performance = 5 * (size-1) * (size-1) / cycles
   return [size, performance]
 def dropout(args, cycles):
   size        = int(args[0])

--- a/scripts/performance.py
+++ b/scripts/performance.py
@@ -176,9 +176,10 @@ def main():
   metadata    = str(sys.argv[1]).split()
   args        = str(sys.argv[2]).split()
   cycles      = int(sys.argv[3])
-  dcache_stall= int(sys.argv[4])
-  icache_stall= int(sys.argv[5])
-  sb_full     = int(sys.argv[6])
+  if len(sys.argv) > 4:
+    dcache_stall= int(sys.argv[4])
+    icache_stall= int(sys.argv[5])
+    sb_full     = int(sys.argv[6])
   # Extract performance information
   try:
     result   = perfExtr[metadata[0]](args, cycles)
@@ -189,7 +190,10 @@ def main():
 
   # Print performance information on file
   # kernel, lanes, vsize, sew, perf, max_perf, ideal_disp
-  print(metadata[0], metadata[1], result[0], metadata[3], result[1], real_max_perf, metadata[4], dcache_stall, icache_stall, sb_full)
+  if len(sys.argv) > 4:
+    print(metadata[0], metadata[1], result[0], metadata[3], result[1], real_max_perf, metadata[4], dcache_stall, icache_stall, sb_full)
+  else:
+    print(metadata[0], metadata[1], result[0], metadata[3], result[1], real_max_perf, metadata[4])
 
 if __name__ == '__main__':
   main()

--- a/scripts/plot2d.py
+++ b/scripts/plot2d.py
@@ -49,7 +49,7 @@ def update_db(fpath, db, template):
       append_entry(db, template)
       elm = line.split()
       # [token]: lanes vsize sew cycles
-      assert len(elm) == 7
+      assert len(elm) == 10
       db[-1] = {
         'kernel'     : elm[0],
         'lanes'      : int(elm[1]),

--- a/scripts/plot2d.py
+++ b/scripts/plot2d.py
@@ -1,0 +1,109 @@
+# Ara's plotting library
+
+import numpy as np
+import copy
+import seaborn as sns
+import pandas as pd
+import matplotlib.pylab as plt
+import argparse
+
+# Instantiate the parser
+parser = argparse.ArgumentParser(description=
+'''
+Draw useful plots.
+''')
+
+# Switch
+parser.add_argument('-f', '--infile', action='store',
+                    help=
+'''
+Specify a file that contains all the kernel files with results.
+''')
+
+args = parser.parse_args()
+
+# Roofline plot
+
+# 2 vars - 1 const 1d histogram
+
+# 2d heatmap - vars on x/y-axes - hm() value on z-axis
+# arg1: label vector(y-axis + z-axis)
+# arg2: label vector (x-axis)
+def heatmap(db):
+  titlefont = {'fontname' : 'Garamond'};
+  axisfont  = {'fontname' : 'Garamond'};
+  sns.heatmap(db, cmap="Greens", annot=True)
+  plt.title('Relative kernel performance on maximum achievable', **titlefont)
+  plt.xlabel('Vector Length [elements]', **axisfont)
+  plt.ylabel('Kernel', **axisfont)
+  plt.show()
+
+# Append a new entry to the main database
+def append_entry(lst, template):
+  lst.append(copy.deepcopy(template))
+
+# Update the database
+def update_db(fpath, db, template):
+  with open(fpath, 'r') as fid:
+    for line in fid:
+      append_entry(db, template)
+      elm = line.split()
+      # [token]: lanes vsize sew cycles
+      assert len(elm) == 7
+      db[-1] = {
+        'kernel'     : elm[0],
+        'lanes'      : int(elm[1]),
+        'vsize'      : int(elm[2]),
+        'sew'        : int(elm[3]),
+        'perf'       : float(elm[4]),
+        'max_perf'   : float(elm[5]),
+        'ideal_disp' : int(elm[6]),
+      }
+
+def kernel_list_gen(db):
+  return list(set([d['kernel'] for d in db]))
+
+def vsize_list_gen(db, kernel_list):
+  return sorted(list(set([d0['vsize'] for d0 in db if
+    (len([d1 for d1 in db if d1['vsize'] == d0['vsize']]) == len(kernel_list))])))
+
+def create_db(db, r_label, c_label):
+  pd.DataFrame([[{l : [d['cycles']/d['max_cycles'] for d in db if (d['kernel'], d['size']) == (r, l)]} for l in c_label] for r in r_label])
+
+def main():
+  # Main database (DB)
+  db = list()
+
+  # DB entry template
+  template = {
+    'kernel'     : '',
+    'lanes'      : 0,
+    'vsize'      : 0,
+    'sew'        : 0,
+    'perf'       : 0,
+    'max_perf'   : 0,
+    'ideal_disp' : 0,
+  }
+
+  # Update the database with the information from the input file
+  update_db(args.infile, db, template)
+
+  # Build list of available kernels and common vsizes
+  kernel_list = kernel_list_gen(db)
+  vsize_list  = vsize_list_gen(db, kernel_list)
+
+  # Build relative performance(kernel, vsize) db
+  buf = [{vs : [(entry['perf'] / entry['max_perf']) for k in kernel_list for entry in db if (entry['kernel'], entry['vsize']) == (k, vs)]} for vs in vsize_list];
+  pkv_db = dict()
+  for d in buf:
+    pkv_db.update(d)
+  pkv_db = pd.DataFrame(pkv_db);
+  pkv_db.index = kernel_list;
+
+  print(pkv_db)
+
+  # Plot heatmap
+  heatmap(pkv_db)
+
+if __name__ == '__main__':
+  main()

--- a/scripts/plot2d.py
+++ b/scripts/plot2d.py
@@ -58,6 +58,9 @@ def update_db(fpath, db, template):
         'perf'       : float(elm[4]),
         'max_perf'   : float(elm[5]),
         'ideal_disp' : int(elm[6]),
+        'dstall'     : int(elm[7]),
+        'istall'     : int(elm[8]),
+        'sb_full'    : int(elm[9]),
       }
 
 def kernel_list_gen(db):
@@ -83,6 +86,9 @@ def main():
     'perf'       : 0,
     'max_perf'   : 0,
     'ideal_disp' : 0,
+    'dstall'     : 0,
+    'istall'     : 0,
+    'sb_full'    : 0,
   }
 
   # Update the database with the information from the input file

--- a/scripts/plot2d.py
+++ b/scripts/plot2d.py
@@ -99,6 +99,7 @@ def main():
     pkv_db.update(d)
   pkv_db = pd.DataFrame(pkv_db);
   pkv_db.index = kernel_list;
+  pkv_db.sort_index(axis=0, inplace=True)
 
   print(pkv_db)
 

--- a/scripts/plot2d.py
+++ b/scripts/plot2d.py
@@ -20,6 +20,18 @@ parser.add_argument('-f', '--infile', action='store',
 Specify a file that contains all the kernel files with results.
 ''')
 
+parser.add_argument('-o', '--outfile', action='store',
+                    help=
+'''
+Specify a the path in which you want to save the plot.
+''')
+
+parser.add_argument('-s', '--show', action='store',
+                    help=
+'''
+Show the plot.
+''')
+
 args = parser.parse_args()
 
 # Roofline plot
@@ -34,9 +46,13 @@ def heatmap(db):
   axisfont  = {'fontname' : 'Garamond'};
   sns.heatmap(db, cmap="Greens", annot=True)
   plt.title('Relative kernel performance on maximum achievable', **titlefont)
-  plt.xlabel('Vector Length [elements]', **axisfont)
+  plt.xlabel('Vector Length [Byte]', **axisfont)
   plt.ylabel('Kernel', **axisfont)
-  plt.show()
+  if args.show:
+    plt.show()
+  if args.outfile:
+    plt.savefig(args.outfile)
+
 
 # Append a new entry to the main database
 def append_entry(lst, template):
@@ -62,6 +78,10 @@ def update_db(fpath, db, template):
         'istall'     : int(elm[8]),
         'sb_full'    : int(elm[9]),
       }
+
+def elm_2_byte_db(db):
+  for i, elm in enumerate(db):
+    db[i]['vsize'] = elm['vsize'] * elm['sew']
 
 def kernel_list_gen(db):
   return list(set([d['kernel'] for d in db]))
@@ -93,6 +113,9 @@ def main():
 
   # Update the database with the information from the input file
   update_db(args.infile, db, template)
+
+  # Size in Byte
+  elm_2_byte_db(db)
 
   # Build list of available kernels and common vsizes
   kernel_list = kernel_list_gen(db)


### PR DESCRIPTION
Improve performance measurement scripts and kernels.

## Changelog

### Fixed

 - Fix dump vtrace script for vsetvli instructions without x0 (ideal dispatcher)
 - Fix Pathfinder and FFT performance

### Added

 - Plot kernels-Vl performance plot
 - Print I$/D$ stall metrics

### Changed

 - Optimize Jacobi2d
 - Benchmark only the vector kernel in roi_align
 - Improve cache warming functions
 - [f]dotproduct works on the vector length in elements
 - Optimize DWT
 - Fix pathfinder performance

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
