### PR TITLE
[CONTRIBUTING] :pencil2: remove redundant commit message emoji

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ please find some of the most important points below.
     * :sparkles: `:sparkles:` When introducing a new feature
     * :art: `:art:` Improving the format/structure of the code
     * :zap: `:zap:` When improving performance
-    * :fire: `:fire` Removing code or files.
+    * :fire: `:fire` (When) removing code or files.
     * :memo: `:memo:` When writing docs
     * :bug: `:bug:` When fixing a bug
     * :wastebasket: `:wastebasket:` When removing code or files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,6 @@ please find some of the most important points below.
     * :fire: `:fire` Removing code or files.
     * :memo: `:memo:` When writing docs
     * :bug: `:bug:` When fixing a bug
-    * :fire: `:fire:` When removing code or files
     * :wastebasket: `:wastebasket:` When removing code or files
     * :green_heart: `:green_heart:` When fixing the CI build
     * :construction_worker: `:construction_worker:` Adding CI build system


### PR DESCRIPTION
Remove redundant commit message emoji

## Changelog

### Fixed

- Redundant Fire emoji in `CONTRIBUTING.md`

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
