### PR TITLE
[HW] 🐛 Fix for floating-point NaN/subnormal handling in opqueues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix printf bug (missing characters) - UART and CTRL memory regions are now idempotent
  - Start int reductions only if ALU result queue is empty
  - Fix `acc_dispatcher` CVA6 bug for instructions with side effects
+ - Fix NaN/subnormal floating-point handling in opqueues
 
 ### Added
 

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -155,6 +155,42 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   // Helper to fill with neutral values the last packet
   logic incomplete_packet, last_packet;
 
+  // To convert subnormal numbers to normalized form in floating-point numbers,
+  // it is necessary to determine the number of leading zeros in the mantissa.
+  // This is typically accomplished using a lzc (leading zero count) module,
+  // which can accurately count the number of leading zeros in a given number.
+  // By knowing the number of leading zeros in the mantissa, we can properly
+  // adjust the exponent and shift the binary point to achieve a normalized
+  // representation of the number.
+
+  logic [3:0] lzc_count16[2];
+  logic [4:0] lzc_count32;
+
+  fp16_t fp16[2];
+  fp32_t fp32;
+
+  // sew: 16-bit
+  for (genvar i = 0; i < 2; i = i + 1) begin
+    lzc #(
+      .WIDTH(10),
+      .MODE (1 )
+    ) leading_zero_e16_i (
+       .in_i    ( fp16[i].m         ),
+       .cnt_o   ( lzc_count16[i] ),
+       .empty_o ( /*Unused*/     )
+    );
+  end
+
+  // sew: 32-bit
+  lzc #(
+     .WIDTH (23),
+     .MODE  (1 )
+   ) leading_zero_e32(
+     .in_i    ( fp32.m      ),
+     .cnt_o   ( lzc_count32 ),
+     .empty_o ( /*Unused*/  )
+   );
+
   always_comb begin: type_conversion
     // Shuffle the input operand
     automatic logic [idx_width(StrbWidth)-1:0] select = deshuffle_index(select_q, 1, cmd.eew);
@@ -337,23 +373,54 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
           unique casez ({cmd.eew, RVVH(FPUSupport), RVVF(FPUSupport), RVVD(FPUSupport)})
             {EW16, 1'b1, 1'b1, 1'b?}: begin
               for (int e = 0; e < 2; e++) begin
-                automatic fp16_t fp16 = ibuf_operand[8*select + 32*e +: 16];
-                automatic fp32_t fp32;
+                automatic fp32_t fp32_o;
+                automatic fp16_t fp16_temp;
+                automatic logic [7:0] fp32_exp;
 
-                fp32.s = fp16.s;
-                fp32.e = (fp16.e - 15) + 127;
-                fp32.m = {fp16.m, 13'b0};
+                fp16[e] = ibuf_operand[8*select + 32*e +: 16];
 
-                conv_operand[32*e +: 32] = fp32;
+                fp16_temp.m = ((fp16[e].e == '0) && (fp16[e].m != '0)) ? fp16[e].m << (5'd1 + {1'd0, lzc_count16[e]}) : fp16[e].m;
+
+                fp32_exp = (fp16[e].m == '0) ? '0 : 8'd112 - {4'd0, lzc_count16[e]};  //127 - 15 = 112
+
+                unique case(fp16[e].e)
+                  '0:      fp32_o.e = fp32_exp; // Zero or Subnormal
+                  '1:      fp32_o.e = '1; // NaN
+                  default: fp32_o.e = 8'd112 + {3'd0, fp16[e].e}; // Normal ,127 - 15 = 112
+                endcase
+
+                fp32_o.s = fp16[e].s;
+
+                // If the input is NaN, output a quiet NaN mantissa.
+                // Otherwise, append trailing zeros to the mantissa.
+                fp32_o.m = ((fp16[e].e == '1) && (fp16[e].m != '0) ) ? {1'b1, 22'b0} : {fp16_temp.m, 13'b0};
+
+                conv_operand[32*e +: 32] = fp32_o;
               end
             end
             {EW32, 1'b?, 1'b1, 1'b1}: begin
-              automatic fp32_t fp32 = ibuf_operand[8*select +: 32];
               automatic fp64_t fp64;
+              automatic fp32_t fp32_temp;
+
+              automatic logic [10:0] fp64_exp;
+
+              fp32  = ibuf_operand[8*select +: 32];
+
+              fp32_temp.m = ((fp32.e == '0) && (fp32.m != '0)) ? fp32.m << (8'd1 + {3'd0, lzc_count32}) : fp32.m;
+
+              fp64_exp = (fp32.m == '0) ? '0 : 11'd896 - {6'd0, lzc_count32}; //1023 - 127 = 896
+
+              unique case(fp32.e)
+                '0:      fp64.e = fp64_exp; // Zero or Subnormal
+                '1:      fp64.e = '1; // NaN
+                default: fp64.e = 11'd896 + {3'd0, fp32.e}; // Normal , 1023 - 127 = 896
+              endcase
 
               fp64.s = fp32.s;
-              fp64.e = (fp32.e - 127) + 1023;
-              fp64.m = {fp32.m, 29'b0};
+
+              // If the input is NaN, output a quiet NaN mantissa.
+              // Otherwise, append trailing zeros to the mantissa.
+              fp64.m = ((fp32.e == '1) && (fp32.m != '0)) ? {1'b1, 51'b0} : {fp32_temp.m, 29'b0};
 
               conv_operand = fp64;
             end

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -724,6 +724,50 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
       15: reduction_rx_cnt_init = reduction_rx_cnt_t'(4);
     endcase
   endfunction: reduction_rx_cnt_init
+
+  ////////////////////////////////
+  //  Floating-point conversion //
+  ////////////////////////////////
+
+  logic [$clog2(fp_mantissa_bits(EW16, 0))-1:0] fp16_m_lzc[2]; // 4 bits each
+  logic [$clog2(fp_mantissa_bits(EW32, 0))-1:0] fp32_m_lzc;    // 5 bits each
+
+  fp16_t fp16[2];
+  fp32_t fp32;
+
+  // To convert subnormal numbers to normalized form in floating-point numbers,
+  // it is necessary to determine the number of leading zeros in the mantissa.
+  // This is typically accomplished using a lzc (leading zero count) module,
+  // which can accurately count the number of leading zeros in a given number.
+  // By knowing the number of leading zeros in the mantissa, we can properly
+  // adjust the exponent and shift the binary point to achieve a normalized
+  // representation of the number.
+  if ({RVVH(FPUSupport), RVVF(FPUSupport)} == 2'b11) begin
+    // sew: 16-bit
+    for (genvar i = 0; i < 2; i++) begin
+      lzc #(
+        .WIDTH(fp_mantissa_bits(EW16, 0)),
+        .MODE (1)
+      ) leading_zero_e16_i (
+        .in_i   (fp16[i].m    ),
+        .cnt_o  (fp16_m_lzc[i]),
+        .empty_o(/*Unused*/   )
+      );
+    end
+  end
+
+  if ({RVVF(FPUSupport), RVVD(FPUSupport)} == 2'b11) begin
+    // sew: 32-bit
+    lzc #(
+       .WIDTH(fp_mantissa_bits(EW32, 0)),
+       .MODE (1)
+     ) leading_zero_e32 (
+       .in_i   (fp32.m    ),
+       .cnt_o  (fp32_m_lzc),
+       .empty_o(/*Unused*/)
+     );
+  end
+
   ///////////
   //  FPU  //
   ///////////
@@ -1341,6 +1385,9 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     operands_ready = vinsn_issue_q.swap_vs2_vd_op
                    ? {vinsn_issue_q.use_vs2, vinsn_issue_q.use_vd_op, vinsn_issue_q.use_vs1}
                    : {vinsn_issue_q.use_vd_op, vinsn_issue_q.use_vs2, vinsn_issue_q.use_vs1};
+
+    for (int i = 0; i < 2; i++) fp16[i] = '0;
+    for (int i = 0; i < 1; i++) fp32[i] = '0;
 
     first_op_d              = first_op_q;
     simd_red_cnt_d          = simd_red_cnt_q;
@@ -2165,24 +2212,15 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
             RVVD(FPUSupport)})
             {EW32, 1'b1, 1'b1, 1'b?}: begin
               for (int e = 0; e < 2; e++) begin
-                automatic fp16_t fp16 =
-                  vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[15:0];
-                automatic fp32_t fp32;
-                fp32.s = fp16.s;
-                fp32.e = (fp16.e - 15) + 127;
-                fp32.m = {fp16.m, 13'b0};
-
-                vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[32*e +: 32] = fp32;
+                fp16[e] = vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[15:0];
+                vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[32*e +: 32] =
+                  fp32_from_fp16(fp16[e], fp16_m_lzc[e]);
               end
             end
             {EW64, 1'b?, 1'b1, 1'b1}: begin
-              automatic fp32_t fp32 = vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[31:0];
-              automatic fp64_t fp64;
-              fp64.s = fp32.s;
-              fp64.e = (fp32.e - 127) + 1023;
-              fp64.m = {fp32.m, 29'b0};
-
-              vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op = fp64;
+              fp32 = vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op[31:0];
+              vinsn_queue_d.vinsn[vinsn_queue_q.accept_pnt].scalar_op =
+                fp64_from_fp32(fp32, fp32_m_lzc);
             end
             default:;
           endcase


### PR DESCRIPTION
Following up: https://github.com/pulp-platform/ara/pull/222

## Changelog

### Fixed

- Fix NaN handling during opqueue floating-point coversions
- Fix subnormal handling during optuque floating-point conversions

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
- [x] No max freq. degradation