### PR TITLE
[HW] :bug: Fix printf missing characters bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix reshuffle mechanism
  - Fix vstart usage for memory operations
  - Fix fft, exp, softmax, roi_align performance
+ - Fix printf bug (missing characters) - UART and CTRL memory regions are now idempotent
 
 ### Added
 
@@ -47,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - VLEN is now a parameter of the ara architecture and does not depend on a define anymore
  - vlen_t, as a consequence, is now define within the architecture as a parameter/localparam
  - Refactor addrgen module
+ - Memory size is now constant with NrLanes
 
 ## 3.0.0 - 2023-09-08
 

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -494,8 +494,8 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     CLICNumInterruptSrc   : 0,
     // idempotent region
     NrNonIdempotentRules : 2,
-    NonIdempotentAddrBase: {64'b0, 64'b0},
-    NonIdempotentLength  : {64'b0, 64'b0},
+    NonIdempotentAddrBase: {UARTBase, CTRLBase},
+    NonIdempotentLength  : {UARTLength, CTRLLength},
     NrExecuteRegionRules : 3,
     //                      DRAM,       Boot ROM,   Debug Module
     ExecuteRegionAddrBase: {DRAMBase, 64'h1_0000, 64'h0},

--- a/hardware/src/ara_soc.sv
+++ b/hardware/src/ara_soc.sv
@@ -24,7 +24,7 @@ module ara_soc import axi_pkg::*; import ara_pkg::*; #(
     // AXI Resp Delay [ps] for gate-level simulation
     parameter  int           unsigned AxiRespDelay = 200,
     // Main memory
-    parameter  int           unsigned L2NumWords   = 2**20,
+    parameter  int           unsigned L2NumWords   = (2**22) / NrLanes,
     // Dependant parameters. DO NOT CHANGE!
     localparam type                   axi_data_t   = logic [AxiDataWidth-1:0],
     localparam type                   axi_strb_t   = logic [AxiDataWidth/8-1:0],


### PR DESCRIPTION
Fix nasty bug in printf.

## Changelog

### Fixed

- Fix printf bug - UART and CTRL regions are now idempotent

### Changed

- Memory size is now fixed regardless of `NrLanes`

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed