### PR TITLE
Add VCU118 Support to mp/pulp-v1-os-fpga Branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ CXX    = g++
 endif
 
 # We need a recent LLVM to compile Verilator
-CLANG_CC  ?= clang
-CLANG_CXX ?= clang++
+CLANG_CC  ?= clang-14
+CLANG_CXX ?= clang++-14
 ifneq (${CLANG_PATH},)
 	CLANG_CXXFLAGS := "-nostdinc++ -isystem $(CLANG_PATH)/include/c++/v1"
 	CLANG_LDFLAGS  := "-L $(CLANG_PATH)/lib -Wl,-rpath,$(CLANG_PATH)/lib -lc++ -nostdlib++"

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ CXX    = g++
 endif
 
 # We need a recent LLVM to compile Verilator
-CLANG_CC  ?= clang-14
-CLANG_CXX ?= clang++-14
+CLANG_CC  ?= clang
+CLANG_CXX ?= clang++
 ifneq (${CLANG_PATH},)
 	CLANG_CXXFLAGS := "-nostdinc++ -isystem $(CLANG_PATH)/include/c++/v1"
 	CLANG_LDFLAGS  := "-L $(CLANG_PATH)/lib -Wl,-rpath,$(CLANG_PATH)/lib -lc++ -nostdlib++"

--- a/cheshire/Makefile
+++ b/cheshire/Makefile
@@ -20,7 +20,7 @@ VIVADO ?= 'vitis-2020.2 vivado'
 # default configuration for Cheshire + Ara is 2_lanes
 ARA_CONFIGURATION         ?= 2_lanes
 include $(ARA_ROOT)/config/$(ARA_CONFIGURATION).mk
-BOARD                     := vcu128
+BOARD                     ?= vcu128
 VLOG_ARGS                 ?= -suppress 2583 -suppress 13314
 COMMON_CUSTOM_TARGETS     := -t cv64a6_imafdcv_sv39 -t cva6 --define ARA --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen)
 CUSTOM_SIM_BENDER_TARGETS := $(COMMON_CUSTOM_TARGETS) -t sim -t test -t rtl --vlog-arg="$(VLOG_ARGS)"
@@ -40,7 +40,7 @@ apply-patches:
 
 update_xilinx_src:
 	cd $(BACKREF_CHS_ROOT) && \
-	bender script vivado $(CUSTOM_XIL_BENDER_TARGETS) > $(BACKREF_CHS_XIL_SCRIPTS)/add_sources.vcu128.tcl
+	bender script vivado $(CUSTOM_XIL_BENDER_TARGETS) > $(BACKREF_CHS_XIL_SCRIPTS)/add_sources.$(BOARD).tcl
 
 update_vsim_src:
 	cd $(BACKREF_CHS_ROOT) && \
@@ -48,5 +48,5 @@ update_vsim_src:
 	echo 'vlog "$(realpath $(BACKREF_CHS_ROOT))/target/sim/src/elfloader.cpp" -ccflags "-std=c++11"' >> $(BACKREF_CHS_SIM_SCRIPTS)/compile.cheshire_soc.tcl
 
 clean:
-	rm $(BACKREF_CHS_XIL_SCRIPTS)/add_sources.vcu128.tcl
-	rm $(MAKEFILE_DIR)/add_sources.vcu128.tcl
+	rm $(BACKREF_CHS_XIL_SCRIPTS)/add_sources.$(BOARD).tcl
+	rm $(MAKEFILE_DIR)/add_sources.$(BOARD).tcl

--- a/cheshire/Makefile
+++ b/cheshire/Makefile
@@ -4,9 +4,9 @@
 #
 # Author: Moritz Imfeld  <moimfeld@student.ethz.ch>
 # Author: Matteo Perotti <mperotti@ethz.ch>
-#
+# Modifier : Mojtaba Rostami <m.rostami1989@gmail.com>
 
-# Chshire root reposiotry
+# Cheshire root repository
 MAKEFILE_DIR            := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ARA_ROOT                := $(MAKEFILE_DIR)/..
 BACKREF_CHS_ROOT        ?= $(realpath ../../../../..)
@@ -20,18 +20,21 @@ VIVADO ?= 'vitis-2020.2 vivado'
 # default configuration for Cheshire + Ara is 2_lanes
 ARA_CONFIGURATION         ?= 2_lanes
 include $(ARA_ROOT)/config/$(ARA_CONFIGURATION).mk
+
+# Default to VCU128 if no BOARD is specified, but allow overriding.
 BOARD                     ?= vcu128
 VLOG_ARGS                 ?= -suppress 2583 -suppress 13314
 COMMON_CUSTOM_TARGETS     := -t cv64a6_imafdcv_sv39 -t cva6 --define ARA --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen)
 CUSTOM_SIM_BENDER_TARGETS := $(COMMON_CUSTOM_TARGETS) -t sim -t test -t rtl --vlog-arg="$(VLOG_ARGS)"
-CUSTOM_XIL_BENDER_TARGETS := $(COMMON_CUSTOM_TARGETS) -t fpga -t $(BOARD) 
+CUSTOM_XIL_BENDER_TARGETS := $(COMMON_CUSTOM_TARGETS) -t fpga -t $(BOARD)
 
-.PHONY: ara-chs-xilinx-$(BOARD) ara-chs-flash-$(BOARD) apply-patches update_xilinx_src clean
+.PHONY: ara-chs-xilinx ara-chs-flash apply-patches update_xilinx_src clean
 
-ara-chs-xilinx-$(BOARD): update_xilinx_src
+# Combine the xilinx and flash targets to be flexible for different boards.
+ara-chs-xilinx: update_xilinx_src
 	make -C $(BACKREF_CHS_ROOT) chs-xilinx-$(BOARD)
 
-ara-chs-flash-$(BOARD):
+ara-chs-flash:
 	make -C $(BACKREF_CHS_ROOT) chs-xilinx-flash-$(BOARD) VIVADO=$(VIVADO)
 
 apply-patches:
@@ -48,5 +51,6 @@ update_vsim_src:
 	echo 'vlog "$(realpath $(BACKREF_CHS_ROOT))/target/sim/src/elfloader.cpp" -ccflags "-std=c++11"' >> $(BACKREF_CHS_SIM_SCRIPTS)/compile.cheshire_soc.tcl
 
 clean:
-	rm $(BACKREF_CHS_XIL_SCRIPTS)/add_sources.$(BOARD).tcl
-	rm $(MAKEFILE_DIR)/add_sources.$(BOARD).tcl
+	rm -f $(BACKREF_CHS_XIL_SCRIPTS)/add_sources.$(BOARD).tcl
+	rm -f $(MAKEFILE_DIR)/add_sources.$(BOARD).tcl
+


### PR DESCRIPTION

This pull request integrates support for the Xilinx VCU118 FPGA platform into the mp/pulp-v1-os-fpga branch.

## Changelog

### Changes
cheshire/Makefile:

Modified to support any specified platform using BOARD=<desired-board>. For example, use "make ara-chs-xilinx BOARD=vcu118" to build for the VCU118 platform.

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

