### PR TITLE
[DEPENDENCIES] Add `pulp-platform/apb` to Hardware Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Plot kernels-Vl performance plot
  - Print I$/D$ stall metrics
  - Add `spmv`, `conjugate_gradient`, and `gemv` kernels.
-
+ - Add `apb` to Hardware Dependencies
+   
 ### Changed
 
  - Optimize Jacobi2d

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -7,6 +7,7 @@ Ara has strong and weak dependencies on several packages. Such dependencies and 
 Ara needs the following hardware packages to work.
 
 - [axi](https://github.com/pulp-platform/axi)
+- [apb](https://github.com/pulp-platform/apb)
 - [common\_cells](https://github.com/pulp-platform/common_cells)
 - [common\_verification](https://github.com/pulp-platform/common_verification)
 - [cva6](https://github.com/openhwgroup/cva6)


### PR DESCRIPTION
Since macro `APB_TYPEDEF_ALL` is being used in `ara_soc.sv` line 264 and other, it is necessary to add apb in Hardware Dependencies list to for clarity and convenience.  Required File in pulp-platform/apb: https://github.com/pulp-platform/apb/blob/master/include/apb/typedef.svh

Description of PR that completes issue here...

## Changelog
Add pulp-platform/apb to the Hardware Dependencies


### Added

- Add pulp-platform/apb to the Hardware Dependencies

### Changed

- Hardware Dependencies increased from 5 to 6 (Add APB)

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

