### PR TITLE
[Readme.md] Fix instructions to flash SD

### DIFF
--- a/cheshire/README.md
+++ b/cheshire/README.md
@@ -116,8 +116,12 @@ make -C ${ARA_ROOT}/cheshire ara-chs-image BOARD=${BOARD}
 # Generate the bitstream
 echo 'Generate the bitstream'
 make -C ${ARA_ROOT}/cheshire ara-chs-xilinx BOARD=${BOARD}
-# Flash the SD with Linux
+# Flash the SD with Linux (for boards with micro-SD support i.e vcu118)
 echo 'Flash the SD with Linux'
+sudo dd if=sw/boot/linux.<board>.gpt.bin of=/dev/<sdcard>
+sudo sgdisk -e /dev/<sdcard>
+# Flash the on-board storage with Linux
+echo 'Flash the SPI Flash with Linux'
 make -C ${ARA_ROOT}/cheshire ara-chs-xilinx-flash BOARD=${BOARD} CHS_XILINX_HWS_URL=${CHS_XILINX_HWS_URL} CHS_XILINX_HWS_PATH=${CHS_XILINX_HWS_PATH}
 # Program the bitstream
 echo 'Program the bitstream'


### PR DESCRIPTION
Since the` ara-chs-xilinx-flash` is used to program on-board flash with image or bitstream, to flash the SD card on supported hardware, the standard SD card flash process should be used as described here: https://pulp-platform.github.io/cheshire/tg/xilinx/#boot-from-sd-card-genesys2-only

Description of PR that completes issue here...

## Changelog
Update cheshire/ERADME.md
### Fixed
Instructions to flash SD card, clear ambiguity between flashing SD card (for supported HW)  and on-board flash on VCU128

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
