### PR TITLE
[HW] Fix CVA6 bug for instructions with side effects

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -30,7 +30,7 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cva6:
-    revision: 5614fc9ceeae6db3851e8c721de868355db9476b
+    revision: f9ebe5006fefe97fc1d2a8b1515fa2fd321fec6d
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -10,7 +10,7 @@ package:
 dependencies:
   axi:                { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.1                               }
   common_cells:       { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.22.1                               }
-  cva6:               { git: "https://github.com/pulp-platform/cva6.git",               rev: 5614fc9ceeae6db3851e8c721de868355db9476b } # mp/pulp-v1-araOS
+  cva6:               { git: "https://github.com/pulp-platform/cva6.git",               rev: f9ebe5006fefe97fc1d2a8b1515fa2fd321fec6d } # mp/pulp-v1-araOS
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13                               }
   apb:                { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4                                }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix fft, exp, softmax, roi_align performance
  - Fix printf bug (missing characters) - UART and CTRL memory regions are now idempotent
  - Start int reductions only if ALU result queue is empty
+ - Fix `acc_dispatcher` CVA6 bug for instructions with side effects
 
 ### Added
 


### PR DESCRIPTION
Bump CVA6 to fix bug that caused some vector instructions to be issued twice in the presence of instructions with side effects.

## Changelog

### Fixed

- Fix `fence` bug in CVA6.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
