### PR TITLE
[Bender] Bump common_cells and axi to solve verilation warnings

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -7,8 +7,8 @@ packages:
     dependencies:
     - common_cells
   axi:
-    revision: fccffb5953ec8564218ba05e20adbedec845e014
-    version: 0.39.1
+    revision: 587355b77b8ce94dcd600efbd5d5bd118ff913a7
+    version: 0.39.4
     source:
       Git: https://github.com/pulp-platform/axi.git
     dependencies:
@@ -16,8 +16,8 @@ packages:
     - common_verification
     - tech_cells_generic
   common_cells:
-    revision: 2bd027cb87eaa9bf7d17196ec5f69864b35b630f
-    version: 1.32.0
+    revision: c27bce39ebb2e6bae52f60960814a2afca7bd4cb
+    version: 1.37.0
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Refactor addrgen module
  - Memory size is now constant with NrLanes
  - Enable hierarchical verilation
+ - Bump AXI and common cells to solve verilation warnings
 
 ## 3.0.0 - 2023-09-08
 


### PR DESCRIPTION
Solve verilation warnings (missing pins).

## Changelog

### Changed

- Bump common_cells and axi to solve verilation warnings

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
