### PR TITLE
[hardware] disable common-cells assertions forr verilator

### DIFF
--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -106,7 +106,7 @@ vlog_args += -work $(library)
 
 # Bender
 # Defines
-bender_defs += --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen) --define ARIANE_ACCELERATOR_PORT=1
+bender_defs += --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen) --define ARIANE_ACCELERATOR_PORT=1 --define COMMON_CELLS_ASSERTS_OFF
 # Targets
 bender_common_targs := -t rtl -t cv64a6_imafdcv_sv39 -t tech_cells_generic_include_tc_sram -t tech_cells_generic_include_tc_clk
 bender_targs_simc     := $(bender_common_targs) -t ara_test -t cva6_test


### PR DESCRIPTION
With the new `common_cells`, a guard macro has been introduced to keep out assertions during simulations, as they are not 100% compatible with all the simulation tool versions (e.g., Verilator).
We therefore disable them.

## Changelog

### Changed

- Disable `common_cells` assertions in verilator.

## Checklist

- [x] Automated tests pass
- [ ] Changelog updated
- [x] Code style guideline is observed
