### PR TITLE
[hardware] Fix hanging integer reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix vstart usage for memory operations
  - Fix fft, exp, softmax, roi_align performance
  - Fix printf bug (missing characters) - UART and CTRL memory regions are now idempotent
+ - Start int reductions only if ALU result queue is empty
 
 ### Added
 

--- a/hardware/src/lane/valu.sv
+++ b/hardware/src/lane/valu.sv
@@ -813,7 +813,9 @@ module valu import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width;
       // Initialize counters and alu state if the instruction queue was empty
       // and the lane is not reducing
       if ((vinsn_queue_d.issue_cnt == '0) && !prevent_commit) begin
-        alu_state_d = is_reduction(vfu_operation_i.op) ? INTRA_LANE_REDUCTION : NO_REDUCTION;
+        // INTRA_LANE_REDUCTION state needs the result queue
+        // Start the reduction only if the commit queue (so, the result queue, too) is empty
+        alu_state_d = is_reduction(vfu_operation_i.op) && (commit_cnt_q == '0) ? INTRA_LANE_REDUCTION : NO_REDUCTION;
         // The next will be the first operation of this instruction
         // This information is useful for reduction operation
         // Initialize reduction-related sequential elements


### PR DESCRIPTION
If the result queue is not empty and we start a reduction, the state of the ALU goes to INTRA_LANE_REDUCTION. Here, the VRF write-back of the previous instruction does not happen. Moreover, the INTRA_LANE_REDUCTION needs the result queue for its own purposes.

## Changelog

### Fixed

- Start integer reductions only if the result queue is empty

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed