### PR TITLE
[HW] Make `VLEN` a module parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Rename CSRs in dispatcher to improve clarity
  - Change from reporting "errors" to full "exceptions"
  - Bump CVA6 to version that supports "exceptions" reporting
+ - VLEN is now a parameter of the ara architecture and does not depend on a define anymore
+ - vlen_t, as a consequence, is now define within the architecture as a parameter/localparam
 
 ## 3.0.0 - 2023-09-08
 

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -188,6 +188,7 @@ $(veril_library)/V$(veril_top): $(config_file) Makefile ../Bender.yml $(shell fi
 # Verilate the design
 	$(veril_path)/verilator -f $(veril_library)/bender_script_$(config)           \
   -GNrLanes=$(nr_lanes)                                                         \
+  -GVLEN=$(vlen)                                                                \
   -O3                                                                           \
   -Wno-fatal                                                                    \
   -Wno-PINCONNECTEMPTY                                                          \

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -203,7 +203,6 @@ $(veril_library)/V$(veril_top): $(config_file) Makefile ../Bender.yml $(shell fi
   -Wno-WIDTHCONCAT                                                              \
   -Wno-ENUMVALUE                                                                \
   -Wno-COMBDLY                                                                  \
-  --hierarchical                                                                \
   tb/verilator/waiver.vlt                                                       \
   --Mdir $(veril_library)                                                       \
   -Itb/dpi                                                                      \

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -282,37 +282,36 @@ package ara_pkg;
    * packing) functions.
    */
 
-  function automatic int unsigned shuffle_index(logic[15:0] byte_idx, int NrLanes, rvv_pkg::vew_e ew, int VLEN);
-    typedef logic[$clog2(VLEN+1)-1:0] vlen_t;
+  function automatic logic [$clog2(8*MaxNrLanes)-1:0] shuffle_index(logic[15:0] byte_idx, int NrLanes, rvv_pkg::vew_e ew);
     // Generate the shuffling of the table above
     unique case (NrLanes)
       1: unique case (ew)
           rvv_pkg::EW64: begin
-            automatic vlen_t [7:0] idx;
+            automatic logic [$clog2(8)-1:0] idx [7:0];
             idx[7] = 7; idx[6] = 6; idx[5] = 5; idx[4] = 4;
             idx[3] = 3; idx[2] = 2; idx[1] = 1; idx[0] = 0;
             return idx[byte_idx[2:0]];
           end
           rvv_pkg::EW32: begin
-            automatic vlen_t [7:0] idx;
+            automatic logic [$clog2(8)-1:0] idx [7:0];
             idx[7] = 7; idx[6] = 6; idx[5] = 5; idx[4] = 4;
             idx[3] = 3; idx[2] = 2; idx[1] = 1; idx[0] = 0;
             return idx[byte_idx[2:0]];
           end
           rvv_pkg::EW16: begin
-            automatic vlen_t [7:0] idx;
+            automatic logic [$clog2(8)-1:0] idx [7:0];
             idx[7] = 7; idx[6] = 6; idx[5] = 3; idx[4] = 2;
             idx[3] = 5; idx[2] = 4; idx[1] = 1; idx[0] = 0;
             return idx[byte_idx[2:0]];
           end
           rvv_pkg::EW8: begin
-            automatic vlen_t [7:0] idx;
+            automatic logic [$clog2(8)-1:0] idx [7:0];
             idx[7] = 7; idx[6] = 3; idx[5] = 5; idx[4] = 1;
             idx[3] = 6; idx[2] = 2; idx[1] = 4; idx[0] = 0;
             return idx[byte_idx[2:0]];
           end
           default: begin
-            automatic vlen_t [7:0] idx;
+            automatic logic [$clog2(8)-1:0] idx [7:0];
             idx[7] = 7; idx[6] = 6; idx[5] = 5; idx[4] = 4;
             idx[3] = 3; idx[2] = 2; idx[1] = 1; idx[0] = 0;
             return idx[byte_idx[2:0]];
@@ -320,7 +319,7 @@ package ara_pkg;
         endcase
       2: unique case (ew)
           rvv_pkg::EW64: begin
-            automatic vlen_t [15:0] idx;
+            automatic logic [$clog2(16)-1:0] idx [15:0];
             idx[15] = 15; idx[14] = 14; idx[13] = 13; idx[12] = 12;
             idx[11] = 11; idx[10] = 10; idx[09] = 09; idx[08] = 08;
             idx[07] = 07; idx[06] = 06; idx[05] = 05; idx[04] = 04;
@@ -328,7 +327,7 @@ package ara_pkg;
             return idx[byte_idx[3:0]];
           end
           rvv_pkg::EW32: begin
-            automatic vlen_t [15:0] idx;
+            automatic logic [$clog2(16)-1:0] idx [15:0];
             idx[15] = 15; idx[14] = 14; idx[13] = 13; idx[12] = 12;
             idx[11] = 07; idx[10] = 06; idx[09] = 05; idx[08] = 04;
             idx[07] = 11; idx[06] = 10; idx[05] = 09; idx[04] = 08;
@@ -336,7 +335,7 @@ package ara_pkg;
             return idx[byte_idx[3:0]];
           end
           rvv_pkg::EW16: begin
-            automatic vlen_t [15:0] idx;
+            automatic logic [$clog2(16)-1:0] idx [15:0];
             idx[15] = 15; idx[14] = 14; idx[13] = 07; idx[12] = 06;
             idx[11] = 11; idx[10] = 10; idx[09] = 03; idx[08] = 02;
             idx[07] = 13; idx[06] = 12; idx[05] = 05; idx[04] = 04;
@@ -344,7 +343,7 @@ package ara_pkg;
             return idx[byte_idx[3:0]];
           end
           rvv_pkg::EW8: begin
-            automatic vlen_t [15:0] idx;
+            automatic logic [$clog2(16)-1:0] idx [15:0];
             idx[15] = 15; idx[14] = 07; idx[13] = 11; idx[12] = 03;
             idx[11] = 13; idx[10] = 05; idx[09] = 09; idx[08] = 01;
             idx[07] = 14; idx[06] = 06; idx[05] = 10; idx[04] = 02;
@@ -352,7 +351,7 @@ package ara_pkg;
             return idx[byte_idx[3:0]];
           end
           default: begin
-            automatic vlen_t [15:0] idx;
+            automatic logic [$clog2(16)-1:0] idx [15:0];
             idx[15] = 15; idx[14] = 14; idx[13] = 13; idx[12] = 12;
             idx[11] = 11; idx[10] = 10; idx[09] = 09; idx[08] = 08;
             idx[07] = 07; idx[06] = 06; idx[05] = 05; idx[04] = 04;
@@ -362,7 +361,7 @@ package ara_pkg;
         endcase
       4: unique case (ew)
           rvv_pkg::EW64: begin
-            automatic vlen_t [31:0] idx;
+            automatic logic [$clog2(32)-1:0] idx [31:0];
             idx[31] = 31; idx[30] = 30; idx[29] = 29; idx[28] = 28;
             idx[27] = 27; idx[26] = 26; idx[25] = 25; idx[24] = 24;
             idx[23] = 23; idx[22] = 22; idx[21] = 21; idx[20] = 20;
@@ -374,7 +373,7 @@ package ara_pkg;
             return idx[byte_idx[4:0]];
           end
           rvv_pkg::EW32: begin
-            automatic vlen_t [31:0] idx;
+            automatic logic [$clog2(32)-1:0] idx [31:0];
             idx[31] = 31; idx[30] = 30; idx[29] = 29; idx[28] = 28;
             idx[27] = 23; idx[26] = 22; idx[25] = 21; idx[24] = 20;
             idx[23] = 15; idx[22] = 14; idx[21] = 13; idx[20] = 12;
@@ -386,7 +385,7 @@ package ara_pkg;
             return idx[byte_idx[4:0]];
           end
           rvv_pkg::EW16: begin
-            automatic vlen_t [31:0] idx;
+            automatic logic [$clog2(32)-1:0] idx [31:0];
             idx[31] = 31; idx[30] = 30; idx[29] = 23; idx[28] = 22;
             idx[27] = 15; idx[26] = 14; idx[25] = 07; idx[24] = 06;
             idx[23] = 27; idx[22] = 26; idx[21] = 19; idx[20] = 18;
@@ -398,7 +397,7 @@ package ara_pkg;
             return idx[byte_idx[4:0]];
           end
           rvv_pkg::EW8: begin
-            automatic vlen_t [31:0] idx;
+            automatic logic [$clog2(32)-1:0] idx [31:0];
             idx[31] = 31; idx[30] = 23; idx[29] = 15; idx[28] = 07;
             idx[27] = 27; idx[26] = 19; idx[25] = 11; idx[24] = 03;
             idx[23] = 29; idx[22] = 21; idx[21] = 13; idx[20] = 05;
@@ -410,7 +409,7 @@ package ara_pkg;
             return idx[byte_idx[4:0]];
           end
           default: begin
-            automatic vlen_t [31:0] idx;
+            automatic logic [$clog2(32)-1:0] idx [31:0];
             idx[31] = 31; idx[30] = 30; idx[29] = 29; idx[28] = 28;
             idx[27] = 27; idx[26] = 26; idx[25] = 25; idx[24] = 24;
             idx[23] = 23; idx[22] = 22; idx[21] = 21; idx[20] = 20;
@@ -424,7 +423,7 @@ package ara_pkg;
         endcase
       8: unique case (ew)
           rvv_pkg::EW64: begin
-            automatic vlen_t [63:0] idx;
+            automatic logic [$clog2(64)-1:0] idx [63:0];
             idx[63] = 63; idx[62] = 62; idx[61] = 61; idx[60] = 60;
             idx[59] = 59; idx[58] = 58; idx[57] = 57; idx[56] = 56;
             idx[55] = 55; idx[54] = 54; idx[53] = 53; idx[52] = 52;
@@ -444,7 +443,7 @@ package ara_pkg;
             return idx[byte_idx[5:0]];
           end
           rvv_pkg::EW32: begin
-            automatic vlen_t [63:0] idx;
+            automatic logic [$clog2(64)-1:0] idx [63:0];
             idx[63] = 63; idx[62] = 62; idx[61] = 61; idx[60] = 60;
             idx[59] = 55; idx[58] = 54; idx[57] = 53; idx[56] = 52;
             idx[55] = 47; idx[54] = 46; idx[53] = 45; idx[52] = 44;
@@ -464,7 +463,7 @@ package ara_pkg;
             return idx[byte_idx[5:0]];
           end
           rvv_pkg::EW16: begin
-            automatic vlen_t [63:0] idx;
+            automatic logic [$clog2(64)-1:0] idx [63:0];
             idx[63] = 63; idx[62] = 62; idx[61] = 55; idx[60] = 54;
             idx[59] = 47; idx[58] = 46; idx[57] = 39; idx[56] = 38;
             idx[55] = 31; idx[54] = 30; idx[53] = 23; idx[52] = 22;
@@ -484,7 +483,7 @@ package ara_pkg;
             return idx[byte_idx[5:0]];
           end
           rvv_pkg::EW8: begin
-            automatic vlen_t [63:0] idx;
+            automatic logic [$clog2(64)-1:0] idx [63:0];
             idx[63] = 63; idx[62] = 55; idx[61] = 47; idx[60] = 39;
             idx[59] = 31; idx[58] = 23; idx[57] = 15; idx[56] = 07;
             idx[55] = 59; idx[54] = 51; idx[53] = 43; idx[52] = 35;
@@ -504,7 +503,7 @@ package ara_pkg;
             return idx[byte_idx[5:0]];
           end
           default: begin
-            automatic vlen_t [63:0] idx;
+            automatic logic [$clog2(64)-1:0] idx [63:0];
             idx[63] = 63; idx[62] = 62; idx[61] = 61; idx[60] = 60;
             idx[59] = 59; idx[58] = 58; idx[57] = 57; idx[56] = 56;
             idx[55] = 55; idx[54] = 54; idx[53] = 53; idx[52] = 52;
@@ -526,7 +525,7 @@ package ara_pkg;
         endcase
       16: unique case (ew)
           rvv_pkg::EW64: begin
-            automatic vlen_t [127:0] idx;
+            automatic logic [$clog2(128)-1:0] idx [127:0];
             idx[127] = 127; idx[126] = 126; idx[125] = 125; idx[124] = 124;
             idx[123] = 123; idx[122] = 122; idx[121] = 121; idx[120] = 120;
             idx[119] = 119; idx[118] = 118; idx[117] = 117; idx[116] = 116;
@@ -562,7 +561,7 @@ package ara_pkg;
             return idx[byte_idx[6:0]];
           end
           rvv_pkg::EW32: begin
-            automatic vlen_t [127:0] idx;
+            automatic logic [$clog2(128)-1:0] idx [127:0];
             idx[127] = 127; idx[126] = 126; idx[125] = 125; idx[124] = 124;
             idx[123] = 119; idx[122] = 118; idx[121] = 117; idx[120] = 116;
             idx[119] = 111; idx[118] = 110; idx[117] = 109; idx[116] = 108;
@@ -598,7 +597,7 @@ package ara_pkg;
             return idx[byte_idx[6:0]];
           end
           rvv_pkg::EW16: begin
-            automatic vlen_t [127:0] idx;
+            automatic logic [$clog2(128)-1:0] idx [127:0];
             idx[127] = 127; idx[126] = 126; idx[125] = 119; idx[124] = 118;
             idx[123] = 111; idx[122] = 110; idx[121] = 103; idx[120] = 102;
             idx[119] = 095; idx[118] = 094; idx[117] = 087; idx[116] = 086;
@@ -634,7 +633,7 @@ package ara_pkg;
             return idx[byte_idx[6:0]];
           end
           rvv_pkg::EW8: begin
-            automatic vlen_t [127:0] idx;
+            automatic logic [$clog2(128)-1:0] idx [127:0];
             idx[127] = 127; idx[126] = 119; idx[125] = 111; idx[124] = 103;
             idx[123] = 095; idx[122] = 087; idx[121] = 079; idx[120] = 071;
             idx[119] = 063; idx[118] = 055; idx[117] = 047; idx[116] = 039;
@@ -670,7 +669,7 @@ package ara_pkg;
             return idx[byte_idx[6:0]];
           end
           default: begin
-            automatic vlen_t [127:0] idx;
+            automatic logic [$clog2(128)-1:0] idx [127:0];
             idx[127] = 127; idx[126] = 126; idx[125] = 125; idx[124] = 124;
             idx[123] = 123; idx[122] = 122; idx[121] = 121; idx[120] = 120;
             idx[119] = 119; idx[118] = 118; idx[117] = 117; idx[116] = 116;
@@ -709,23 +708,23 @@ package ara_pkg;
       default: $error("Error. Supported number of lanes are 1, 2, 4, 8, 16.");
     endcase
 
-  /*automatic vlen_t [8*MaxNrLanes-1:0] element_shuffle_index;
+  /*automatic logic [$clog2(ELENB*NrLanes)-1:0] [8*MaxNrLanes-1:0] element_shuffle_index;
 
    unique case (ew)
    rvv_pkg::EW64:
-   for (vlen_t element = 0; element < NrLanes; element++)
+   for (logic [$clog2(ELENB*NrLanes)-1:0] element = 0; element < NrLanes; element++)
    for (int b = 0; b < 8; b++)
    element_shuffle_index[8*(element >> 0) + b] = 8*element + b;
    rvv_pkg::EW32:
-   for (vlen_t element = 0; element < 2*NrLanes; element++)
+   for (logic [$clog2(ELENB*NrLanes)-1:0] element = 0; element < 2*NrLanes; element++)
    for (int b = 0; b < 4; b++)
    element_shuffle_index[4*((element >> 1) + int'(element[0]) * NrLanes*1) + b] = 4*element + b;
    rvv_pkg::EW16:
-   for (vlen_t element = 0; element < 4*NrLanes; element++)
+   for (logic [$clog2(ELENB*NrLanes)-1:0] element = 0; element < 4*NrLanes; element++)
    for (int b = 0; b < 2; b++)
    element_shuffle_index[2*((element >> 2) + int'(element[1]) * NrLanes*1 + int'(element[0]) * NrLanes*2) + b] = 2*element + b;
    rvv_pkg::EW8:
-   for (vlen_t element = 0; element < 8*NrLanes; element++)
+   for (logic [$clog2(ELENB*NrLanes)-1:0] element = 0; element < 8*NrLanes; element++)
    for (int b = 0; b < 1; b++)
    element_shuffle_index[1*((element >> 3) + int'(element[2]) * NrLanes*1 + int'(element[1]) * NrLanes*2 + int'(element[0]) * NrLanes*4) + b] = 1*element + b;
    default:;
@@ -734,42 +733,41 @@ package ara_pkg;
    return element_shuffle_index[byte_index];*/
   endfunction : shuffle_index
 
-  function automatic int unsigned deshuffle_index(logic[15:0] byte_index, int NrLanes, rvv_pkg::vew_e ew, int VLEN);
-    typedef logic[$clog2(VLEN+1)-1:0] vlen_t;
+  function automatic logic [$clog2(8*MaxNrLanes)-1:0] deshuffle_index(logic[15:0] byte_index, int NrLanes, rvv_pkg::vew_e ew);
     // Generate the deshuffling of the table above
     unique case (NrLanes)
       1: begin
-        automatic vlen_t [7:0] index;
+        automatic logic [$clog2(8)-1:0] index [7:0];
         for (int b = 0; b < 8; b++)
           index[shuffle_index(b, NrLanes, ew)] = b;
         return index[byte_index[2:0]];
       end
       2: begin
-        automatic vlen_t [15:0] index;
+        automatic logic [$clog2(16)-1:0] index [15:0];
         for (int b = 0; b < 16; b++)
           index[shuffle_index(b, NrLanes, ew)] = b;
         return index[byte_index[3:0]];
       end
       4: begin
-        automatic vlen_t [31:0] index;
+        automatic logic [$clog2(32)-1:0] index [31:0];
         for (int b = 0; b < 32; b++)
           index[shuffle_index(b, NrLanes, ew)] = b;
         return index[byte_index[4:0]];
       end
       8: begin
-        automatic vlen_t [63:0] index;
+        automatic logic [$clog2(64)-1:0] index [63:0];
         for (int b = 0; b < 64; b++)
           index[shuffle_index(b, NrLanes, ew)] = b;
         return index[byte_index[5:0]];
       end
       16: begin
-        automatic vlen_t [127:0] index;
+        automatic logic [$clog2(128)-1:0] index [127:0];
         for (int b = 0; b < 128; b++)
           index[shuffle_index(b, NrLanes, ew)] = b;
         return index[byte_index[6:0]];
       end
       default: begin
-        automatic vlen_t [31:0] index;
+        automatic logic [$clog2(32)-1:0] index [31:0];
         for (int b = 0; b < 32; b++)
           index[shuffle_index(b, NrLanes, ew)] = b;
         return index[byte_index[4:0]];

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -237,93 +237,6 @@ package ara_pkg;
   typedef acc_pkg::accelerator_req_t accelerator_req_t;
   typedef acc_pkg::accelerator_resp_t accelerator_resp_t;
 
-  /////////////////////////
-  //  Backend interface  //
-  /////////////////////////
-
-  // Interfaces between Ara's dispatcher and Ara's backend
-
-  typedef struct packed {
-    ara_op_e op; // Operation
-
-    // Stores and slides do not re-shuffle the
-    // source registers. In these two cases, vl refers
-    // to the target EEW and vtype.vsew, respectively.
-    // Since operand requesters work with the old
-    // eew of the source registers, we should rescale
-    // vl to the old eew to fetch the correct number of Bytes.
-    //
-    // Another solution would be to pass directly the target
-    // eew (vstores) or the vtype.vsew (vslides), but this would
-    // create confusion with the current naming convention
-    logic scale_vl;
-
-    // Mask vector register operand
-    logic vm;
-    rvv_pkg::vew_e eew_vmask;
-
-    // 1st vector register operand
-    logic [4:0] vs1;
-    logic use_vs1;
-    opqueue_conversion_e conversion_vs1;
-    rvv_pkg::vew_e eew_vs1;
-
-    // 2nd vector register operand
-    logic [4:0] vs2;
-    logic use_vs2;
-    opqueue_conversion_e conversion_vs2;
-    rvv_pkg::vew_e eew_vs2;
-
-    // Use vd as an operand as well (e.g., vmacc)
-    logic use_vd_op;
-    rvv_pkg::vew_e eew_vd_op;
-
-    // Scalar operand
-    elen_t scalar_op;
-    logic use_scalar_op;
-
-    // 2nd scalar operand: stride for constant-strided vector load/stores, slide offset for vector
-    // slides
-    elen_t stride;
-    logic is_stride_np2;
-
-    // Destination vector register
-    logic [4:0] vd;
-    logic use_vd;
-
-    // If asserted: vs2 is kept in MulFPU opqueue C, and vd_op in MulFPU A
-    logic swap_vs2_vd_op;
-
-    // Effective length multiplier
-    rvv_pkg::vlmul_e emul;
-
-    // Rounding-Mode for FP operations
-    fpnew_pkg::roundmode_e fp_rm;
-    // Widen FP immediate (re-encoding)
-    logic wide_fp_imm;
-    // Resizing of FP conversions
-    resize_e cvt_resize;
-
-    // Vector machine metadata
-    vlen_t vl;
-    vlen_t vstart;
-    rvv_pkg::vtype_t vtype;
-
-    // Request token, for registration in the sequencer
-    logic token;
-  } ara_req_t;
-
-  typedef struct packed {
-    // Scalar response
-    elen_t resp;
-
-    // Instruction triggered an exception
-    ariane_pkg::exception_t exception;
-
-    // New value for vstart
-    vlen_t exception_vstart;
-  } ara_resp_t;
-
   ////////////////////
   //  PE interface  //
   ////////////////////
@@ -347,78 +260,6 @@ package ara_pkg;
     OffsetLoad, OffsetStore, OffsetMask, OffsetSlide
   } vfu_offset_e;
 
-  typedef struct packed {
-    vid_t id; // ID of the vector instruction
-
-    ara_op_e op; // Operation
-
-    // Mask vector register operand
-    logic vm;
-    rvv_pkg::vew_e eew_vmask;
-
-    vfu_e vfu; // VFU responsible for handling this instruction
-
-    // Rescale vl taking into account the new and old EEW
-    logic scale_vl;
-
-    // 1st vector register operand
-    logic [4:0] vs1;
-    logic use_vs1;
-    opqueue_conversion_e conversion_vs1;
-    rvv_pkg::vew_e eew_vs1;
-
-    // 2nd vector register operand
-    logic [4:0] vs2;
-    logic use_vs2;
-    opqueue_conversion_e conversion_vs2;
-    rvv_pkg::vew_e eew_vs2;
-
-    // Use vd as an operand as well (e.g., vmacc)
-    logic use_vd_op;
-    rvv_pkg::vew_e eew_vd_op;
-
-    // Scalar operand
-    elen_t scalar_op;
-    logic use_scalar_op;
-
-    // If asserted: vs2 is kept in MulFPU opqueue C, and vd_op in MulFPU A
-    logic swap_vs2_vd_op;
-
-    // 2nd scalar operand: stride for constant-strided vector load/stores
-    elen_t stride;
-    logic is_stride_np2;
-
-    // Destination vector register
-    logic [4:0] vd;
-    logic use_vd;
-
-    // Effective length multiplier
-    rvv_pkg::vlmul_e emul;
-
-    // Rounding-Mode for FP operations
-    fpnew_pkg::roundmode_e fp_rm;
-    // Widen FP immediate (re-encoding)
-    logic wide_fp_imm;
-    // Resizing of FP conversions
-    resize_e cvt_resize;
-
-    // Vector machine metadata
-    vlen_t vl;
-    vlen_t vstart;
-    rvv_pkg::vtype_t vtype;
-
-    // Hazards
-    logic [NrVInsn-1:0] hazard_vs1;
-    logic [NrVInsn-1:0] hazard_vs2;
-    logic [NrVInsn-1:0] hazard_vm;
-    logic [NrVInsn-1:0] hazard_vd;
-  } pe_req_t;
-
-  typedef struct packed {
-    // Each set bit indicates that the corresponding vector loop has finished execution
-    logic [NrVInsn-1:0] vinsn_done;
-  } pe_resp_t;
-
   /* The VRF data is stored into the lanes in a shuffled way, similar to how it was done
    * in version 0.9 of the RISC-V Vector Specification, when SLEN < VLEN. In fact, VRF
    * data is organized in lanes as in section 4.3 of the RVV Specification v0.9, with
@@ -441,7 +282,8 @@ package ara_pkg;
    * packing) functions.
    */
 
-  function automatic vlen_t shuffle_index(vlen_t byte_idx, int NrLanes, rvv_pkg::vew_e ew);
+  function automatic int unsigned shuffle_index(logic[15:0] byte_idx, int NrLanes, rvv_pkg::vew_e ew, int VLEN);
+    typedef logic[$clog2(VLEN+1)-1:0] vlen_t;
     // Generate the shuffling of the table above
     unique case (NrLanes)
       1: unique case (ew)
@@ -892,7 +734,8 @@ package ara_pkg;
    return element_shuffle_index[byte_index];*/
   endfunction : shuffle_index
 
-  function automatic vlen_t deshuffle_index(vlen_t byte_index, int NrLanes, rvv_pkg::vew_e ew);
+  function automatic int unsigned deshuffle_index(logic[15:0] byte_index, int NrLanes, rvv_pkg::vew_e ew, int VLEN);
+    typedef logic[$clog2(VLEN+1)-1:0] vlen_t;
     // Generate the deshuffling of the table above
     unique case (NrLanes)
       1: begin
@@ -982,73 +825,6 @@ package ara_pkg;
     ALU_SLDU     = 1'b0,
     MFPU_ADDRGEN = 1'b1
   } target_fu_e;
-
-  // This is the interface between the lane's sequencer and the operand request stage, which
-  // makes consecutive requests to the vector elements inside the VRF.
-  typedef struct packed {
-    vid_t id; // ID of the vector instruction
-
-    logic [4:0] vs; // Vector register operand
-
-    logic scale_vl; // Rescale vl taking into account the new and old EEW
-
-    resize_e cvt_resize;    // Resizing of FP conversions
-
-    logic is_reduct; // Is this a reduction?
-
-    rvv_pkg::vew_e eew;        // Effective element width
-    opqueue_conversion_e conv; // Type conversion
-
-    target_fu_e target_fu;     // Target FU of the opqueue (if it is not clear)
-
-    // Vector machine metadata
-    rvv_pkg::vtype_t vtype;
-    vlen_t vl;
-    vlen_t vstart;
-
-    // Hazards
-    logic [NrVInsn-1:0] hazard;
-  } operand_request_cmd_t;
-
-  typedef struct packed {
-    rvv_pkg::vew_e eew;        // Effective element width
-    vlen_t vl;                 // Vector length
-    opqueue_conversion_e conv; // Type conversion
-    logic [1:0] ntr_red;       // Neutral type for reductions
-    logic is_reduct;           // Is this a reduction?
-    target_fu_e target_fu;     // Target FU of the opqueue (if it is not clear)
-  } operand_queue_cmd_t;
-
-  // This is the interface between the lane's sequencer and the lane's VFUs.
-  typedef struct packed {
-    vid_t id; // ID of the vector instruction
-
-    ara_op_e op; // Operation
-    logic vm;    // Masked instruction
-
-    logic use_vs1;   // This operation uses vs1
-    logic use_vs2;   // This operation uses vs1
-    logic use_vd_op; // This operation uses vd as an operand as well
-
-    elen_t scalar_op;    // Scalar operand
-    logic use_scalar_op; // This operation uses the scalar operand
-
-    vfu_e vfu; // VFU responsible for this instruction
-
-    logic [4:0] vd; // Vector destination register
-    logic use_vd;
-
-    logic swap_vs2_vd_op; // If asserted: vs2 is kept in MulFPU opqueue C, and vd_op in MulFPU A
-
-    fpnew_pkg::roundmode_e fp_rm; // Rounding-Mode for FP operations
-    logic wide_fp_imm;            // Widen FP immediate (re-encoding)
-    resize_e cvt_resize;    // Resizing of FP conversions
-
-    // Vector machine metadata
-    vlen_t vl;
-    vlen_t vstart;
-    rvv_pkg::vtype_t vtype;
-  } vfu_operation_t;
 
   // Due to the shuffled nature of the vector elements inside one lane, the byte enable
   // signal must be generated differently depending on how many valid elements are there.

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -17,12 +17,6 @@ package ara_pkg;
   localparam int unsigned ELEN  = 64;
   // Maximum size of a single vector element, in bytes.
   localparam int unsigned ELENB = ELEN / 8;
-  // Number of bits in a vector register.
-  localparam int unsigned VLEN  = `ifdef VLEN `VLEN `else 0 `endif;
-  // Number of bytes in a vector register.
-  localparam int unsigned VLENB = VLEN / 8;
-  // Maximum vector length (in elements).
-  localparam int unsigned MAXVL = VLEN; // SEW = EW8, LMUL = 8. VL = 8 * VLEN / 8 = VLEN.
 
   // Number of vector instructions that can run in parallel.
   localparam int unsigned NrVInsn = 8;
@@ -105,7 +99,6 @@ package ara_pkg;
   //  Definitions  //
   ///////////////////
 
-  typedef logic [$clog2(MAXVL+1)-1:0] vlen_t;
   typedef logic [$clog2(NrVInsn)-1:0] vid_t;
   typedef logic [ELEN-1:0] elen_t;
 
@@ -979,8 +972,9 @@ package ara_pkg;
   localparam int unsigned NrVRFBanksPerLane = 8;
 
   // Find the starting address of a vector register vid
-  function automatic logic [63:0] vaddr(logic [4:0] vid, int NrLanes);
-    vaddr = vid * (VLENB / NrLanes / 8);
+  function automatic logic [63:0] vaddr(logic [4:0] vid, int NrLanes, int vlen);
+    int vlenb = vlen / 8;
+    vaddr = vid * (vlenb / NrLanes / 8);
   endfunction: vaddr
 
   // Differenciate between SLDU and ADDRGEN operands from opqueue

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -30,7 +30,8 @@ module ara import ara_pkg::*; #(
     // Ara has NrLanes + 3 processing elements: each one of the lanes, the vector load unit, the
     // vector store unit, the slide unit, and the mask unit.
     localparam int           unsigned NrPEs        = NrLanes + 4,
-    localparam type                   vlen_t       = logic[$clog2(VLEN+1)-1:0]
+    localparam type                   vlen_t       = logic[$clog2(VLEN+1)-1:0],
+    localparam int           unsigned VLENB        = VLEN / 8
   ) (
     // Clock and Reset
     input  logic              clk_i,
@@ -633,15 +634,15 @@ module ara import ara_pkg::*; #(
   if (NrLanes > MaxNrLanes)
     $error("[ara] Ara supports at most MaxNrLanes lanes.");
 
-  if (ara_pkg::VLEN == 0)
+  if (VLEN == 0)
     $error("[ara] The vector length must be greater than zero.");
 
-  if (ara_pkg::VLEN < ELEN)
+  if (VLEN < ELEN)
     $error(
       "[ara] The vector length must be greater or equal than the maximum size of a single vector element"
     );
 
-  if (ara_pkg::VLEN != 2**$clog2(ara_pkg::VLEN))
+  if (VLEN != 2**$clog2(VLEN))
     $error("[ara] The vector length must be a power of two.");
 
 endmodule : ara

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -30,7 +30,7 @@ module ara import ara_pkg::*; #(
     // Ara has NrLanes + 3 processing elements: each one of the lanes, the vector load unit, the
     // vector store unit, the slide unit, and the mask unit.
     localparam int           unsigned NrPEs        = NrLanes + 4,
-    localparam type                  vlen_t        = logic[$clog2(VLEN+1)-1:0]
+    localparam type                   vlen_t       = logic[$clog2(VLEN+1)-1:0]
   ) (
     // Clock and Reset
     input  logic              clk_i,
@@ -64,6 +64,160 @@ module ara import ara_pkg::*; #(
   localparam int unsigned StrbWidth = DataWidth / 8;
   typedef logic [StrbWidth-1:0] strb_t;
 
+  // Interfaces between Ara's dispatcher and Ara's backend
+  typedef struct packed {
+    ara_op_e op; // Operation
+
+    // Stores and slides do not re-shuffle the
+    // source registers. In these two cases, vl refers
+    // to the target EEW and vtype.vsew, respectively.
+    // Since operand requesters work with the old
+    // eew of the source registers, we should rescale
+    // vl to the old eew to fetch the correct number of Bytes.
+    //
+    // Another solution would be to pass directly the target
+    // eew (vstores) or the vtype.vsew (vslides), but this would
+    // create confusion with the current naming convention
+    logic scale_vl;
+
+    // Mask vector register operand
+    logic vm;
+    rvv_pkg::vew_e eew_vmask;
+
+    // 1st vector register operand
+    logic [4:0] vs1;
+    logic use_vs1;
+    opqueue_conversion_e conversion_vs1;
+    rvv_pkg::vew_e eew_vs1;
+
+    // 2nd vector register operand
+    logic [4:0] vs2;
+    logic use_vs2;
+    opqueue_conversion_e conversion_vs2;
+    rvv_pkg::vew_e eew_vs2;
+
+    // Use vd as an operand as well (e.g., vmacc)
+    logic use_vd_op;
+    rvv_pkg::vew_e eew_vd_op;
+
+    // Scalar operand
+    elen_t scalar_op;
+    logic use_scalar_op;
+
+    // 2nd scalar operand: stride for constant-strided vector load/stores, slide offset for vector
+    // slides
+    elen_t stride;
+    logic is_stride_np2;
+
+    // Destination vector register
+    logic [4:0] vd;
+    logic use_vd;
+
+    // If asserted: vs2 is kept in MulFPU opqueue C, and vd_op in MulFPU A
+    logic swap_vs2_vd_op;
+
+    // Effective length multiplier
+    rvv_pkg::vlmul_e emul;
+
+    // Rounding-Mode for FP operations
+    fpnew_pkg::roundmode_e fp_rm;
+    // Widen FP immediate (re-encoding)
+    logic wide_fp_imm;
+    // Resizing of FP conversions
+    resize_e cvt_resize;
+
+    // Vector machine metadata
+    vlen_t vl;
+    vlen_t vstart;
+    rvv_pkg::vtype_t vtype;
+
+    // Request token, for registration in the sequencer
+    logic token;
+  } ara_req_t;
+
+  typedef struct packed {
+    // Scalar response
+    elen_t resp;
+
+    // Instruction triggered an exception
+    ariane_pkg::exception_t exception;
+
+    // New value for vstart
+    vlen_t exception_vstart;
+  } ara_resp_t;
+
+  typedef struct packed {
+    vid_t id; // ID of the vector instruction
+
+    ara_op_e op; // Operation
+
+    // Mask vector register operand
+    logic vm;
+    rvv_pkg::vew_e eew_vmask;
+
+    vfu_e vfu; // VFU responsible for handling this instruction
+
+    // Rescale vl taking into account the new and old EEW
+    logic scale_vl;
+
+    // 1st vector register operand
+    logic [4:0] vs1;
+    logic use_vs1;
+    opqueue_conversion_e conversion_vs1;
+    rvv_pkg::vew_e eew_vs1;
+
+    // 2nd vector register operand
+    logic [4:0] vs2;
+    logic use_vs2;
+    opqueue_conversion_e conversion_vs2;
+    rvv_pkg::vew_e eew_vs2;
+
+    // Use vd as an operand as well (e.g., vmacc)
+    logic use_vd_op;
+    rvv_pkg::vew_e eew_vd_op;
+
+    // Scalar operand
+    elen_t scalar_op;
+    logic use_scalar_op;
+
+    // If asserted: vs2 is kept in MulFPU opqueue C, and vd_op in MulFPU A
+    logic swap_vs2_vd_op;
+
+    // 2nd scalar operand: stride for constant-strided vector load/stores
+    elen_t stride;
+    logic is_stride_np2;
+
+    // Destination vector register
+    logic [4:0] vd;
+    logic use_vd;
+
+    // Effective length multiplier
+    rvv_pkg::vlmul_e emul;
+
+    // Rounding-Mode for FP operations
+    fpnew_pkg::roundmode_e fp_rm;
+    // Widen FP immediate (re-encoding)
+    logic wide_fp_imm;
+    // Resizing of FP conversions
+    resize_e cvt_resize;
+
+    // Vector machine metadata
+    vlen_t vl;
+    vlen_t vstart;
+    rvv_pkg::vtype_t vtype;
+
+    // Hazards
+    logic [NrVInsn-1:0] hazard_vs1;
+    logic [NrVInsn-1:0] hazard_vs2;
+    logic [NrVInsn-1:0] hazard_vm;
+    logic [NrVInsn-1:0] hazard_vd;
+  } pe_req_t;
+
+  typedef struct packed {
+    // Each set bit indicates that the corresponding vector loop has finished execution
+    logic [NrVInsn-1:0] vinsn_done;
+  } pe_resp_t;
+
   //////////////////
   //  Dispatcher  //
   //////////////////
@@ -87,8 +241,10 @@ module ara import ara_pkg::*; #(
   vxrm_t     [NrLanes-1:0]      alu_vxrm;
 
   ara_dispatcher #(
-    .NrLanes(NrLanes),
-    .VLEN   (VLEN   )
+    .NrLanes   (NrLanes   ),
+    .VLEN      (VLEN      ),
+    .ara_req_t (ara_req_t ),
+    .ara_resp_t(ara_resp_t)
   ) i_dispatcher (
     .clk_i             (clk_i           ),
     .rst_ni            (rst_ni          ),
@@ -149,8 +305,12 @@ module ara import ara_pkg::*; #(
   logic      result_scalar_valid;
 
   ara_sequencer #(
-    .NrLanes(NrLanes),
-    .VLEN   (VLEN   )
+    .NrLanes   (NrLanes   ),
+    .VLEN      (VLEN      ),
+    .ara_req_t (ara_req_t ),
+    .ara_resp_t(ara_resp_t),
+    .pe_req_t  (pe_req_t  ),
+    .pe_resp_t (pe_resp_t )
   ) i_sequencer (
     .clk_i                 (clk_i                    ),
     .rst_ni                (rst_ni                   ),
@@ -234,11 +394,13 @@ module ara import ara_pkg::*; #(
 
   for (genvar lane = 0; lane < NrLanes; lane++) begin: gen_lanes
     lane #(
-      .NrLanes     (NrLanes     ),
-      .VLEN        (VLEN        ),
-      .FPUSupport  (FPUSupport  ),
-      .FPExtSupport(FPExtSupport),
-      .FixPtSupport(FixPtSupport)
+      .NrLanes              (NrLanes              ),
+      .VLEN                 (VLEN                 ),
+      .FPUSupport           (FPUSupport           ),
+      .FPExtSupport         (FPExtSupport         ),
+      .FixPtSupport         (FixPtSupport         ),
+      .pe_req_t             (pe_req_t             ),
+      .pe_resp_t            (pe_resp_t            )
     ) i_lane (
       .clk_i                           (clk_i                               ),
       .rst_ni                          (rst_ni                              ),
@@ -326,7 +488,9 @@ module ara import ara_pkg::*; #(
     .axi_b_t     (axi_b_t     ),
     .axi_req_t   (axi_req_t   ),
     .axi_resp_t  (axi_resp_t  ),
-    .vaddr_t     (vaddr_t     )
+    .vaddr_t     (vaddr_t     ),
+    .pe_req_t    (pe_req_t    ),
+    .pe_resp_t   (pe_resp_t   )
   ) i_vlsu (
     .clk_i                      (clk_i                                                 ),
     .rst_ni                     (rst_ni                                                ),
@@ -380,9 +544,11 @@ module ara import ara_pkg::*; #(
   logic sldu_mask_ready;
 
   sldu #(
-    .NrLanes(NrLanes),
-    .VLEN   (VLEN   ),
-    .vaddr_t(vaddr_t)
+    .NrLanes  (NrLanes  ),
+    .VLEN     (VLEN     ),
+    .vaddr_t  (vaddr_t  ),
+    .pe_req_t (pe_req_t ),
+    .pe_resp_t(pe_resp_t)
   ) i_sldu (
     .clk_i                   (clk_i                            ),
     .rst_ni                  (rst_ni                           ),
@@ -417,9 +583,11 @@ module ara import ara_pkg::*; #(
   /////////////////
 
   masku #(
-    .NrLanes(NrLanes),
-    .VLEN   (VLEN   ),
-    .vaddr_t(vaddr_t)
+    .NrLanes  (NrLanes  ),
+    .VLEN     (VLEN     ),
+    .vaddr_t  (vaddr_t  ),
+    .pe_req_t (pe_req_t ),
+    .pe_resp_t(pe_resp_t)
   ) i_masku (
     .clk_i                   (clk_i                           ),
     .rst_ni                  (rst_ni                          ),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -10,12 +10,15 @@
 
 module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     parameter int           unsigned NrLanes      = 0,
+    parameter int           unsigned VLEN         = 0,
     // Support for floating-point data types
     parameter fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7
     parameter fpext_support_e        FPExtSupport = FPExtSupportEnable,
     // Support for fixed-point data types
-    parameter fixpt_support_e        FixPtSupport = FixedPointEnable
+    parameter fixpt_support_e        FixPtSupport = FixedPointEnable,
+    // Dependent parameters: DO NOT CHANGE
+    localparam type                  vlen_t       = logic[$clog2(VLEN+1)-1:0]
   ) (
     // Clock and reset
     input  logic                                 clk_i,

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -20,7 +20,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     // Support for fixed-point data types
     parameter fixpt_support_e        FixPtSupport = FixedPointEnable,
     // Dependent parameters: DO NOT CHANGE
-    localparam type                  vlen_t       = logic[$clog2(VLEN+1)-1:0]
+    localparam type                  vlen_t       = logic[$clog2(VLEN+1)-1:0],
+    localparam int          unsigned VLENB        = VLEN / 8
   ) (
     // Clock and reset
     input  logic                                 clk_i,

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -11,6 +11,8 @@
 module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     parameter int           unsigned NrLanes      = 0,
     parameter int           unsigned VLEN         = 0,
+    parameter type                   ara_req_t    = logic,
+    parameter type                   ara_resp_t   = logic,
     // Support for floating-point data types
     parameter fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -9,8 +9,12 @@
 
 module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     // RVV Parameters
-    parameter  int unsigned NrLanes = 1,          // Number of parallel vector lanes
-    parameter  int unsigned VLEN    = 0,
+    parameter  int unsigned NrLanes    = 1,          // Number of parallel vector lanes
+    parameter  int unsigned VLEN       = 0,
+    parameter  type         ara_req_t  = logic,
+    parameter  type         ara_resp_t = logic,
+    parameter  type         pe_req_t   = logic,
+    parameter  type         pe_resp_t  = logic,
     // Dependant parameters. DO NOT CHANGE!
     // Ara has NrLanes + 3 processing elements: each one of the lanes, the vector load unit, the
     // vector store unit, the slide unit, and the mask unit.

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -156,7 +156,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   logic    pe_req_valid_d;
 
   // This function determines the VFU responsible for handling this operation.
-  function automatic vfu_e vfu(ara_op_e op);
+  function automatic vfu_e vfu(ara_op_e op = VADD);
     unique case (op) inside
       [VADD:VWREDSUM]      : vfu = VFU_Alu;
       [VMUL:VFWREDOSUM]    : vfu = VFU_MFpu;

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -165,6 +165,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
       [VSE:VSXE]           : vfu = VFU_StoreUnit;
       [VSLIDEUP:VSLIDEDOWN]: vfu = VFU_SlideUnit;
       [VMVXS:VFMVFS]       : vfu = VFU_None;
+      default              : vfu = VFU_None;
     endcase
   endfunction : vfu
 

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -10,10 +10,12 @@
 module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     // RVV Parameters
     parameter  int unsigned NrLanes = 1,          // Number of parallel vector lanes
+    parameter  int unsigned VLEN    = 0,
     // Dependant parameters. DO NOT CHANGE!
     // Ara has NrLanes + 3 processing elements: each one of the lanes, the vector load unit, the
     // vector store unit, the slide unit, and the mask unit.
-    localparam int unsigned NrPEs   = NrLanes + 4
+    localparam int unsigned NrPEs   = NrLanes + 4,
+    localparam type         vlen_t  = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                            clk_i,
     input  logic                            rst_ni,

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -9,6 +9,7 @@
 module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     // RVV Parameters
     parameter  int           unsigned NrLanes      = 0,                          // Number of parallel vector lanes.
+    parameter  int           unsigned VLEN         = 0,                          // VLEN [bit]
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7
@@ -511,6 +512,7 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
 `ifndef TARGET_GATESIM
   ara_system #(
     .NrLanes           (NrLanes              ),
+    .VLEN              (VLEN                 ),
     .FPUSupport        (FPUSupport           ),
     .FPExtSupport      (FPExtSupport         ),
     .FixPtSupport      (FixPtSupport         ),

--- a/hardware/src/ara_system.sv
+++ b/hardware/src/ara_system.sv
@@ -9,6 +9,7 @@
 module ara_system import axi_pkg::*; import ara_pkg::*; #(
     // RVV Parameters
     parameter int                      unsigned NrLanes            = 0,                               // Number of parallel vector lanes.
+    parameter int                      unsigned VLEN               = 0,                               // VLEN [bit]
     // Support for floating-point data types
     parameter fpu_support_e                     FPUSupport         = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7
@@ -208,6 +209,7 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
 
   ara #(
     .NrLanes     (NrLanes         ),
+    .VLEN        (VLEN            ),
     .FPUSupport  (FPUSupport      ),
     .FPExtSupport(FPExtSupport    ),
     .FixPtSupport(FixPtSupport    ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -11,6 +11,7 @@
 
 module lane import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int           unsigned NrLanes         = 1, // Number of lanes
+    parameter  int           unsigned VLEN            = 0,
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport      = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7
@@ -26,7 +27,9 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     // Address of an element in the lane's VRF
     localparam type                   vaddr_t         = logic [$clog2(VRFBSizePerLane)-1:0],
     localparam int           unsigned DataWidth       = $bits(elen_t), // Width of the lane datapath
-    localparam type                   strb_t          = logic [DataWidth/8-1:0] // Byte-strobe type
+    localparam type                   strb_t          = logic [DataWidth/8-1:0], // Byte-strobe type
+    // vl_csr type
+    localparam type                   vlen_t          = logic [$clog2(VLEN+1)-1:0]
   ) (
     input  logic                                           clk_i,
     input  logic                                           rst_ni,
@@ -192,8 +195,9 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic                                       sldu_result_gnt_opqueues;
 
   operand_requester #(
-    .NrBanks(NrVRFBanksPerLane),
     .NrLanes(NrLanes          ),
+    .VLEN   (VLEN             ),
+    .NrBanks(NrVRFBanksPerLane),
     .vaddr_t(vaddr_t          )
   ) i_operand_requester (
     .clk_i                    (clk_i                   ),
@@ -305,6 +309,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
 
   operand_queues_stage #(
     .NrLanes   (NrLanes   ),
+    .VLEN      (VLEN      ),
     .FPUSupport(FPUSupport)
   ) i_operand_queues (
     .clk_i                            (clk_i                              ),
@@ -355,6 +360,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
 
   vector_fus_stage #(
     .NrLanes     (NrLanes     ),
+    .VLEN        (VLEN        ),
     .FPUSupport  (FPUSupport  ),
     .FPExtSupport(FPExtSupport),
     .FixPtSupport(FixPtSupport),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -22,6 +22,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     parameter  type                   pe_resp_t             = logic,
     // Dependant parameters. DO NOT CHANGE!
     // VRF Parameters
+    localparam int           unsigned VLENB           = VLEN / 8,
     localparam int           unsigned MaxVLenPerLane  = VLEN / NrLanes,       // In bits
     localparam int           unsigned MaxVLenBPerLane = VLENB / NrLanes,      // In bytes
     localparam int           unsigned VRFSizePerLane  = MaxVLenPerLane * 32,  // In bits

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -11,7 +11,7 @@
 module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     parameter int unsigned NrLanes               = 0,
     parameter type         pe_req_t              = logic,
-    parameter type         pe_resp_t             = logic
+    parameter type         pe_resp_t             = logic,
     parameter type         operand_request_cmd_t = logic,
     parameter type         vfu_operation_t       = logic
   ) (

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -9,7 +9,11 @@
 // and with the main sequencer.
 
 module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
-    parameter int unsigned NrLanes = 0
+    parameter int unsigned NrLanes               = 0,
+    parameter type         pe_req_t              = logic,
+    parameter type         pe_resp_t             = logic
+    parameter type         operand_request_cmd_t = logic,
+    parameter type         vfu_operation_t       = logic
   ) (
     input  logic                                          clk_i,
     input  logic                                          rst_ni,

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -9,20 +9,21 @@
 // need it.
 
 module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
-    parameter  int           unsigned CmdBufDepth    = 2,
-    parameter  int           unsigned DataBufDepth   = 2,
-    parameter  int           unsigned NrSlaves       = 1,
-    parameter  int           unsigned NrLanes        = 0,
-    parameter  int           unsigned VLEN           = 0,
+    parameter  int           unsigned CmdBufDepth         = 2,
+    parameter  int           unsigned DataBufDepth        = 2,
+    parameter  int           unsigned NrSlaves            = 1,
+    parameter  int           unsigned NrLanes             = 0,
+    parameter  int           unsigned VLEN                = 0,
     // Support for floating-point data types
-    parameter  fpu_support_e          FPUSupport     = FPUSupportHalfSingleDouble,
+    parameter  fpu_support_e          FPUSupport          = FPUSupportHalfSingleDouble,
     // Supported conversions
-    parameter  logic                  SupportIntExt2 = 1'b0,
-    parameter  logic                  SupportIntExt4 = 1'b0,
-    parameter  logic                  SupportIntExt8 = 1'b0,
+    parameter  logic                  SupportIntExt2      = 1'b0,
+    parameter  logic                  SupportIntExt4      = 1'b0,
+    parameter  logic                  SupportIntExt8      = 1'b0,
     // Support neutral value filling
-    parameter  logic                  SupportReduct  = 1'b0,
-    parameter  logic                  SupportNtrVal  = 1'b0,
+    parameter  logic                  SupportReduct       = 1'b0,
+    parameter  logic                  SupportNtrVal       = 1'b0,
+    parameter  type                   operand_queue_cmd_t = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam int           unsigned DataWidth      = $bits(elen_t),
     localparam int           unsigned StrbWidth      = DataWidth/8,
@@ -153,7 +154,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
 
   always_comb begin: type_conversion
     // Shuffle the input operand
-    automatic logic [idx_width(StrbWidth)-1:0] select = deshuffle_index(select_q, 1, cmd.eew, VLEN);
+    automatic logic [idx_width(StrbWidth)-1:0] select = deshuffle_index(select_q, 1, cmd.eew);
 
     // Default: no conversion
     conv_operand = ibuf_operand;
@@ -374,15 +375,15 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
         if (last_packet && incomplete_packet) begin
           if (SupportNtrVal) unique case (cmd.eew)
             EW8 : for (int unsigned b = 0; b < 8; b++) begin
-                    automatic int unsigned bs = shuffle_index(b, 1, EW8, VLEN);
+                    automatic int unsigned bs = shuffle_index(b, 1, EW8);
                     if ((b >> 0) >= cmd.vl[2:0]) conv_operand[8*bs +: 8] = ntr.w8[b];
                   end
             EW16: for (int unsigned b = 0; b < 8; b++) begin
-                    automatic int unsigned bs = shuffle_index(b, 1, EW16, VLEN);
+                    automatic int unsigned bs = shuffle_index(b, 1, EW16);
                     if ((b >> 1) >= cmd.vl[1:0]) conv_operand[8*bs +: 8] = ntr.w8[b];
                   end
             EW32: for (int unsigned b = 0; b < 8; b++) begin
-                    automatic int unsigned bs = shuffle_index(b, 1, EW32, VLEN);
+                    automatic int unsigned bs = shuffle_index(b, 1, EW32);
                     if ((b >> 2) >= cmd.vl[0:0]) conv_operand[8*bs +: 8] = ntr.w8[b];
                   end
             default:;

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -153,7 +153,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
 
   always_comb begin: type_conversion
     // Shuffle the input operand
-    automatic logic [idx_width(StrbWidth)-1:0] select = deshuffle_index(select_q, 1, cmd.eew);
+    automatic logic [idx_width(StrbWidth)-1:0] select = deshuffle_index(select_q, 1, cmd.eew, VLEN);
 
     // Default: no conversion
     conv_operand = ibuf_operand;
@@ -374,15 +374,15 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
         if (last_packet && incomplete_packet) begin
           if (SupportNtrVal) unique case (cmd.eew)
             EW8 : for (int unsigned b = 0; b < 8; b++) begin
-                    automatic int unsigned bs = shuffle_index(b, 1, EW8);
+                    automatic int unsigned bs = shuffle_index(b, 1, EW8, VLEN);
                     if ((b >> 0) >= cmd.vl[2:0]) conv_operand[8*bs +: 8] = ntr.w8[b];
                   end
             EW16: for (int unsigned b = 0; b < 8; b++) begin
-                    automatic int unsigned bs = shuffle_index(b, 1, EW16);
+                    automatic int unsigned bs = shuffle_index(b, 1, EW16, VLEN);
                     if ((b >> 1) >= cmd.vl[1:0]) conv_operand[8*bs +: 8] = ntr.w8[b];
                   end
             EW32: for (int unsigned b = 0; b < 8; b++) begin
-                    automatic int unsigned bs = shuffle_index(b, 1, EW32);
+                    automatic int unsigned bs = shuffle_index(b, 1, EW32, VLEN);
                     if ((b >> 2) >= cmd.vl[0:0]) conv_operand[8*bs +: 8] = ntr.w8[b];
                   end
             default:;

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -13,6 +13,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     parameter  int           unsigned DataBufDepth   = 2,
     parameter  int           unsigned NrSlaves       = 1,
     parameter  int           unsigned NrLanes        = 0,
+    parameter  int           unsigned VLEN           = 0,
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport     = FPUSupportHalfSingleDouble,
     // Supported conversions
@@ -24,7 +25,8 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     parameter  logic                  SupportNtrVal  = 1'b0,
     // Dependant parameters. DO NOT CHANGE!
     localparam int           unsigned DataWidth      = $bits(elen_t),
-    localparam int           unsigned StrbWidth      = DataWidth/8
+    localparam int           unsigned StrbWidth      = DataWidth/8,
+    localparam type                   vlen_t         = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                              clk_i,
     input  logic                              rst_ni,

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -7,10 +7,11 @@
 // This stage holds the operand queues, holding elements for the VRFs.
 
 module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
-    parameter int     unsigned NrLanes = 0,
-    parameter int     unsigned VLEN    = 0,
+    parameter int     unsigned NrLanes          = 0,
+    parameter int     unsigned VLEN             = 0,
     // Support for floating-point data types
-    parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble
+    parameter fpu_support_e FPUSupport          = FPUSupportHalfSingleDouble,
+    parameter type          operand_queue_cmd_t = logic,
   ) (
     input  logic                                     clk_i,
     input  logic                                     rst_ni,
@@ -53,16 +54,17 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ///////////
 
   operand_queue #(
-    .CmdBufDepth   (ValuInsnQueueDepth),
-    .DataBufDepth  (5                 ),
-    .FPUSupport    (FPUSupport        ),
-    .NrLanes       (NrLanes           ),
-    .VLEN          (VLEN              ),
-    .SupportIntExt2(1'b1              ),
-    .SupportIntExt4(1'b1              ),
-    .SupportIntExt8(1'b1              ),
-    .SupportReduct (1'b1              ),
-    .SupportNtrVal (1'b0              )
+    .CmdBufDepth          (ValuInsnQueueDepth   ),
+    .DataBufDepth         (5                    ),
+    .FPUSupport           (FPUSupport           ),
+    .NrLanes              (NrLanes              ),
+    .VLEN                 (VLEN                 ),
+    .SupportIntExt2       (1'b1                 ),
+    .SupportIntExt4       (1'b1                 ),
+    .SupportIntExt8       (1'b1                 ),
+    .SupportReduct        (1'b1                 ),
+    .SupportNtrVal        (1'b0                 ),
+    .operand_request_cmd_t(operand_request_cmd_t)
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -80,16 +82,17 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .CmdBufDepth   (ValuInsnQueueDepth),
-    .DataBufDepth  (5                 ),
-    .FPUSupport    (FPUSupport        ),
-    .NrLanes       (NrLanes           ),
-    .VLEN          (VLEN              ),
-    .SupportIntExt2(1'b1              ),
-    .SupportIntExt4(1'b1              ),
-    .SupportIntExt8(1'b1              ),
-    .SupportReduct (1'b1              ),
-    .SupportNtrVal (1'b1              )
+    .CmdBufDepth          (ValuInsnQueueDepth   ),
+    .DataBufDepth         (5                    ),
+    .FPUSupport           (FPUSupport           ),
+    .NrLanes              (NrLanes              ),
+    .VLEN                 (VLEN                 ),
+    .SupportIntExt2       (1'b1                 ),
+    .SupportIntExt4       (1'b1                 ),
+    .SupportIntExt8       (1'b1                 ),
+    .SupportReduct        (1'b1                 ),
+    .SupportNtrVal        (1'b1                 ),
+    .operand_request_cmd_t(operand_request_cmd_t)
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -111,14 +114,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   //////////////////////
 
   operand_queue #(
-    .CmdBufDepth   (MfpuInsnQueueDepth ),
-    .DataBufDepth  (5                  ),
-    .FPUSupport    (FPUSupport         ),
-    .NrLanes       (NrLanes            ),
-    .VLEN          (VLEN               ),
-    .SupportIntExt2(1'b1               ),
-    .SupportReduct (1'b1               ),
-    .SupportNtrVal (1'b0               )
+    .CmdBufDepth          (MfpuInsnQueueDepth   ),
+    .DataBufDepth         (5                    ),
+    .FPUSupport           (FPUSupport           ),
+    .NrLanes              (NrLanes              ),
+    .VLEN                 (VLEN                 ),
+    .SupportIntExt2       (1'b1                 ),
+    .SupportReduct        (1'b1                 ),
+    .SupportNtrVal        (1'b0                 ),
+    .operand_request_cmd_t(operand_request_cmd_t)
   ) i_operand_queue_mfpu_a (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -136,14 +140,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .CmdBufDepth   (MfpuInsnQueueDepth ),
-    .DataBufDepth  (5                  ),
-    .FPUSupport    (FPUSupport         ),
-    .NrLanes       (NrLanes            ),
-    .VLEN          (VLEN               ),
-    .SupportIntExt2(1'b1               ),
-    .SupportReduct (1'b1               ),
-    .SupportNtrVal (1'b1               )
+    .CmdBufDepth          (MfpuInsnQueueDepth   ),
+    .DataBufDepth         (5                    ),
+    .FPUSupport           (FPUSupport           ),
+    .NrLanes              (NrLanes              ),
+    .VLEN                 (VLEN                 ),
+    .SupportIntExt2       (1'b1                 ),
+    .SupportReduct        (1'b1                 ),
+    .SupportNtrVal        (1'b1                 ),
+    .operand_request_cmd_t(operand_request_cmd_t)
   ) i_operand_queue_mfpu_b (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -161,14 +166,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .CmdBufDepth   (MfpuInsnQueueDepth ),
-    .DataBufDepth  (5                  ),
-    .FPUSupport    (FPUSupport         ),
-    .NrLanes       (NrLanes            ),
-    .VLEN          (VLEN               ),
-    .SupportIntExt2(1'b1               ),
-    .SupportReduct (1'b1               ),
-    .SupportNtrVal (1'b1               )
+    .CmdBufDepth          (MfpuInsnQueueDepth   ),
+    .DataBufDepth         (5                    ),
+    .FPUSupport           (FPUSupport           ),
+    .NrLanes              (NrLanes              ),
+    .VLEN                 (VLEN                 ),
+    .SupportIntExt2       (1'b1                 ),
+    .SupportReduct        (1'b1                 ),
+    .SupportNtrVal        (1'b1                 ),
+    .operand_request_cmd_t(operand_request_cmd_t)
   ) i_operand_queue_mfpu_c (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -190,11 +196,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ///////////////////////
 
   operand_queue #(
-    .CmdBufDepth   (VstuInsnQueueDepth + MaskuInsnQueueDepth),
-    .DataBufDepth  (2                                       ),
-    .FPUSupport    (FPUSupport                              ),
-    .NrLanes       (NrLanes                                 ),
-    .VLEN          (VLEN                                    )
+    .CmdBufDepth          (VstuInsnQueueDepth + MaskuInsnQueueDepth),
+    .DataBufDepth         (2                                       ),
+    .FPUSupport           (FPUSupport                              ),
+    .NrLanes              (NrLanes                                 ),
+    .VLEN                 (VLEN                                    ),
+    .operand_request_cmd_t(operand_request_cmd_t                   )
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
@@ -232,11 +239,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     (sldu_addrgen_operand_target_fu_o == MFPU_ADDRGEN);
 
   operand_queue #(
-    .CmdBufDepth   (VlduInsnQueueDepth),
-    .DataBufDepth  (2                 ),
-    .FPUSupport    (FPUSupport        ),
-    .NrLanes       (NrLanes           ),
-    .VLEN          (VLEN              )
+    .CmdBufDepth          (VlduInsnQueueDepth   ),
+    .DataBufDepth         (2                    ),
+    .FPUSupport           (FPUSupport           ),
+    .NrLanes              (NrLanes              ),
+    .VLEN                 (VLEN                 ),
+    .operand_request_cmd_t(operand_request_cmd_t)
   ) i_operand_queue_slide_addrgen_a (
     .clk_i                    (clk_i                                                       ),
     .rst_ni                   (rst_ni                                                      ),
@@ -258,14 +266,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   /////////////////
 
   operand_queue #(
-    .CmdBufDepth   (MaskuInsnQueueDepth),
-    .DataBufDepth  (1                  ),
-    .FPUSupport    (FPUSupport         ),
-    .SupportIntExt2(1'b1               ),
-    .SupportIntExt4(1'b1               ),
-    .SupportIntExt8(1'b1               ),
-    .NrLanes    (NrLanes   ),
-    .VLEN          (VLEN               )
+    .CmdBufDepth          (MaskuInsnQueueDepth  ),
+    .DataBufDepth         (1                    ),
+    .FPUSupport           (FPUSupport           ),
+    .SupportIntExt2       (1'b1                 ),
+    .SupportIntExt4       (1'b1                 ),
+    .SupportIntExt8       (1'b1                 ),
+    .NrLanes              (NrLanes              ),
+    .VLEN                 (VLEN                 ),
+    .operand_request_cmd_t(operand_request_cmd_t)
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),
@@ -283,10 +292,11 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .CmdBufDepth   (MaskuInsnQueueDepth),
-    .DataBufDepth  (1                  ),
-    .NrLanes       (NrLanes            ),
-    .VLEN          (VLEN               )
+    .CmdBufDepth          (MaskuInsnQueueDepth  ),
+    .DataBufDepth         (1                    ),
+    .NrLanes              (NrLanes              ),
+    .VLEN                 (VLEN                 ),
+    .operand_request_cmd_t(operand_request_cmd_t)
   ) i_operand_queue_mask_m (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -11,7 +11,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     parameter int     unsigned VLEN             = 0,
     // Support for floating-point data types
     parameter fpu_support_e FPUSupport          = FPUSupportHalfSingleDouble,
-    parameter type          operand_queue_cmd_t = logic,
+    parameter type          operand_queue_cmd_t = logic
   ) (
     input  logic                                     clk_i,
     input  logic                                     rst_ni,
@@ -54,17 +54,17 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ///////////
 
   operand_queue #(
-    .CmdBufDepth          (ValuInsnQueueDepth   ),
-    .DataBufDepth         (5                    ),
-    .FPUSupport           (FPUSupport           ),
-    .NrLanes              (NrLanes              ),
-    .VLEN                 (VLEN                 ),
-    .SupportIntExt2       (1'b1                 ),
-    .SupportIntExt4       (1'b1                 ),
-    .SupportIntExt8       (1'b1                 ),
-    .SupportReduct        (1'b1                 ),
-    .SupportNtrVal        (1'b0                 ),
-    .operand_request_cmd_t(operand_request_cmd_t)
+    .CmdBufDepth        (ValuInsnQueueDepth   ),
+    .DataBufDepth       (5                    ),
+    .FPUSupport         (FPUSupport           ),
+    .NrLanes            (NrLanes              ),
+    .VLEN               (VLEN                 ),
+    .SupportIntExt2     (1'b1                 ),
+    .SupportIntExt4     (1'b1                 ),
+    .SupportIntExt8     (1'b1                 ),
+    .SupportReduct      (1'b1                 ),
+    .SupportNtrVal      (1'b0                 ),
+    .operand_queue_cmd_t(operand_queue_cmd_t  )
   ) i_operand_queue_alu_a (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -82,17 +82,17 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .CmdBufDepth          (ValuInsnQueueDepth   ),
-    .DataBufDepth         (5                    ),
-    .FPUSupport           (FPUSupport           ),
-    .NrLanes              (NrLanes              ),
-    .VLEN                 (VLEN                 ),
-    .SupportIntExt2       (1'b1                 ),
-    .SupportIntExt4       (1'b1                 ),
-    .SupportIntExt8       (1'b1                 ),
-    .SupportReduct        (1'b1                 ),
-    .SupportNtrVal        (1'b1                 ),
-    .operand_request_cmd_t(operand_request_cmd_t)
+    .CmdBufDepth        (ValuInsnQueueDepth   ),
+    .DataBufDepth       (5                    ),
+    .FPUSupport         (FPUSupport           ),
+    .NrLanes            (NrLanes              ),
+    .VLEN               (VLEN                 ),
+    .SupportIntExt2     (1'b1                 ),
+    .SupportIntExt4     (1'b1                 ),
+    .SupportIntExt8     (1'b1                 ),
+    .SupportReduct      (1'b1                 ),
+    .SupportNtrVal      (1'b1                 ),
+    .operand_queue_cmd_t(operand_queue_cmd_t  )
   ) i_operand_queue_alu_b (
     .clk_i                    (clk_i                          ),
     .rst_ni                   (rst_ni                         ),
@@ -114,15 +114,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   //////////////////////
 
   operand_queue #(
-    .CmdBufDepth          (MfpuInsnQueueDepth   ),
-    .DataBufDepth         (5                    ),
-    .FPUSupport           (FPUSupport           ),
-    .NrLanes              (NrLanes              ),
-    .VLEN                 (VLEN                 ),
-    .SupportIntExt2       (1'b1                 ),
-    .SupportReduct        (1'b1                 ),
-    .SupportNtrVal        (1'b0                 ),
-    .operand_request_cmd_t(operand_request_cmd_t)
+    .CmdBufDepth        (MfpuInsnQueueDepth   ),
+    .DataBufDepth       (5                    ),
+    .FPUSupport         (FPUSupport           ),
+    .NrLanes            (NrLanes              ),
+    .VLEN               (VLEN                 ),
+    .SupportIntExt2     (1'b1                 ),
+    .SupportReduct      (1'b1                 ),
+    .SupportNtrVal      (1'b0                 ),
+    .operand_queue_cmd_t(operand_queue_cmd_t)
   ) i_operand_queue_mfpu_a (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -140,15 +140,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .CmdBufDepth          (MfpuInsnQueueDepth   ),
-    .DataBufDepth         (5                    ),
-    .FPUSupport           (FPUSupport           ),
-    .NrLanes              (NrLanes              ),
-    .VLEN                 (VLEN                 ),
-    .SupportIntExt2       (1'b1                 ),
-    .SupportReduct        (1'b1                 ),
-    .SupportNtrVal        (1'b1                 ),
-    .operand_request_cmd_t(operand_request_cmd_t)
+    .CmdBufDepth        (MfpuInsnQueueDepth   ),
+    .DataBufDepth       (5                    ),
+    .FPUSupport         (FPUSupport           ),
+    .NrLanes            (NrLanes              ),
+    .VLEN               (VLEN                 ),
+    .SupportIntExt2     (1'b1                 ),
+    .SupportReduct      (1'b1                 ),
+    .SupportNtrVal      (1'b1                 ),
+    .operand_queue_cmd_t(operand_queue_cmd_t  )
   ) i_operand_queue_mfpu_b (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -166,15 +166,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .CmdBufDepth          (MfpuInsnQueueDepth   ),
-    .DataBufDepth         (5                    ),
-    .FPUSupport           (FPUSupport           ),
-    .NrLanes              (NrLanes              ),
-    .VLEN                 (VLEN                 ),
-    .SupportIntExt2       (1'b1                 ),
-    .SupportReduct        (1'b1                 ),
-    .SupportNtrVal        (1'b1                 ),
-    .operand_request_cmd_t(operand_request_cmd_t)
+    .CmdBufDepth        (MfpuInsnQueueDepth   ),
+    .DataBufDepth       (5                    ),
+    .FPUSupport         (FPUSupport           ),
+    .NrLanes            (NrLanes              ),
+    .VLEN               (VLEN                 ),
+    .SupportIntExt2     (1'b1                 ),
+    .SupportReduct      (1'b1                 ),
+    .SupportNtrVal      (1'b1                 ),
+    .operand_queue_cmd_t(operand_queue_cmd_t  )
   ) i_operand_queue_mfpu_c (
     .clk_i                    (clk_i                             ),
     .rst_ni                   (rst_ni                            ),
@@ -196,12 +196,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ///////////////////////
 
   operand_queue #(
-    .CmdBufDepth          (VstuInsnQueueDepth + MaskuInsnQueueDepth),
-    .DataBufDepth         (2                                       ),
-    .FPUSupport           (FPUSupport                              ),
-    .NrLanes              (NrLanes                                 ),
-    .VLEN                 (VLEN                                    ),
-    .operand_request_cmd_t(operand_request_cmd_t                   )
+    .CmdBufDepth        (VstuInsnQueueDepth + MaskuInsnQueueDepth),
+    .DataBufDepth       (2                                       ),
+    .FPUSupport         (FPUSupport                              ),
+    .NrLanes            (NrLanes                                 ),
+    .VLEN               (VLEN                                    ),
+    .operand_queue_cmd_t(operand_queue_cmd_t                     )
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
@@ -239,12 +239,12 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     (sldu_addrgen_operand_target_fu_o == MFPU_ADDRGEN);
 
   operand_queue #(
-    .CmdBufDepth          (VlduInsnQueueDepth   ),
-    .DataBufDepth         (2                    ),
-    .FPUSupport           (FPUSupport           ),
-    .NrLanes              (NrLanes              ),
-    .VLEN                 (VLEN                 ),
-    .operand_request_cmd_t(operand_request_cmd_t)
+    .CmdBufDepth        (VlduInsnQueueDepth   ),
+    .DataBufDepth       (2                    ),
+    .FPUSupport         (FPUSupport           ),
+    .NrLanes            (NrLanes              ),
+    .VLEN               (VLEN                 ),
+    .operand_queue_cmd_t(operand_queue_cmd_t  )
   ) i_operand_queue_slide_addrgen_a (
     .clk_i                    (clk_i                                                       ),
     .rst_ni                   (rst_ni                                                      ),
@@ -266,15 +266,15 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   /////////////////
 
   operand_queue #(
-    .CmdBufDepth          (MaskuInsnQueueDepth  ),
-    .DataBufDepth         (1                    ),
-    .FPUSupport           (FPUSupport           ),
-    .SupportIntExt2       (1'b1                 ),
-    .SupportIntExt4       (1'b1                 ),
-    .SupportIntExt8       (1'b1                 ),
-    .NrLanes              (NrLanes              ),
-    .VLEN                 (VLEN                 ),
-    .operand_request_cmd_t(operand_request_cmd_t)
+    .CmdBufDepth        (MaskuInsnQueueDepth  ),
+    .DataBufDepth       (1                    ),
+    .FPUSupport         (FPUSupport           ),
+    .SupportIntExt2     (1'b1                 ),
+    .SupportIntExt4     (1'b1                 ),
+    .SupportIntExt8     (1'b1                 ),
+    .NrLanes            (NrLanes              ),
+    .VLEN               (VLEN                 ),
+    .operand_queue_cmd_t(operand_queue_cmd_t  )
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),
@@ -292,11 +292,11 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   );
 
   operand_queue #(
-    .CmdBufDepth          (MaskuInsnQueueDepth  ),
-    .DataBufDepth         (1                    ),
-    .NrLanes              (NrLanes              ),
-    .VLEN                 (VLEN                 ),
-    .operand_request_cmd_t(operand_request_cmd_t)
+    .CmdBufDepth        (MaskuInsnQueueDepth  ),
+    .DataBufDepth       (1                    ),
+    .NrLanes            (NrLanes              ),
+    .VLEN               (VLEN                 ),
+    .operand_queue_cmd_t(operand_queue_cmd_t  )
   ) i_operand_queue_mask_m (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -8,6 +8,7 @@
 
 module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     parameter int     unsigned NrLanes = 0,
+    parameter int     unsigned VLEN    = 0,
     // Support for floating-point data types
     parameter fpu_support_e FPUSupport = FPUSupportHalfSingleDouble
   ) (
@@ -56,6 +57,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .DataBufDepth  (5                 ),
     .FPUSupport    (FPUSupport        ),
     .NrLanes       (NrLanes           ),
+    .VLEN          (VLEN              ),
     .SupportIntExt2(1'b1              ),
     .SupportIntExt4(1'b1              ),
     .SupportIntExt8(1'b1              ),
@@ -82,6 +84,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .DataBufDepth  (5                 ),
     .FPUSupport    (FPUSupport        ),
     .NrLanes       (NrLanes           ),
+    .VLEN          (VLEN              ),
     .SupportIntExt2(1'b1              ),
     .SupportIntExt4(1'b1              ),
     .SupportIntExt8(1'b1              ),
@@ -112,6 +115,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .DataBufDepth  (5                  ),
     .FPUSupport    (FPUSupport         ),
     .NrLanes       (NrLanes            ),
+    .VLEN          (VLEN               ),
     .SupportIntExt2(1'b1               ),
     .SupportReduct (1'b1               ),
     .SupportNtrVal (1'b0               )
@@ -136,6 +140,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .DataBufDepth  (5                  ),
     .FPUSupport    (FPUSupport         ),
     .NrLanes       (NrLanes            ),
+    .VLEN          (VLEN               ),
     .SupportIntExt2(1'b1               ),
     .SupportReduct (1'b1               ),
     .SupportNtrVal (1'b1               )
@@ -160,6 +165,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .DataBufDepth  (5                  ),
     .FPUSupport    (FPUSupport         ),
     .NrLanes       (NrLanes            ),
+    .VLEN          (VLEN               ),
     .SupportIntExt2(1'b1               ),
     .SupportReduct (1'b1               ),
     .SupportNtrVal (1'b1               )
@@ -187,7 +193,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .CmdBufDepth   (VstuInsnQueueDepth + MaskuInsnQueueDepth),
     .DataBufDepth  (2                                       ),
     .FPUSupport    (FPUSupport                              ),
-    .NrLanes       (NrLanes                                 )
+    .NrLanes       (NrLanes                                 ),
+    .VLEN          (VLEN                                    )
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
@@ -228,7 +235,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .CmdBufDepth   (VlduInsnQueueDepth),
     .DataBufDepth  (2                 ),
     .FPUSupport    (FPUSupport        ),
-    .NrLanes       (NrLanes           )
+    .NrLanes       (NrLanes           ),
+    .VLEN          (VLEN              )
   ) i_operand_queue_slide_addrgen_a (
     .clk_i                    (clk_i                                                       ),
     .rst_ni                   (rst_ni                                                      ),
@@ -256,7 +264,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .SupportIntExt2(1'b1               ),
     .SupportIntExt4(1'b1               ),
     .SupportIntExt8(1'b1               ),
-    .NrLanes    (NrLanes   )
+    .NrLanes    (NrLanes   ),
+    .VLEN          (VLEN               )
   ) i_operand_queue_mask_b (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),
@@ -276,7 +285,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   operand_queue #(
     .CmdBufDepth   (MaskuInsnQueueDepth),
     .DataBufDepth  (1                  ),
-    .NrLanes       (NrLanes            )
+    .NrLanes       (NrLanes            ),
+    .VLEN          (VLEN               )
   ) i_operand_queue_mask_m (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),

--- a/hardware/src/lane/operand_requester.sv
+++ b/hardware/src/lane/operand_requester.sv
@@ -9,10 +9,12 @@
 // queues. This stage also includes the VRF arbiter.
 
 module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
-    parameter  int  unsigned NrLanes = 0,
-    parameter  int  unsigned VLEN    = 0,
-    parameter  int  unsigned NrBanks = 0,     // Number of banks in the vector register file
-    parameter  type          vaddr_t = logic, // Type used to address vector register file elements
+    parameter  int  unsigned NrLanes               = 0,
+    parameter  int  unsigned VLEN                  = 0,
+    parameter  int  unsigned NrBanks               = 0,     // Number of banks in the vector register file
+    parameter  type          vaddr_t               = logic, // Type used to address vector register file elements
+    parameter  type          operand_request_cmd_t = logic,
+    parameter  type          operand_queue_cmd_t   = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam type          strb_t  = logic[$bits(elen_t)/8-1:0],
     localparam type          vlen_t  = logic[$clog2(VLEN+1)-1:0]

--- a/hardware/src/lane/operand_requester.sv
+++ b/hardware/src/lane/operand_requester.sv
@@ -10,10 +10,12 @@
 
 module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int  unsigned NrLanes = 0,
+    parameter  int  unsigned VLEN    = 0,
     parameter  int  unsigned NrBanks = 0,     // Number of banks in the vector register file
     parameter  type          vaddr_t = logic, // Type used to address vector register file elements
     // Dependant parameters. DO NOT CHANGE!
-    localparam type          strb_t  = logic[$bits(elen_t)/8-1:0]
+    localparam type          strb_t  = logic[$bits(elen_t)/8-1:0],
+    localparam type          vlen_t  = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                                       clk_i,
     input  logic                                       rst_ni,
@@ -313,7 +315,7 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
             // Store the request
             requester_d = '{
               id     : operand_request_i[requester].id,
-              addr   : vaddr(operand_request_i[requester].vs, NrLanes) +
+              addr   : vaddr(operand_request_i[requester].vs, NrLanes, VLEN) +
               (operand_request_i[requester].vstart >>
                 (int'(EW64) - int'(operand_request_i[requester].eew))),
               // For memory operations, the number of elements initially refers to the new EEW (vsew here),
@@ -402,7 +404,7 @@ module operand_requester import ara_pkg::*; import rvv_pkg::*; #(
                 // Store the request
                 requester_d = '{
                   id   : operand_request_i[requester].id,
-                  addr : vaddr(operand_request_i[requester].vs, NrLanes) +
+                  addr : vaddr(operand_request_i[requester].vs, NrLanes, VLEN) +
                   (operand_request_i[requester].vstart >>
                     (int'(EW64) - int'(operand_request_i[requester].eew))),
                   len    : (operand_request_i[requester].scale_vl) ?

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -9,6 +9,7 @@
 
 module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     parameter  int    unsigned NrLanes      = 0,
+    parameter  int    unsigned VLEN         = 0,
     // Support for fixed-point data types
     parameter  fixpt_support_e FixPtSupport = FixedPointEnable,
     // Type used to address vector register file elements
@@ -16,7 +17,8 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
     // Dependant parameters. DO NOT CHANGE!
     localparam int    unsigned DataWidth    = $bits(elen_t),
     localparam int    unsigned StrbWidth    = DataWidth/8,
-    localparam type            strb_t       = logic [StrbWidth-1:0]
+    localparam type            strb_t       = logic [StrbWidth-1:0],
+    localparam type            vlen_t       = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                         clk_i,
     input  logic                         rst_ni,
@@ -465,7 +467,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
 
               // Store the result in the result queue
               result_queue_d[result_queue_write_pnt_q].wdata = result_queue_q[result_queue_write_pnt_q].wdata | valu_result;
-              result_queue_d[result_queue_write_pnt_q].addr  = vaddr(vinsn_issue_q.vd, NrLanes) + ((vinsn_issue_q.vl - issue_cnt_q) >> (int'(EW64) - vinsn_issue_q.vtype.vsew));
+              result_queue_d[result_queue_write_pnt_q].addr  = vaddr(vinsn_issue_q.vd, NrLanes, VLEN) + ((vinsn_issue_q.vl - issue_cnt_q) >> (int'(EW64) - vinsn_issue_q.vtype.vsew));
               result_queue_d[result_queue_write_pnt_q].id    = vinsn_issue_q.id;
               result_queue_d[result_queue_write_pnt_q].mask  = vinsn_issue_q.vfu == VFU_MaskUnit;
               if (!narrowing(vinsn_issue_q.op) || !narrowing_select_q)

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -8,12 +8,13 @@
 // in a SIMD fashion, always operating on 64 bits.
 
 module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
-    parameter  int    unsigned NrLanes      = 0,
-    parameter  int    unsigned VLEN         = 0,
+    parameter  int    unsigned NrLanes         = 0,
+    parameter  int    unsigned VLEN            = 0,
     // Support for fixed-point data types
-    parameter  fixpt_support_e FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e FixPtSupport    = FixedPointEnable,
     // Type used to address vector register file elements
-    parameter  type            vaddr_t      = logic,
+    parameter  type            vaddr_t         = logic,
+    parameter  type            vfu_operation_t = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam int    unsigned DataWidth    = $bits(elen_t),
     localparam int    unsigned StrbWidth    = DataWidth/8,

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -572,7 +572,7 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
                     valu_result[8*b +: 8]  :
                     alu_operand_a[8*b +: 8];
               end
-              result_queue_d[result_queue_write_pnt_q].addr  = vaddr(vinsn_issue_q.vd, NrLanes);
+              result_queue_d[result_queue_write_pnt_q].addr  = vaddr(vinsn_issue_q.vd, NrLanes, VLEN);
               result_queue_d[result_queue_write_pnt_q].id    = vinsn_issue_q.id;
               result_queue_d[result_queue_write_pnt_q].be    = be(1, vinsn_issue_q.vtype.vsew);
 

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -9,6 +9,7 @@
 
 module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     parameter  int           unsigned NrLanes      = 0,
+    parameter  int           unsigned VLEN         = 0,
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7
@@ -19,7 +20,8 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     parameter  type                   vaddr_t      = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam int           unsigned DataWidth    = $bits(elen_t),
-    localparam type                   strb_t       = logic [DataWidth/8-1:0]
+    localparam type                   strb_t       = logic [DataWidth/8-1:0],
+    localparam type                   vlen_t       = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                              clk_i,
     input  logic                              rst_ni,
@@ -99,6 +101,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
 
   valu #(
     .NrLanes(NrLanes),
+    .VLEN(VLEN),
     .FixPtSupport(FixPtSupport),
     .vaddr_t(vaddr_t)
   ) i_valu (
@@ -146,6 +149,7 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
 
   vmfpu #(
     .NrLanes   (NrLanes   ),
+    .VLEN(VLEN),
     .FPUSupport(FPUSupport),
     .FPExtSupport(FPExtSupport),
     .FixPtSupport(FixPtSupport),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -8,16 +8,17 @@
 // of each lane, namely the ALU and the Multiplier/FPU.
 
 module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
-    parameter  int           unsigned NrLanes      = 0,
-    parameter  int           unsigned VLEN         = 0,
+    parameter  int           unsigned NrLanes         = 0,
+    parameter  int           unsigned VLEN            = 0,
     // Support for floating-point data types
-    parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    parameter  fpu_support_e          FPUSupport      = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7
-    parameter  fpext_support_e        FPExtSupport = FPExtSupportEnable,
+    parameter  fpext_support_e        FPExtSupport    = FPExtSupportEnable,
     // Support for fixed-point data types
-    parameter  fixpt_support_e        FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e        FixPtSupport    = FixedPointEnable,
     // Type used to address vector register file elements
-    parameter  type                   vaddr_t      = logic,
+    parameter  type                   vaddr_t         = logic,
+    parameter  type                   vfu_operation_t = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam int           unsigned DataWidth    = $bits(elen_t),
     localparam type                   strb_t       = logic [DataWidth/8-1:0],
@@ -100,10 +101,11 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
   //////////////////
 
   valu #(
-    .NrLanes(NrLanes),
-    .VLEN(VLEN),
-    .FixPtSupport(FixPtSupport),
-    .vaddr_t(vaddr_t)
+    .NrLanes        (NrLanes        ),
+    .VLEN           (VLEN           ),
+    .FixPtSupport   (FixPtSupport   ),
+    .vaddr_t        (vaddr_t        ),
+    .vfu_operation_t(vfu_operation_t)
   ) i_valu (
     .clk_i                (clk_i                          ),
     .rst_ni               (rst_ni                         ),
@@ -148,12 +150,13 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
   ///////////////////
 
   vmfpu #(
-    .NrLanes   (NrLanes   ),
-    .VLEN(VLEN),
-    .FPUSupport(FPUSupport),
-    .FPExtSupport(FPExtSupport),
-    .FixPtSupport(FixPtSupport),
-    .vaddr_t   (vaddr_t   )
+    .NrLanes        (NrLanes        ),
+    .VLEN           (VLEN           ),
+    .FPUSupport     (FPUSupport     ),
+    .FPExtSupport   (FPExtSupport   ),
+    .FixPtSupport   (FixPtSupport   ),
+    .vaddr_t        (vaddr_t        ),
+    .vfu_operation_t(vfu_operation_t)
   ) i_vmfpu (
     .clk_i                (clk_i                           ),
     .rst_ni               (rst_ni                          ),

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -9,16 +9,17 @@
 
 module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   import cf_math_pkg::idx_width; #(
-    parameter  int           unsigned NrLanes      = 0,
-    parameter  int           unsigned VLEN         = 0,
+    parameter  int           unsigned NrLanes         = 0,
+    parameter  int           unsigned VLEN            = 0,
     // Support for floating-point data types
-    parameter  fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
+    parameter  fpu_support_e          FPUSupport      = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7, rounding-toward-odd
-    parameter  fpext_support_e        FPExtSupport = FPExtSupportEnable,
+    parameter  fpext_support_e        FPExtSupport    = FPExtSupportEnable,
     // Support for fixed-point data types
-    parameter  fixpt_support_e        FixPtSupport = FixedPointEnable,
+    parameter  fixpt_support_e        FixPtSupport    = FixedPointEnable,
     // Type used to address vector register file elements
-    parameter  type                   vaddr_t      = logic,
+    parameter  type                   vaddr_t         = logic,
+    parameter  type                   vfu_operation_t = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam int           unsigned DataWidth    = $bits(elen_t),
     localparam int           unsigned StrbWidth    = DataWidth/8,

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -11,11 +11,13 @@
 
 module masku import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int  unsigned NrLanes = 0,
+    parameter  int  unsigned VLEN    = 0,
     parameter  type          vaddr_t = logic, // Type used to address vector register file elements
     // Dependant parameters. DO NOT CHANGE!
     localparam int  unsigned DataWidth = $bits(elen_t), // Width of the lane datapath
     localparam int  unsigned StrbWidth = DataWidth/8,
-    localparam type          strb_t    = logic [StrbWidth-1:0] // Byte-strobe type
+    localparam type          strb_t    = logic [StrbWidth-1:0], // Byte-strobe type
+    localparam type          vlen_t    = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                                       clk_i,
     input  logic                                       rst_ni,
@@ -844,7 +846,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             result_queue_d[result_queue_write_pnt_q][lane] = '{
               wdata: result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result[lane],
               be   : (vinsn_issue.op inside {[VMSBF:VID]}) ? '1 : be(element_cnt, vinsn_issue.vtype.vsew),
-              addr : (vinsn_issue.op inside {[VMSBF:VID]}) ? vaddr(vinsn_issue.vd, NrLanes) + ((vinsn_issue.vl - issue_cnt_q) >> (int'(EW64) - vinsn_issue.vtype.vsew)) : vaddr(vinsn_issue.vd, NrLanes) +
+              addr : (vinsn_issue.op inside {[VMSBF:VID]}) ? vaddr(vinsn_issue.vd, NrLanes, VLEN) + ((vinsn_issue.vl - issue_cnt_q) >> (int'(EW64) - vinsn_issue.vtype.vsew)) : vaddr(vinsn_issue.vd, NrLanes) +
                 (((vinsn_issue.vl - issue_cnt_q) / NrLanes / DataWidth)),
               id : vinsn_issue.id
             };

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -374,12 +374,12 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
       // Shuffle the bit enable signal
       for (int b = 0; b < NrLanes*StrbWidth; b++) begin
-        automatic int vrf_byte              = shuffle_index(b, NrLanes, bit_enable_shuffle_eew, VLEN);
+        automatic int vrf_byte              = shuffle_index(b, NrLanes, bit_enable_shuffle_eew);
         bit_enable_shuffle[8*vrf_byte +: 8] = bit_enable[8*b +: 8];
 
         // Take the mask into account
         if (!vinsn_issue.vm) begin
-          automatic int mask_byte          = shuffle_index(b, NrLanes, vinsn_issue.eew_vmask, VLEN);
+          automatic int mask_byte          = shuffle_index(b, NrLanes, vinsn_issue.eew_vmask);
           automatic int mask_byte_lane     = mask_byte[idx_width(StrbWidth) +: idx_width(NrLanes)];
           automatic int mask_byte_offset   = mask_byte[idx_width(StrbWidth)-1:0];
           bit_enable_mask[8*vrf_byte +: 8] = bit_enable_shuffle[8*vrf_byte +: 8] &
@@ -394,7 +394,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
       // Deshuffle the operands for the mask instructions
       for (int b = 0; b < (NrLanes*StrbWidth); b++) begin
-        automatic int deshuffle_byte             = deshuffle_index(b, NrLanes, vinsn_issue.vtype.vsew, VLEN);
+        automatic int deshuffle_byte             = deshuffle_index(b, NrLanes, vinsn_issue.vtype.vsew);
         alu_operand_b_seq[8*deshuffle_byte +: 8] = alu_operand_a[8*b +: 8];
         masku_operand_vd [8*deshuffle_byte +: 8] = alu_operand_b[8*b +: 8];
       end
@@ -430,14 +430,14 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             EW8: for (int b = 0; b < 8*NrLanes; b++) begin
                 // Shuffle the source byte, then find the lane and the offset of this byte in the
                 // full operand word.
-                automatic int src_byte        = shuffle_index(1*b, NrLanes, EW8, VLEN);
+                automatic int src_byte        = shuffle_index(1*b, NrLanes, EW8);
                 automatic int src_byte_lane   = src_byte[idx_width(StrbWidth) +: idx_width(NrLanes)];
                 automatic int src_byte_offset = src_byte[idx_width(StrbWidth)-1:0];
 
                 // Find the destination byte
                 automatic int dest_bit_seq  = b + vrf_pnt_q;
                 automatic int dest_byte_seq = dest_bit_seq / StrbWidth;
-                automatic int dest_byte     = shuffle_index(dest_byte_seq, NrLanes, EW8, VLEN);
+                automatic int dest_byte     = shuffle_index(dest_byte_seq, NrLanes, EW8);
 
                 alu_result_flat[StrbWidth*dest_byte + dest_bit_seq[idx_width(StrbWidth)-1:0]] =
                 (!vinsn_issue.vm && !masku_operand_a_i[src_byte_lane][8*src_byte_offset+1]) ?
@@ -447,14 +447,14 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             EW16: for (int b = 0; b < 4*NrLanes; b++) begin
                 // Shuffle the source byte, then find the lane and the offset of this byte in the
                 // full operand word.
-                automatic int src_byte        = shuffle_index(2*b, NrLanes, EW16, VLEN);
+                automatic int src_byte        = shuffle_index(2*b, NrLanes, EW16);
                 automatic int src_byte_lane   = src_byte[idx_width(StrbWidth) +: idx_width(NrLanes)];
                 automatic int src_byte_offset = src_byte[idx_width(StrbWidth)-1:0];
 
                 // Find the destination byte
                 automatic int dest_bit_seq  = b + vrf_pnt_q;
                 automatic int dest_byte_seq = dest_bit_seq / StrbWidth;
-                automatic int dest_byte     = shuffle_index(dest_byte_seq, NrLanes, EW16, VLEN);
+                automatic int dest_byte     = shuffle_index(dest_byte_seq, NrLanes, EW16);
 
                 alu_result_flat[StrbWidth*dest_byte + dest_bit_seq[idx_width(StrbWidth)-1:0]] =
                 (!vinsn_issue.vm && !masku_operand_a_i[src_byte_lane][8*src_byte_offset+1]) ?
@@ -464,14 +464,14 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             EW32: for (int b = 0; b < 2*NrLanes; b++) begin
                 // Shuffle the source byte, then find the lane and the offset of this byte in the
                 // full operand word.
-                automatic int src_byte        = shuffle_index(4*b, NrLanes, EW32, VLEN);
+                automatic int src_byte        = shuffle_index(4*b, NrLanes, EW32);
                 automatic int src_byte_lane   = src_byte[idx_width(StrbWidth) +: idx_width(NrLanes)];
                 automatic int src_byte_offset = src_byte[idx_width(StrbWidth)-1:0];
 
                 // Find the destination byte
                 automatic int dest_bit_seq  = b + vrf_pnt_q;
                 automatic int dest_byte_seq = dest_bit_seq / StrbWidth;
-                automatic int dest_byte     = shuffle_index(dest_byte_seq, NrLanes, EW32, VLEN);
+                automatic int dest_byte     = shuffle_index(dest_byte_seq, NrLanes, EW32);
 
                 alu_result_flat[StrbWidth*dest_byte + dest_bit_seq[idx_width(StrbWidth)-1:0]] =
                 (!vinsn_issue.vm && !masku_operand_a_i[src_byte_lane][8*src_byte_offset+1]) ?
@@ -481,14 +481,14 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             EW64: for (int b = 0; b < 1*NrLanes; b++) begin
                 // Shuffle the source byte, then find the lane and the offset of this byte in the
                 // full operand word.
-                automatic int src_byte        = shuffle_index(8*b, NrLanes, EW64, VLEN);
+                automatic int src_byte        = shuffle_index(8*b, NrLanes, EW64);
                 automatic int src_byte_lane   = src_byte[idx_width(StrbWidth) +: idx_width(NrLanes)];
                 automatic int src_byte_offset = src_byte[idx_width(StrbWidth)-1:0];
 
                 // Find the destination byte
                 automatic int dest_bit_seq  = b + vrf_pnt_q;
                 automatic int dest_byte_seq = dest_bit_seq / StrbWidth;
-                automatic int dest_byte     = shuffle_index(dest_byte_seq, NrLanes, EW64, VLEN);
+                automatic int dest_byte     = shuffle_index(dest_byte_seq, NrLanes, EW64);
 
                 alu_result_flat[StrbWidth*dest_byte + dest_bit_seq[idx_width(StrbWidth)-1:0]] =
                   (!vinsn_issue.vm && !masku_operand_a_i[src_byte_lane][8*src_byte_offset+1]) ?
@@ -611,7 +611,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
     // Shuffle result for masked instructions
     for (int b = 0; b < (NrLanes*StrbWidth); b++) begin
-      automatic int shuffle_byte             = shuffle_index(b, NrLanes, vinsn_issue.vtype.vsew, VLEN);
+      automatic int shuffle_byte             = shuffle_index(b, NrLanes, vinsn_issue.vtype.vsew);
       alu_result_vm_seq[8*shuffle_byte +: 8] = alu_result_vm_m[8*b +: 8];
     end
 
@@ -713,7 +713,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
         // Copy data from the mask operands into the mask queue
         for (int vrf_seq_byte = 0; vrf_seq_byte < NrLanes*StrbWidth; vrf_seq_byte++) begin
           // Map vrf_seq_byte to the corresponding byte in the VRF word.
-          automatic int vrf_byte = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue.vtype.vsew, VLEN);
+          automatic int vrf_byte = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue.vtype.vsew);
 
           // At which lane, and what is the byte offset in that lane, of the byte vrf_byte?
           // NOTE: This does not work if the number of lanes is not a power of two.
@@ -729,7 +729,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
           automatic int mask_seq_bit  = vrf_seq_byte >> int'(vinsn_issue.vtype.vsew);
           automatic int mask_seq_byte = (mask_seq_bit >> $clog2(StrbWidth)) + vrf_pnt_byte_offset;
           // Shuffle this source byte
-          automatic int mask_byte     = shuffle_index(mask_seq_byte, NrLanes, vinsn_issue.eew_vmask, VLEN);
+          automatic int mask_byte     = shuffle_index(mask_seq_byte, NrLanes, vinsn_issue.eew_vmask);
           // Account for the bit offset
           automatic int mask_bit = (mask_byte << $clog2(StrbWidth)) +
             mask_seq_bit[idx_width(StrbWidth)-1:0] + vrf_pnt_bit_offset;
@@ -848,7 +848,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             result_queue_d[result_queue_write_pnt_q][lane] = '{
               wdata: result_queue_q[result_queue_write_pnt_q][lane].wdata | alu_result[lane],
               be   : (vinsn_issue.op inside {[VMSBF:VID]}) ? '1 : be(element_cnt, vinsn_issue.vtype.vsew),
-              addr : (vinsn_issue.op inside {[VMSBF:VID]}) ? vaddr(vinsn_issue.vd, NrLanes, VLEN) + ((vinsn_issue.vl - issue_cnt_q) >> (int'(EW64) - vinsn_issue.vtype.vsew)) : vaddr(vinsn_issue.vd, NrLanes) +
+              addr : (vinsn_issue.op inside {[VMSBF:VID]}) ? vaddr(vinsn_issue.vd, NrLanes, VLEN) + ((vinsn_issue.vl - issue_cnt_q) >> (int'(EW64) - vinsn_issue.vtype.vsew)) : vaddr(vinsn_issue.vd, NrLanes, VLEN) +
                 (((vinsn_issue.vl - issue_cnt_q) / NrLanes / DataWidth)),
               id : vinsn_issue.id
             };

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -385,7 +385,8 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
   vlen_t issue_cnt_d, issue_cnt_q;
   // Respected by default: input_limit_d  = 8*NrLanes + out_pnt_d - in_pnt_d;
   // To enforce: output_limit_d = out_pnt_d + issue_cnt_d;
-  logic [idx_width(MAXVL+1):0] output_limit_d, output_limit_q;
+  // MAXVL == VLEN (when LMUL == 8, i.e., the maximum possible)
+  logic [idx_width(VLEN+1):0] output_limit_d, output_limit_q;
 
   // Remaining bytes of the current instruction in the commit phase
   vlen_t commit_cnt_d, commit_cnt_q;
@@ -543,7 +544,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
 
           // Shuffle the output enable
           for (int unsigned b = 0; b < 8*NrLanes; b++)
-            out_en_flat[shuffle_index(b, NrLanes, vinsn_issue_q.vtype.vsew, VLEN)] = out_en_seq[b];
+            out_en_flat[shuffle_index(b, NrLanes, vinsn_issue_q.vtype.vsew)] = out_en_seq[b];
 
           // Mask the output enable with the mask vector
           out_en = out_en_flat & ({8*NrLanes{vinsn_issue_q.vm | (vinsn_issue_q.vfu inside {VFU_Alu, VFU_MFpu})}} | mask_q);
@@ -652,7 +653,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
             if (vinsn_issue_q.op == VSLIDEDOWN && vinsn_issue_q.use_scalar_op) begin
               // Copy the scalar operand to the last word
               automatic int out_seq_byte = issue_cnt_q;
-              automatic int out_byte = shuffle_index(out_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew, VLEN);
+              automatic int out_byte = shuffle_index(out_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew);
               automatic int tgt_lane = out_byte[3 +: $clog2(NrLanes)];
               automatic int tgt_lane_offset = out_byte[2:0];
 

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -8,9 +8,11 @@
 // instructions, which need access to the whole Vector Register File.
 
 module sldu import ara_pkg::*; import rvv_pkg::*; #(
-    parameter  int  unsigned NrLanes = 0,
-    parameter  int  unsigned VLEN    = 0,
-    parameter  type          vaddr_t = logic, // Type used to address vector register file elements,
+    parameter  int  unsigned NrLanes   = 0,
+    parameter  int  unsigned VLEN      = 0,
+    parameter  type          vaddr_t   = logic, // Type used to address vector register file elements,
+    parameter  type          pe_req_t  = logic,
+    parameter  type          pe_resp_t = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam int  unsigned DataWidth = $bits(elen_t), // Width of the lane datapath
     localparam int  unsigned StrbWidth = DataWidth/8,
@@ -541,7 +543,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
 
           // Shuffle the output enable
           for (int unsigned b = 0; b < 8*NrLanes; b++)
-            out_en_flat[shuffle_index(b, NrLanes, vinsn_issue_q.vtype.vsew)] = out_en_seq[b];
+            out_en_flat[shuffle_index(b, NrLanes, vinsn_issue_q.vtype.vsew, VLEN)] = out_en_seq[b];
 
           // Mask the output enable with the mask vector
           out_en = out_en_flat & ({8*NrLanes{vinsn_issue_q.vm | (vinsn_issue_q.vfu inside {VFU_Alu, VFU_MFpu})}} | mask_q);
@@ -650,7 +652,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
             if (vinsn_issue_q.op == VSLIDEDOWN && vinsn_issue_q.use_scalar_op) begin
               // Copy the scalar operand to the last word
               automatic int out_seq_byte = issue_cnt_q;
-              automatic int out_byte = shuffle_index(out_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew);
+              automatic int out_byte = shuffle_index(out_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew, VLEN);
               automatic int tgt_lane = out_byte[3 +: $clog2(NrLanes)];
               automatic int tgt_lane_offset = out_byte[2:0];
 

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -9,11 +9,13 @@
 
 module sldu import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int  unsigned NrLanes = 0,
-    parameter  type          vaddr_t = logic, // Type used to address vector register file elements
+    parameter  int  unsigned VLEN    = 0,
+    parameter  type          vaddr_t = logic, // Type used to address vector register file elements,
     // Dependant parameters. DO NOT CHANGE!
     localparam int  unsigned DataWidth = $bits(elen_t), // Width of the lane datapath
     localparam int  unsigned StrbWidth = DataWidth/8,
-    localparam type          strb_t    = logic [StrbWidth-1:0] // Byte-strobe type
+    localparam type          strb_t    = logic [StrbWidth-1:0], // Byte-strobe type
+    localparam type          vlen_t    = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                   clk_i,
     input  logic                   rst_ni,
@@ -556,7 +558,7 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
           for (int lane = 0; lane < NrLanes; lane++) begin
             result_queue_d[result_queue_write_pnt_q][lane].id   = vinsn_issue_q.id;
             result_queue_d[result_queue_write_pnt_q][lane].addr =
-              vaddr(vinsn_issue_q.vd, NrLanes) + vrf_pnt_q;
+              vaddr(vinsn_issue_q.vd, NrLanes, VLEN) + vrf_pnt_q;
           end
 
           // Bump pointers (reductions always finish in one shot)

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -15,6 +15,8 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     parameter int  unsigned AxiAddrWidth = 0,
     parameter type          axi_ar_t     = logic,
     parameter type          axi_aw_t     = logic,
+    parameter  type         pe_req_t     = logic,
+    parameter  type         pe_resp_t    = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam type         axi_addr_t   = logic [AxiAddrWidth-1:0],
     localparam type         vlen_t       = logic[$clog2(VLEN+1)-1:0]
@@ -201,7 +203,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     shuffled_word = addrgen_operand_i;
     // Deshuffle the whole NrLanes * 8 Byte word
     for (int unsigned b = 0; b < 8*NrLanes; b++) begin
-      automatic shortint unsigned b_shuffled = shuffle_index(b, NrLanes, pe_req_q.eew_vs2, VLEN);
+      automatic shortint unsigned b_shuffled = shuffle_index(b, NrLanes, pe_req_q.eew_vs2);
       deshuffled_word[8*b +: 8] = shuffled_word[8*b_shuffled +: 8];
     end
 

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -201,7 +201,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     shuffled_word = addrgen_operand_i;
     // Deshuffle the whole NrLanes * 8 Byte word
     for (int unsigned b = 0; b < 8*NrLanes; b++) begin
-      automatic shortint unsigned b_shuffled = shuffle_index(b, NrLanes, pe_req_q.eew_vs2);
+      automatic shortint unsigned b_shuffled = shuffle_index(b, NrLanes, pe_req_q.eew_vs2, VLEN);
       deshuffled_word[8*b +: 8] = shuffled_word[8*b_shuffled +: 8];
     end
 

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -9,13 +9,15 @@
 
 module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     parameter int  unsigned NrLanes      = 0,
+    parameter int  unsigned VLEN         = 0,
     // AXI Interface parameters
     parameter int  unsigned AxiDataWidth = 0,
     parameter int  unsigned AxiAddrWidth = 0,
     parameter type          axi_ar_t     = logic,
     parameter type          axi_aw_t     = logic,
     // Dependant parameters. DO NOT CHANGE!
-    parameter type          axi_addr_t   = logic [AxiAddrWidth-1:0]
+    localparam type         axi_addr_t   = logic [AxiAddrWidth-1:0],
+    localparam type         vlen_t       = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                           clk_i,
     input  logic                           rst_ni,

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -9,6 +9,7 @@
 
 module vldu import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int  unsigned NrLanes = 0,
+    parameter  int  unsigned VLEN    = 0,
     parameter  type          vaddr_t = logic,  // Type used to address vector register file elements
     // AXI Interface parameters
     parameter  int  unsigned AxiDataWidth = 0,
@@ -17,6 +18,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     // Dependant parameters. DO NOT CHANGE!
     localparam int           DataWidth    = $bits(elen_t),
     localparam type          strb_t       = logic[DataWidth/8-1:0],
+    localparam type          vlen_t       = logic[$clog2(VLEN+1)-1:0],
     localparam type          axi_addr_t   = logic [AxiAddrWidth-1:0]
   ) (
     input  logic                           clk_i,
@@ -286,7 +288,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         // Initialize id and addr fields of the result queue requests
         for (int lane = 0; lane < NrLanes; lane++) begin
           result_queue_d[result_queue_write_pnt_q][lane].id   = vinsn_issue_q.id;
-          result_queue_d[result_queue_write_pnt_q][lane].addr = vaddr(vinsn_issue_q.vd, NrLanes) +
+          result_queue_d[result_queue_write_pnt_q][lane].addr = vaddr(vinsn_issue_q.vd, NrLanes, VLEN) +
             (((vinsn_issue_q.vl - (issue_cnt_q >> int'(vinsn_issue_q.vtype.vsew))) / NrLanes) >>
             (int'(EW64) - int'(vinsn_issue_q.vtype.vsew)));
         end

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -8,9 +8,11 @@
 // upon receiving vector memory operations.
 
 module vldu import ara_pkg::*; import rvv_pkg::*; #(
-    parameter  int  unsigned NrLanes = 0,
-    parameter  int  unsigned VLEN    = 0,
-    parameter  type          vaddr_t = logic,  // Type used to address vector register file elements
+    parameter  int  unsigned NrLanes   = 0,
+    parameter  int  unsigned VLEN      = 0,
+    parameter  type          vaddr_t   = logic,  // Type used to address vector register file elements
+    parameter  type          pe_req_t  = logic,
+    parameter  type          pe_resp_t = logic,
     // AXI Interface parameters
     parameter  int  unsigned AxiDataWidth = 0,
     parameter  int  unsigned AxiAddrWidth = 0,
@@ -268,7 +270,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
             // Map axi_byte to the corresponding byte in the VRF word (sequential)
             automatic int vrf_seq_byte = axi_byte - lower_byte - r_pnt_q + vrf_pnt_q;
             // And then shuffle it
-            automatic int vrf_byte = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew);
+            automatic int vrf_byte = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew, VLEN);
 
             // Is this byte a valid byte in the VRF word?
             if (vrf_seq_byte < issue_cnt_q && vrf_seq_byte < NrLanes * 8) begin

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -270,7 +270,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
             // Map axi_byte to the corresponding byte in the VRF word (sequential)
             automatic int vrf_seq_byte = axi_byte - lower_byte - r_pnt_q + vrf_pnt_q;
             // And then shuffle it
-            automatic int vrf_byte = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew, VLEN);
+            automatic int vrf_byte = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.vtype.vsew);
 
             // Is this byte a valid byte in the VRF word?
             if (vrf_seq_byte < issue_cnt_q && vrf_seq_byte < NrLanes * 8) begin

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -9,9 +9,11 @@
 // and coherence with Ariane's own load/store unit.
 
 module vlsu import ara_pkg::*; import rvv_pkg::*; #(
-    parameter  int  unsigned NrLanes = 0,
-    parameter  int  unsigned VLEN    = 0,
-    parameter  type          vaddr_t = logic,  // Type used to address vector register file elements
+    parameter  int  unsigned NrLanes   = 0,
+    parameter  int  unsigned VLEN      = 0,
+    parameter  type          vaddr_t   = logic,  // Type used to address vector register file elements
+    parameter  type          pe_req_t  = logic,
+    parameter  type          pe_resp_t = logic,
     // AXI Interface parameters
     parameter  int  unsigned AxiDataWidth = 0,
     parameter  int  unsigned AxiAddrWidth = 0,
@@ -123,7 +125,9 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .AxiDataWidth(AxiDataWidth),
     .AxiAddrWidth(AxiAddrWidth),
     .axi_ar_t    (axi_ar_t    ),
-    .axi_aw_t    (axi_aw_t    )
+    .axi_aw_t    (axi_aw_t    ),
+    .pe_req_t    (pe_req_t    ),
+    .pe_resp_t   (pe_resp_t   )
   ) i_addrgen (
     .clk_i                      (clk_i                      ),
     .rst_ni                     (rst_ni                     ),
@@ -167,7 +171,9 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .axi_r_t     (axi_r_t     ),
     .NrLanes     (NrLanes     ),
     .VLEN        (VLEN        ),
-    .vaddr_t     (vaddr_t     )
+    .vaddr_t     (vaddr_t     ),
+    .pe_req_t    (pe_req_t    ),
+    .pe_resp_t   (pe_resp_t   )
   ) i_vldu (
     .clk_i                  (clk_i                     ),
     .rst_ni                 (rst_ni                    ),
@@ -212,7 +218,9 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .axi_b_t     (axi_b_t     ),
     .NrLanes     (NrLanes     ),
     .VLEN        (VLEN        ),
-    .vaddr_t     (vaddr_t     )
+    .vaddr_t     (vaddr_t     ),
+    .pe_req_t    (pe_req_t    ),
+    .pe_resp_t   (pe_resp_t   )
   ) i_vstu (
     .clk_i                  (clk_i                      ),
     .rst_ni                 (rst_ni                     ),

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -10,6 +10,7 @@
 
 module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int  unsigned NrLanes = 0,
+    parameter  int  unsigned VLEN    = 0,
     parameter  type          vaddr_t = logic,  // Type used to address vector register file elements
     // AXI Interface parameters
     parameter  int  unsigned AxiDataWidth = 0,
@@ -23,7 +24,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     parameter  type          axi_resp_t   = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam int  unsigned DataWidth    = $bits(elen_t),
-    localparam type          strb_t       = logic [DataWidth/8-1:0]
+    localparam type          strb_t       = logic [DataWidth/8-1:0],
+    localparam type          vlen_t       = logic[$clog2(VLEN+1)-1:0]
   ) (
     input  logic                    clk_i,
     input  logic                    rst_ni,
@@ -117,6 +119,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
 
   addrgen #(
     .NrLanes     (NrLanes     ),
+    .VLEN        (VLEN        ),
     .AxiDataWidth(AxiDataWidth),
     .AxiAddrWidth(AxiAddrWidth),
     .axi_ar_t    (axi_ar_t    ),
@@ -163,6 +166,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .AxiDataWidth(AxiDataWidth),
     .axi_r_t     (axi_r_t     ),
     .NrLanes     (NrLanes     ),
+    .VLEN        (VLEN        ),
     .vaddr_t     (vaddr_t     )
   ) i_vldu (
     .clk_i                  (clk_i                     ),
@@ -207,6 +211,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .axi_w_t     (axi_w_t     ),
     .axi_b_t     (axi_b_t     ),
     .NrLanes     (NrLanes     ),
+    .VLEN        (VLEN        ),
     .vaddr_t     (vaddr_t     )
   ) i_vstu (
     .clk_i                  (clk_i                      ),

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -14,9 +14,11 @@
 // upon receiving vector memory operations.
 
 module vstu import ara_pkg::*; import rvv_pkg::*; #(
-    parameter  int  unsigned NrLanes = 0,
-    parameter  int  unsigned VLEN    = 0,
-    parameter  type          vaddr_t = logic,  // Type used to address vector register file elements
+    parameter  int  unsigned NrLanes   = 0,
+    parameter  int  unsigned VLEN      = 0,
+    parameter  type          vaddr_t   = logic,  // Type used to address vector register file elements
+    parameter  type          pe_req_t  = logic,
+    parameter  type          pe_resp_t = logic,
     // AXI Interface parameters
     parameter  int  unsigned AxiDataWidth = 0,
     parameter  int  unsigned AxiAddrWidth = 0,
@@ -236,7 +238,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
           // Map axy_byte to the corresponding byte in the VRF word (sequential)
           automatic int vrf_seq_byte = axi_byte - lower_byte + vrf_pnt_q;
           // And then shuffle it
-          automatic int vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.eew_vs1);
+          automatic int vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.eew_vs1, VLEN);
 
           // Is this byte a valid byte in the VRF word?
           if (vrf_seq_byte < issue_cnt_q) begin

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -27,7 +27,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
     // Dependant parameters. DO NOT CHANGE!
     localparam int           DataWidth    = $bits(elen_t),
     localparam type          strb_t       = logic[DataWidth/8-1:0],
-    localparam type          vlen_t       = logic[$clog2(VLEN+1)-1:0]
+    localparam type          vlen_t       = logic[$clog2(VLEN+1)-1:0],
     localparam type          axi_addr_t   = logic [AxiAddrWidth-1:0]
   )(
     input  logic                           clk_i,
@@ -238,7 +238,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
           // Map axy_byte to the corresponding byte in the VRF word (sequential)
           automatic int vrf_seq_byte = axi_byte - lower_byte + vrf_pnt_q;
           // And then shuffle it
-          automatic int vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.eew_vs1, VLEN);
+          automatic int vrf_byte     = shuffle_index(vrf_seq_byte, NrLanes, vinsn_issue_q.eew_vs1);
 
           // Is this byte a valid byte in the VRF word?
           if (vrf_seq_byte < issue_cnt_q) begin

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -15,6 +15,7 @@
 
 module vstu import ara_pkg::*; import rvv_pkg::*; #(
     parameter  int  unsigned NrLanes = 0,
+    parameter  int  unsigned VLEN    = 0,
     parameter  type          vaddr_t = logic,  // Type used to address vector register file elements
     // AXI Interface parameters
     parameter  int  unsigned AxiDataWidth = 0,
@@ -24,6 +25,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
     // Dependant parameters. DO NOT CHANGE!
     localparam int           DataWidth    = $bits(elen_t),
     localparam type          strb_t       = logic[DataWidth/8-1:0],
+    localparam type          vlen_t       = logic[$clog2(VLEN+1)-1:0]
     localparam type          axi_addr_t   = logic [AxiAddrWidth-1:0]
   )(
     input  logic                           clk_i,

--- a/hardware/tb/ara_tb.sv
+++ b/hardware/tb/ara_tb.sv
@@ -29,6 +29,12 @@ module ara_tb;
   localparam NrLanes = 0;
   `endif
 
+  `ifdef VLEN
+  localparam VLEN = `VLEN;
+  `else
+  localparam VLEN = 0;
+  `endif
+
   localparam ClockPeriod  = 1ns;
   // Axi response delay [ps]
   localparam int unsigned AxiRespDelay = 200;
@@ -78,6 +84,7 @@ module ara_tb;
   `ifndef VERILATOR
   ara_testharness #(
     .NrLanes     (NrLanes         ),
+    .VLEN        (VLEN            ),
     .AxiAddrWidth(AxiAddrWidth    ),
     .AxiDataWidth(AxiWideDataWidth),
     .AxiRespDelay(AxiRespDelay    )

--- a/hardware/tb/ara_tb_verilator.sv
+++ b/hardware/tb/ara_tb_verilator.sv
@@ -7,7 +7,8 @@
 // Description: Top level testbench module for Verilator.
 
 module ara_tb_verilator #(
-    parameter int unsigned NrLanes = 0
+    parameter int unsigned NrLanes = 0,
+    parameter int unsigned VLEN    = 0
   )(
     input  logic        clk_i,
     input  logic        rst_ni,
@@ -27,6 +28,7 @@ module ara_tb_verilator #(
 
   ara_testharness #(
     .NrLanes     (NrLanes         ),
+    .VLEN        (VLEN            ),
     .AxiAddrWidth(AxiAddrWidth    ),
     .AxiDataWidth(AxiWideDataWidth)
   ) dut (

--- a/hardware/tb/ara_testharness.sv
+++ b/hardware/tb/ara_testharness.sv
@@ -10,6 +10,7 @@
 module ara_testharness #(
     // Ara-specific parameters
     parameter int unsigned NrLanes      = 0,
+    parameter int unsigned VLEN         = 0,
     // AXI Parameters
     parameter int unsigned AxiUserWidth = 1,
     parameter int unsigned AxiIdWidth   = 5,
@@ -67,6 +68,7 @@ module ara_testharness #(
 
   ara_soc #(
     .NrLanes     (NrLanes      ),
+    .VLEN        (VLEN         ),
     .AxiAddrWidth(AxiAddrWidth ),
     .AxiDataWidth(AxiDataWidth ),
     .AxiIdWidth  (AxiIdWidth   ),

--- a/hardware/tb/verilator/waiver.vlt
+++ b/hardware/tb/verilator/waiver.vlt
@@ -4,13 +4,6 @@
 
 `verilator_config
 
-// Hierarchical verilation
-hier_block -module "lane"
-
-// Hierarchical modules will be renamed by Verilator. Disable the DECLFILENAME
-// check for those right away
-lint_off -rule DECLFILENAME -file "*" -match "*lane*"
-
 // Ignore duplicate modules, since this is handled by Bender
 lint_off -rule MODDUP
 


### PR DESCRIPTION
`VLEN` is now a parameter of the Ara module. 
The `ara_package.sv` code does not depend on defines anymore.

## Changelog

### Changed

- `VLEN` is now a parameter of the ara architecture and does not depend on a define anymore
- `vlen_t`, as a consequence, is now define within the architecture as a parameter/localparam
- Change verilation from hierarchical (lane -> Ara) to fully flat (Ara)

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
