### PR TITLE
[HW] Bump CVA6 to `pulp-v1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
         ln -s $VERILATOR_ROOT/share/verilator/include $VERILATOR_ROOT/include
         ln -s $VERILATOR_ROOT/share/verilator/bin/verilator_includer $VERILATOR_ROOT/bin/verilator_includer
     - name: Download RTL submodules
-      run: make -C hardware update
+      run: make -C hardware checkout
     - name: Compile Verilated model of Ara
       run: |
         sudo apt-get install libelf-dev

--- a/Bender.local
+++ b/Bender.local
@@ -1,7 +1,0 @@
-# Copyright 2023 ETH Zurich and University of Bologna.
-# Solderpad Hardware License, Version 0.51, see LICENSE for details.
-# SPDX-License-Identifier: SHL-0.51
-
-overrides:
-  axi:                { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.1 }
-  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13 }

--- a/Bender.lock
+++ b/Bender.lock
@@ -6,16 +6,6 @@ packages:
       Git: https://github.com/pulp-platform/apb.git
     dependencies:
     - common_cells
-  ariane:
-    revision: 2ebe023f7289300348c68e99267afcc03256f3ed
-    version: null
-    source:
-      Git: https://github.com/pulp-platform/cva6.git
-    dependencies:
-    - axi
-    - common_cells
-    - fpnew
-    - tech_cells_generic
   axi:
     revision: fccffb5953ec8564218ba05e20adbedec845e014
     version: 0.39.1
@@ -39,11 +29,21 @@ packages:
     source:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
-  fpnew:
-    revision: 3116391bf66660f806b45e212b9949c528b4e270
-    version: 0.7.0
+  cva6:
+    revision: ee89dcc00e6c1a1f4cf97ee1835e950fcfdeebb5
+    version: null
     source:
-      Git: https://github.com/openhwgroup/cvfpu.git
+      Git: https://github.com/pulp-platform/cva6.git
+    dependencies:
+    - axi
+    - common_cells
+    - fpnew
+    - tech_cells_generic
+  fpnew:
+    revision: f231041c610f270ffc03cbdac38739ddb6426572
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/cvfpu.git
     dependencies:
     - common_cells
     - fpu_div_sqrt_mvp

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,12 +17,12 @@ dependencies:
 workspace:
   checkout_dir: "hardware/deps"
 
-export_include_dirs:
-  - hardware/include
-
 sources:
-  files:
+  include_dirs:
     # Headers
+    - hardware/include
+  files:
+    # Packages
     - hardware/include/rvv_pkg.sv
     - hardware/include/ara_pkg.sv
 

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   axi:                { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.1                               }
   common_cells:       { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.22.1                               }
-  ariane:             { git: "https://github.com/pulp-platform/cva6.git",               rev: 2ebe023f7289300348c68e99267afcc03256f3ed } # mp/acc_port_rebase
+  cva6:               { git: "https://github.com/pulp-platform/cva6.git",               rev: ee89dcc00e6c1a1f4cf97ee1835e950fcfdeebb5 } # pulp-v1
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13                               }
   apb:                { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4                                }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+ - Disable common_cells assertions when simulating with Verilator
+ - Bender checkout instead of update
+ - Remove Bender.local (use Bender.lock for reproducibility)
+ - Update CVA6 to OpenHW group master branch
  - Optimize Jacobi2d
  - Benchmark only the vector kernel in roi_align
  - Improve cache warming functions

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To install Bender and initialize all the hardware IPs, run the following command
 # Go to the hardware folder
 cd hardware
 # Install Bender and checkout all the IPs
-make update
+make checkout
 ```
 
 ### Patches (only once!)

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -106,7 +106,8 @@ vlog_args += -work $(library)
 
 # Bender
 # Defines
-bender_defs += --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen) --define ARIANE_ACCELERATOR_PORT=1 --define COMMON_CELLS_ASSERTS_OFF
+bender_defs += --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen) --define ARIANE_ACCELERATOR_PORT=1
+bender_defs_veril := $(bender_defs) --define COMMON_CELLS_ASSERTS_OFF
 # Targets
 bender_common_targs := -t rtl -t cv64a6_imafdcv_sv39 -t tech_cells_generic_include_tc_sram -t tech_cells_generic_include_tc_clk
 bender_targs_simc     := $(bender_common_targs) -t ara_test -t cva6_test
@@ -183,7 +184,7 @@ verilate: $(buildpath) bender $(veril_library)/V$(veril_top)
 
 $(veril_library)/V$(veril_top): $(config_file) Makefile ../Bender.yml $(shell find src -type f) $(shell find ../config -type f) $(shell find include -type f) $(shell find tb -type f) $(shell find deps -type f)
 	rm -rf $(veril_library); mkdir -p $(veril_library)
-	$(BENDER) script verilator $(bender_targs_veril) $(bender_defs) > $(veril_library)/bender_script_$(config)
+	$(BENDER) script verilator $(bender_targs_veril) $(bender_defs_veril) > $(veril_library)/bender_script_$(config)
 # Verilate the design
 	$(veril_path)/verilator -f $(veril_library)/bender_script_$(config)           \
   -GNrLanes=$(nr_lanes)                                                         \

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -80,9 +80,11 @@ package ara_pkg;
   localparam int unsigned LatFCompEW16    = 'd3;
   localparam int unsigned LatFCompEW8     = 'd2;
   localparam int unsigned LatFCompEW16Alt = 'd3;
+  localparam int unsigned LatFCompEW8Alt  = 'd2;
   localparam int unsigned LatFDivSqrt     = 'd3;
   localparam int unsigned LatFNonComp     = 'd1;
   localparam int unsigned LatFConv        = 'd2;
+  localparam int unsigned LatFDotp        = 'd0;
   // Define the maximum FPU latency
   localparam int unsigned LatFMax = LatFCompEW64;
 

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -466,16 +466,4 @@ module ara import ara_pkg::*; #(
   if (ara_pkg::VLEN != 2**$clog2(ara_pkg::VLEN))
     $error("[ara] The vector length must be a power of two.");
 
-  if (RVVD(FPUSupport) && !ariane_pkg::RVD)
-    $error(
-      "[ara] Cannot support double-precision floating-point on Ara if Ariane does not support it.");
-
-  if (RVVF(FPUSupport) && !ariane_pkg::RVF)
-    $error(
-      "[ara] Cannot support single-precision floating-point on Ara if Ariane does not support it.");
-
-  if (RVVH(FPUSupport) && !ariane_pkg::XF16)
-    $error(
-      "[ara] Cannot support half-precision floating-point on Ara if Ariane does not support it.");
-
 endmodule : ara

--- a/hardware/src/ara_system.sv
+++ b/hardware/src/ara_system.sv
@@ -16,7 +16,7 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
     // Support for fixed-point data types
     parameter fixpt_support_e                   FixPtSupport       = FixedPointEnable,
     // Ariane configuration
-    parameter ariane_pkg::ariane_cfg_t          ArianeCfg          = ariane_pkg::ArianeDefaultConfig,
+    parameter config_pkg::cva6_cfg_t            CVA6Cfg            = cva6_config_pkg::cva6_cfg,
     // AXI Interface
     parameter int                      unsigned AxiAddrWidth       = 64,
     parameter int                      unsigned AxiIdWidth         = 6,
@@ -112,35 +112,39 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
   );
 `else
   cva6 #(
-    .ArianeCfg(ArianeCfg),
-    .cvxif_req_t (acc_pkg::accelerator_req_t),
-    .cvxif_resp_t (acc_pkg::accelerator_resp_t),
-    .AxiAddrWidth ( AxiAddrWidth ),
-    .AxiDataWidth ( AxiNarrowDataWidth ),
-    .AxiIdWidth ( AxiIdWidth ),
-    .axi_ar_chan_t (ariane_axi_ar_t),
-    .axi_aw_chan_t (ariane_axi_aw_t),
-    .axi_w_chan_t (ariane_axi_w_t),
-    .axi_req_t (ariane_axi_req_t),
-    .axi_rsp_t (ariane_axi_resp_t)
+    .CVA6Cfg          (CVA6Cfg                    ),
+    .cvxif_req_t      (acc_pkg::accelerator_req_t ),
+    .cvxif_resp_t     (acc_pkg::accelerator_resp_t),
+    .axi_ar_chan_t    (ariane_axi_ar_t            ),
+    .axi_aw_chan_t    (ariane_axi_aw_t            ),
+    .axi_w_chan_t     (ariane_axi_w_t             ),
+    .b_chan_t         (ariane_axi_b_t             ),
+    .r_chan_t         (ariane_axi_r_t             ),
+    .noc_req_t        (ariane_axi_req_t           ),
+    .noc_resp_t       (ariane_axi_resp_t          )
   ) i_ariane (
-    .clk_i            (clk_i                 ),
-    .rst_ni           (rst_ni                ),
-    .boot_addr_i      (boot_addr_i           ),
-    .hart_id_i        (hart_id               ),
-    .irq_i            ('0                    ),
-    .ipi_i            ('0                    ),
-    .time_irq_i       ('0                    ),
-    .debug_req_i      ('0                    ),
-    .rvfi_o           (                      ),
+    .clk_i            (clk_i                   ),
+    .rst_ni           (rst_ni                  ),
+    .boot_addr_i      (boot_addr_i             ),
+    .hart_id_i        (hart_id                 ),
+    .irq_i            ('0                      ),
+    .ipi_i            ('0                      ),
+    .time_irq_i       ('0                      ),
+    .debug_req_i      ('0                      ),
+    .clic_irq_valid_i ('0                      ),
+    .clic_irq_id_i    ('0                      ),
+    .clic_irq_level_i ('0                      ),
+    .clic_irq_priv_i  (riscv::priv_lvl_t'(2'b0)),
+    .clic_irq_shv_i   ('0                      ),
+    .clic_irq_ready_o (/* empty */             ),
+    .clic_kill_req_i  ('0                      ),
+    .clic_kill_ack_o  (/* empty */             ),
+    .rvfi_probes_o    (/* empty */             ),
     // Accelerator ports
-    .cvxif_req_o      (acc_req               ),
-    .cvxif_resp_i     (acc_resp_pack         ),
-    .l15_req_o        (                      ),
-    .l15_rtrn_i       ( '0                   ),
-    // Memory interface
-    .axi_req_o        (ariane_narrow_axi_req ),
-    .axi_resp_i       (ariane_narrow_axi_resp)
+    .cvxif_req_o      (acc_req                 ),
+    .cvxif_resp_i     (acc_resp_pack           ),
+    .noc_req_o        (ariane_narrow_axi_req   ),
+    .noc_resp_i       (ariane_narrow_axi_resp  )
   );
 `endif
 

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -762,22 +762,24 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       Width        : 64,
       EnableVectors: 1'b1,
       EnableNanBox : 1'b1,
-      FpFmtMask    : {RVVF(FPUSupport), RVVD(FPUSupport), RVVH(FPUSupport), 1'b0, 1'b0},
+      FpFmtMask    : {RVVF(FPUSupport), RVVD(FPUSupport), RVVH(FPUSupport), 1'b0, 1'b0, 1'b0},
       IntFmtMask   : {1'b0, 1'b1, 1'b1, 1'b1}
     };
 
     // Implementation (number of registers etc)
     localparam fpu_implementation_t FPUImplementation = '{
       PipeRegs: '{
-        '{LatFCompEW32, LatFCompEW64, LatFCompEW16, LatFCompEW8, LatFCompEW16Alt},
+        '{LatFCompEW32, LatFCompEW64, LatFCompEW16, LatFCompEW8, LatFCompEW16Alt, LatFCompEW8Alt},
         '{default: LatFDivSqrt},
         '{default: LatFNonComp},
-        '{default: LatFConv}},
+        '{default: LatFConv},
+        '{default: LatFDotp}},
       UnitTypes: '{
         '{default: PARALLEL}, // ADDMUL
         '{default: MERGED},   // DIVSQRT
         '{default: PARALLEL}, // NONCOMP
-        '{default: MERGED}}, // CONV
+        '{default: MERGED}, // CONV
+        '{default: DISABLED}}, // DOTP
       PipeConfig: DISTRIBUTED
     };
 
@@ -989,6 +991,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     ) i_fpnew_bulk (
       .clk_i         (clk_i          ),
       .rst_ni        (rst_ni         ),
+      .hart_id_i     ('0             ),
       .flush_i       (1'b0           ),
       .rnd_mode_i    (fp_rm          ),
       .op_i          (fp_op          ),

--- a/hardware/tb/dpi/elfloader.cc
+++ b/hardware/tb/dpi/elfloader.cc
@@ -1,1 +1,1 @@
-../../deps/ariane/corev_apu/tb/dpi/elfloader.cc
+../../deps/cva6/corev_apu/tb/dpi/elfloader.cc


### PR DESCRIPTION
Bump CVA6 to a recent version from OpenHW Group.
Moreover, use `Bender.lock` and remove `Bender.local` to improve reproducibility.

## Changelog

### Changed

 - Disable common_cells assertions when simulating with Verilator
 - Bender checkout instead of update
 - Remove Bender.local (use Bender.lock for reproducibility)
 - Update CVA6 to OpenHW group master branch


## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
