### PR TITLE
[SW] Remove redundant instruction in reset_vector

### DIFF
--- a/apps/common/crt0.S
+++ b/apps/common/crt0.S
@@ -59,7 +59,6 @@ reset_vector:
     li      x18, 0
     li      x19, 0
     li      x20, 0
-    li      x10, 0
     li      x21, 0
     li      x22, 0
     li      x23, 0


### PR DESCRIPTION
Removed a redundant `li x10, 0` instruction in the reset_vector section of crt0.S. This cleanup improves code clarity without altering the functionality.
