### PR TITLE
[HW] Bump CVA6 to `pulp-v2`

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -7,8 +7,8 @@ packages:
     dependencies:
     - common_cells
   axi:
-    revision: 587355b77b8ce94dcd600efbd5d5bd118ff913a7
-    version: 0.39.4
+    revision: 853ede23b2a9837951b74dbdc6d18c3eef5bac7d
+    version: 0.39.5
     source:
       Git: https://github.com/pulp-platform/axi.git
     dependencies:

--- a/Bender.lock
+++ b/Bender.lock
@@ -30,7 +30,7 @@ packages:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
   cva6:
-    revision: feb5f72b5cafb840388ea85b155dfb4013c1926f
+    revision: 99eac9a649001bdf5b8f9da52e0ca73d5c48db1c
     version: null
     source:
       Git: https://github.com/pulp-platform/cva6.git
@@ -40,7 +40,7 @@ packages:
     - fpnew
     - tech_cells_generic
   fpnew:
-    revision: f231041c610f270ffc03cbdac38739ddb6426572
+    revision: e5aa6a01b5bbe1675c3aa8872e1203413ded83d1
     version: null
     source:
       Git: https://github.com/pulp-platform/cvfpu.git

--- a/Bender.yml
+++ b/Bender.yml
@@ -8,11 +8,11 @@ package:
     - "Paul Scheffler <paulsc@iis.ee.ethz.ch>"
 
 dependencies:
-  axi:                { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.1                               }
-  common_cells:       { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.22.1                               }
-  cva6:               { git: "https://github.com/pulp-platform/cva6.git",               rev: feb5f72b5cafb840388ea85b155dfb4013c1926f } # mp/pulp-v1-araOS
-  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13                               }
-  apb:                { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4                                }
+  axi:                { git: "https://github.com/pulp-platform/axi.git",                version: 0.39.1 }
+  common_cells:       { git: "https://github.com/pulp-platform/common_cells.git",       version: 1.22.1 }
+  cva6:               { git: "https://github.com/pulp-platform/cva6.git",               rev: pulp-v2    }
+  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.13 }
+  apb:                { git: "https://github.com/pulp-platform/apb.git",                version: 0.2.4  }
 
 workspace:
   checkout_dir: "hardware/deps"
@@ -71,6 +71,7 @@ sources:
     - target: ara_test
       files:
         # Level 1
+        - hardware/deps/cva6/corev_apu/tb/common/mock_uart.sv
         - hardware/tb/ara_testharness.sv
         # Level 2
         - hardware/tb/ara_tb.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -17,6 +17,9 @@ dependencies:
 workspace:
   checkout_dir: "hardware/deps"
 
+export_include_dirs:
+  - hardware/include
+
 sources:
   include_dirs:
     # Headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix bug in ordered reductions
  - Avoid spurious valids to the simd multipliers
  - Fix ideal dispatcher (update the ara-cva6 interface)
+ - Bump AXI (v0.39.4 is broken)
+ - Remove timing loop in addrgen (triggered by CVA6 pulp-v2)
+ - Fix latch in vmfpu
 
 ### Added
 
@@ -107,6 +110,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Re-parametrize the design with pulp-v2 parameters
  - Bump AXI version from 0.39.4 (broken) to 0.39.5
  - Bump default simulator to QuestaSim 2021.3
+ - Bump CVA6 to pulp-v2 and update parametrization
+ - Bump QuestaSim version
 
 ## 3.0.0 - 2023-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Update READMEs with FPGA implementation instructions
  - Optimize `addrgen` timing for OS-on operation
  - Enable OS by default
+ - Bump CVA6 to pulp-v2
+ - Re-parametrize the design with pulp-v2 parameters
+ - Bump AXI version from 0.39.4 (broken) to 0.39.5
+ - Bump default simulator to QuestaSim 2021.3
 
 ## 3.0.0 - 2023-09-08
 

--- a/cheshire/Makefile
+++ b/cheshire/Makefile
@@ -25,8 +25,8 @@ ARA_CONFIGURATION         ?= 2_lanes
 include $(ARA_ROOT)/config/$(ARA_CONFIGURATION).mk
 BOARD                     ?= vcu128
 VLOG_ARGS                 ?= -suppress 2583 -suppress 13314
-COMMON_CUSTOM_TARGETS     := -t cv64a6_imafdcv_sv39 -t cva6 -t exclude_first_pass_decoder --define ARA --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen)
-CUSTOM_SIM_BENDER_TARGETS := $(COMMON_CUSTOM_TARGETS) -t sim -t test -t rtl --vlog-arg="$(VLOG_ARGS)"
+COMMON_CUSTOM_TARGETS     := -t cv64a6_imafdcv_sv39 -t cva6 -t rtl -t exclude_first_pass_decoder --define ARA --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen)
+CUSTOM_SIM_BENDER_TARGETS := $(COMMON_CUSTOM_TARGETS) -t sim -t test --vlog-arg="$(VLOG_ARGS)"
 CUSTOM_XIL_BENDER_TARGETS := $(COMMON_CUSTOM_TARGETS) -t fpga -t $(BOARD)
 
 # Define XILINX FPGA URL and PATH for programming

--- a/cheshire/sw/include/rvv_test.h
+++ b/cheshire/sw/include/rvv_test.h
@@ -10,6 +10,10 @@
 
 #include "regs/cheshire.h"
 
+#ifndef PRINTF
+#define PRINTF 1
+#endif
+
 #if (PRINTF == 1)
 #include "printf.h"
 #endif
@@ -17,6 +21,10 @@
 /////////////////
 // SEW and EEW //
 /////////////////
+
+#ifndef EEW
+#define EEW 64
+#endif
 
 // Public defines
 #if EEW == 64
@@ -82,6 +90,17 @@
 ///////////////////////
 // SoC-level regfile //
 ///////////////////////
+
+// Fake offset values if the stub is not supported
+#ifndef CHESHIRE_STUB_EX_EN_REG_OFFSET
+#define CHESHIRE_STUB_EX_EN_REG_OFFSET       0
+#define CHESHIRE_STUB_NO_EX_LAT_REG_OFFSET   0
+#define CHESHIRE_STUB_REQ_RSP_LAT_REG_OFFSET 0
+#define CHESHIRE_ARA_VIRT_MEM_EN_REG_OFFSET  0
+#define CHESHIRE_RVV_DEBUG_REG_REG_OFFSET    0
+#define CHESHIRE_MMU_REQ_GEN_EN_REG_OFFSET   0
+#define CHESHIRE_MMU_REQ_GEN_LAT_REG_OFFSET  0
+#endif
 
 #define INIT_RVV_TEST_SOC_REGFILE \
 volatile uint32_t *rf_stub_ex_en      = reg32(&__base_regs, CHESHIRE_STUB_EX_EN_REG_OFFSET);       \

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -54,7 +54,7 @@ top_level      ?= ara_tb
 ifeq ($(vcd_dump), 1)
   questa_version ?= 2019.3
 else
-  questa_version ?= 2021.2
+  questa_version ?= 2021.3
 endif
 # QuestaSim command
 questa_cmd     ?= questa-$(questa_version)

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -109,7 +109,7 @@ vlog_args += -work $(library)
 bender_defs += --define NR_LANES=$(nr_lanes) --define VLEN=$(vlen) --define ARIANE_ACCELERATOR_PORT=1
 bender_defs_veril := $(bender_defs) --define COMMON_CELLS_ASSERTS_OFF
 # Targets
-bender_common_targs := -t rtl -t cv64a6_imafdcv_sv39 -t tech_cells_generic_include_tc_sram -t tech_cells_generic_include_tc_clk
+bender_common_targs := -t rtl -t cv64a6_imafdcv_sv39 -t tech_cells_generic_include_tc_sram -t tech_cells_generic_include_tc_clk -t exclude_first_pass_decoder
 bender_targs_simc     := $(bender_common_targs) -t ara_test -t cva6_test
 bender_targs_veril    := $(bender_common_targs) -t ara_test -t cva6_test -t verilator
 bender_targs_spyglass := $(bender_common_targs) -t spyglass

--- a/hardware/include/ara/intf_typedef.svh
+++ b/hardware/include/ara/intf_typedef.svh
@@ -1,0 +1,89 @@
+// Copyright 2021 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+///////////////////////////////////
+// CVA6 - Accelerator interfaces //
+///////////////////////////////////
+
+// Accelerator - CVA6's
+`define CVA6_INTF_TYPEDEF_ACC_REQ(accelerator_req_t, CVA6Cfg, roundmode_e) \
+  typedef struct packed {                                                  \
+    logic                             req_valid;                           \
+    logic                             resp_ready;                          \
+    logic [31:0]                      insn;                                \
+    logic [CVA6Cfg.XLEN-1:0]          rs1;                                 \
+    logic [CVA6Cfg.XLEN-1:0]          rs2;                                 \
+    roundmode_e                       frm;                                 \
+    logic [CVA6Cfg.TRANS_ID_BITS-1:0] trans_id;                            \
+    logic                             store_pending;                       \
+    logic                             acc_cons_en;                         \
+    logic                             inval_ready;                         \
+  } accelerator_req_t;
+
+`define CVA6_INTF_TYPEDEF_ACC_RESP(accelerator_resp_t, CVA6Cfg, exception_t) \
+  typedef struct packed {                                                    \
+    logic                              req_ready;                            \
+    logic                              resp_valid;                           \
+    logic [CVA6Cfg.XLEN-1:0]           result;                               \
+    logic [CVA6Cfg.TRANS_ID_BITS-1:0]  trans_id;                             \
+    exception_t                        exception;                            \
+    logic                              store_pending;                        \
+    logic                              store_complete;                       \
+    logic                              load_complete;                        \
+    logic [4:0]                        fflags;                               \
+    logic                              fflags_valid;                         \
+    logic                              inval_valid;                          \
+    logic [63:0]                       inval_addr;                           \
+  } accelerator_resp_t;
+
+`define CVA6_INTF_TYPEDEF_MMU_REQ(acc_mmu_req_t, CVA6Cfg) \
+  typedef struct packed {                                 \
+    logic                    acc_mmu_misaligned_ex;       \
+    logic                    acc_mmu_req;                 \
+    logic [CVA6Cfg.VLEN-1:0] acc_mmu_vaddr;               \
+    logic                    acc_mmu_is_store;            \
+  } acc_mmu_req_t;
+
+`define CVA6_INTF_TYPEDEF_MMU_RESP(acc_mmu_resp_t, CVA6Cfg, exception_t) \
+  typedef struct packed {                                                \
+    logic                    acc_mmu_dtlb_hit;                           \
+    logic [CVA6Cfg.PPNW-1:0] acc_mmu_dtlb_ppn;                           \
+    logic                    acc_mmu_valid;                              \
+    logic [CVA6Cfg.PLEN-1:0] acc_mmu_paddr;                              \
+    exception_t              acc_mmu_exception;                          \
+  } acc_mmu_resp_t;
+
+`define CVA6_INTF_TYPEDEF_CVA6_TO_ACC(cva6_to_acc_t, accelerator_req_t, acc_mmu_resp_t) \
+  typedef struct packed {                                                               \
+    accelerator_req_t acc_req;                                                          \
+    logic             acc_mmu_en;                                                       \
+    acc_mmu_resp_t    acc_mmu_resp;                                                     \
+  } cva6_to_acc_t;
+
+`define CVA6_INTF_TYPEDEF_ACC_TO_CVA6(acc_to_cva6_t, accelerator_resp_t, acc_mmu_req_t) \
+  typedef struct packed {                                                               \
+    accelerator_resp_t acc_resp;                                                        \
+    acc_mmu_req_t      acc_mmu_req;                                                     \
+  } acc_to_cva6_t;
+
+/////////////////////////
+// Exception data type //
+/////////////////////////
+
+`define CVA6_TYPEDEF_EXCEPTION(exception_t, CVA6Cfg)           \
+  typedef struct packed {                                      \
+    // cause of exception                                      \
+    logic [CVA6Cfg.XLEN-1:0] cause;                            \
+    // additional information of causing exception             \
+    // (e.g.: instruction causing it), address of LD/ST fault  \
+    logic [CVA6Cfg.XLEN-1:0] tval;                             \
+    // additional information when the causing exception in    \
+    // a guest exception                                       \
+    logic [CVA6Cfg.GPLEN-1:0] tval2;                           \
+    // transformed instruction information                     \
+    logic [31:0] tinst;                                        \
+    // signals when a guest virtual address is written to tval \
+    logic gva  ;                                               \
+    logic valid;                                               \
+  } exception_t;

--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -352,18 +352,6 @@ typedef struct packed {
     fp64_from_fp32 = fp64;
   endfunction
 
-  /////////////////////////////
-  //  Accelerator interface  //
-  /////////////////////////////
-
-  // Use Ariane's accelerator interface.
-  typedef acc_pkg::cva6_to_acc_t cva6_to_acc_t;
-  typedef acc_pkg::acc_to_cva6_t acc_to_cva6_t;
-  typedef acc_pkg::accelerator_req_t accelerator_req_t;
-  typedef acc_pkg::accelerator_resp_t accelerator_resp_t;
-  typedef acc_pkg::acc_mmu_req_t acc_mmu_req_t;
-  typedef acc_pkg::acc_mmu_resp_t acc_mmu_resp_t;
-
   ////////////////////
   //  PE interface  //
   ////////////////////

--- a/hardware/src/accel_dispatcher_ideal.sv
+++ b/hardware/src/accel_dispatcher_ideal.sv
@@ -20,8 +20,11 @@
 `define N_VINSN 1
 `endif
 
-module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; #(
-  parameter config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg
+module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; # (
+  parameter  config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg,
+  parameter type cva6_to_acc_t = logic,
+  parameter type acc_to_cva6_t = logic,
+  localparam type xlen_t = logic [CVA6Cfg.XLEN-1:0]
 ) (
   input  logic         clk_i,
   input  logic         rst_ni,
@@ -42,8 +45,8 @@ module accel_dispatcher_ideal import axi_pkg::*; import ara_pkg::*; #(
 
   typedef struct packed {
     riscv::instruction_t insn;
-    riscv::xlen_t rs1;
-    riscv::xlen_t rs2;
+    xlen_t rs1;
+    xlen_t rs2;
   } fifo_payload_t;
 
   logic [DATA_WIDTH-1:0] fifo_data_raw;
@@ -158,7 +161,7 @@ endmodule
 
     typedef struct packed {
       riscv::instruction_t insn;
-      riscv::xlen_t rs1;
+      xlen_t rs1;
     } fifo_payload_t;
     fifo_payload_t payload;
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -9,10 +9,15 @@
 // response or an error message.
 
 module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
-    parameter int           unsigned NrLanes      = 0,
-    parameter int           unsigned VLEN         = 0,
-    parameter type                   ara_req_t    = logic,
-    parameter type                   ara_resp_t   = logic,
+    parameter int           unsigned NrLanes            = 0,
+    parameter int           unsigned VLEN               = 0,
+    parameter type                   ara_req_t          = logic,
+    parameter type                   ara_resp_t         = logic,
+    parameter type                   accelerator_req_t  = logic,
+    parameter type                   accelerator_resp_t = logic,
+    // CVA6 configuration
+    parameter config_pkg::cva6_cfg_t CVA6Cfg      = cva6_config_pkg::cva6_cfg,
+    localparam type                  xlen_t       = logic [CVA6Cfg.XLEN-1:0],
     // Support for floating-point data types
     parameter fpu_support_e          FPUSupport   = FPUSupportHalfSingleDouble,
     // External support for vfrec7, vfrsqrt7
@@ -76,15 +81,15 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
   `FF(csr_vxsat_q, csr_vxsat_d, '0)
   `FF(csr_vxrm_q, csr_vxrm_d, '0)
   // Converts between the internal representation of `vtype_t` and the full XLEN-bit CSR.
-  function automatic riscv::xlen_t xlen_vtype(vtype_t vtype);
-    xlen_vtype = {vtype.vill, {riscv::XLEN-9{1'b0}}, vtype.vma, vtype.vta, vtype.vsew,
+  function automatic xlen_t xlen_vtype(vtype_t vtype);
+    xlen_vtype = {vtype.vill, {CVA6Cfg.XLEN-9{1'b0}}, vtype.vma, vtype.vta, vtype.vsew,
       vtype.vlmul[2:0]};
   endfunction: xlen_vtype
 
   // Converts between the XLEN-bit vtype CSR and its internal representation
-  function automatic vtype_t vtype_xlen(riscv::xlen_t xlen);
+  function automatic vtype_t vtype_xlen(xlen_t xlen);
     vtype_xlen = '{
-      vill  : xlen[riscv::XLEN-1],
+      vill  : xlen[CVA6Cfg.XLEN-1],
       vma   : xlen[7],
       vta   : xlen[6],
       vsew  : vew_e'(xlen[5:3]),
@@ -172,6 +177,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
   logic [2:0] reshuffle_req_d, reshuffle_req_q;
   // Segment memory operations end or ongoing?
   logic seg_mem_op_end, pending_seg_mem_op_d, pending_seg_mem_op_q;
+  // Easily handle the riscv incoming instruction
+  riscv::instruction_t instr;
+  assign instr = riscv::instruction_t'(acc_req_i.insn);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -461,7 +469,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       // Inject a reshuffle instruction
       RESHUFFLE: begin
         // Instruction is of one of the RVV types
-        automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
+        automatic rvv_instruction_t insn = rvv_instruction_t'(instr.instr);
 
         // Stall the interface, wait for the backend to accept the injected uop
         acc_resp_o.req_ready  = 1'b0;
@@ -588,14 +596,14 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         acc_resp_o.req_ready = 1'b1;
 
         // Decode the instructions based on their opcode
-        unique case (acc_req_i.insn.itype.opcode)
+        unique case (instr.itype.opcode)
           //////////////////////////////////////
           //  Vector Arithmetic instructions  //
           //////////////////////////////////////
 
           riscv::OpcodeVec: begin
             // Instruction is of one of the RVV types
-            automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
+            automatic rvv_instruction_t insn = rvv_instruction_t'(instr.instr);
 
             // These (mostly) always respond at the same cycle
             acc_resp_o.resp_valid = 1'b1;
@@ -610,11 +618,11 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Update vtype
                 if (insn.vsetvli_type.func1 == 1'b0) begin // vsetvli
-                  csr_vtype_d = vtype_xlen(riscv::xlen_t'(insn.vsetvli_type.zimm11));
+                  csr_vtype_d = vtype_xlen(xlen_t'(insn.vsetvli_type.zimm11));
                 end else if (insn.vsetivli_type.func2 == 2'b11) begin // vsetivli
-                  csr_vtype_d = vtype_xlen(riscv::xlen_t'(insn.vsetivli_type.zimm10));
+                  csr_vtype_d = vtype_xlen(xlen_t'(insn.vsetivli_type.zimm10));
                 end else if (insn.vsetvl_type.func7 == 7'b100_0000) begin // vsetvl
-                  csr_vtype_d = vtype_xlen(riscv::xlen_t'(acc_req_i.rs2[7:0]));
+                  csr_vtype_d = vtype_xlen(xlen_t'(acc_req_i.rs2[7:0]));
                 end else
                   illegal_insn = 1'b1;
 
@@ -2855,7 +2863,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
           riscv::OpcodeLoadFp: begin
             // Instruction is of one of the RVV types
-            automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
+            automatic rvv_instruction_t insn = rvv_instruction_t'(instr.instr);
 
             // The instruction is a load
             is_vload = 1'b1;
@@ -3102,7 +3110,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
           riscv::OpcodeStoreFp: begin
             // Instruction is of one of the RVV types
-            automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
+            automatic rvv_instruction_t insn = rvv_instruction_t'(instr.instr);
 
             // The instruction is a store
             is_vstore = 1'b1;
@@ -3348,10 +3356,10 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
               acc_resp_o.resp_valid = 1'b1;
               is_config        = 1'b1;
 
-              unique case (acc_req_i.insn.itype.funct3)
+              unique case (instr.itype.funct3)
                 3'b001: begin // csrrw
                   // Decode the CSR.
-                  case (riscv::csr_addr_t'(acc_req_i.insn.itype.imm))
+                  case (riscv::csr_addr_t'(instr.itype.imm))
                     // Only vstart can be written with CSR instructions.
                     riscv::CSR_VSTART: begin
                       csr_vstart_d          = acc_req_i.rs1;
@@ -3375,24 +3383,24 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 end
                 3'b010: begin // csrrs
                   // Decode the CSR.
-                  case (riscv::csr_addr_t'(acc_req_i.insn.itype.imm))
+                  case (riscv::csr_addr_t'(instr.itype.imm))
                     riscv::CSR_VSTART: begin
                       csr_vstart_d          = csr_vstart_q | vlen_t'(acc_req_i.rs1);
                       acc_resp_o.result = csr_vstart_q;
                     end
                     riscv::CSR_VTYPE: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = xlen_vtype(csr_vtype_q);
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = xlen_vtype(csr_vtype_q);
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VL: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = csr_vl_q;
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = csr_vl_q;
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VLENB: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = VLENB;
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VXRM: begin
@@ -3413,24 +3421,24 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 end
                 3'b011: begin // csrrc
                   // Decode the CSR.
-                  case (riscv::csr_addr_t'(acc_req_i.insn.itype.imm))
+                  case (riscv::csr_addr_t'(instr.itype.imm))
                     riscv::CSR_VSTART: begin
                       csr_vstart_d          = csr_vstart_q & ~vlen_t'(acc_req_i.rs1);
                       acc_resp_o.result = csr_vstart_q;
                     end
                     riscv::CSR_VTYPE: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = xlen_vtype(csr_vtype_q);
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = xlen_vtype(csr_vtype_q);
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VL: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = csr_vl_q;
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = csr_vl_q;
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VLENB: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = VLENB;
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VXSAT: begin
@@ -3451,7 +3459,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 end
                 3'b101: begin // csrrwi
                   // Decode the CSR.
-                  case (riscv::csr_addr_t'(acc_req_i.insn.itype.imm))
+                  case (riscv::csr_addr_t'(instr.itype.imm))
                     // Only vstart can be written with CSR instructions.
                     riscv::CSR_VSTART: begin
                       csr_vstart_d          = vlen_t'(acc_req_i.rs1);
@@ -3476,24 +3484,24 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 end
                 3'b110: begin // csrrsi
                   // Decode the CSR.
-                  case (riscv::csr_addr_t'(acc_req_i.insn.itype.imm))
+                  case (riscv::csr_addr_t'(instr.itype.imm))
                     riscv::CSR_VSTART: begin
                       csr_vstart_d          = csr_vstart_q | vlen_t'(acc_req_i.rs1);
                       acc_resp_o.result = csr_vstart_q;
                     end
                     riscv::CSR_VTYPE: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = xlen_vtype(csr_vtype_q);
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = xlen_vtype(csr_vtype_q);
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VL: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = csr_vl_q;
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = csr_vl_q;
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VLENB: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = VLENB;
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VXSAT: begin
@@ -3517,24 +3525,24 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                 end
                 3'b111: begin // csrrci
                   // Decode the CSR.
-                  unique case (riscv::csr_addr_t'(acc_req_i.insn.itype.imm))
+                  unique case (riscv::csr_addr_t'(instr.itype.imm))
                     riscv::CSR_VSTART: begin
                       csr_vstart_d          = csr_vstart_q & ~vlen_t'(acc_req_i.rs1);
                       acc_resp_o.result = csr_vstart_q;
                     end
                     riscv::CSR_VTYPE: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = xlen_vtype(csr_vtype_q);
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = xlen_vtype(csr_vtype_q);
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VL: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = csr_vl_q;
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = csr_vl_q;
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VLENB: begin
                       // Only reads are allowed
-                      if (acc_req_i.insn.itype.rs1 == '0) acc_resp_o.result = VLENB;
+                      if (instr.itype.rs1 == '0) acc_resp_o.result = VLENB;
                       else illegal_insn = 1'b1;
                     end
                     riscv::CSR_VXSAT: begin
@@ -3558,7 +3566,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   // Trigger an illegal instruction
                   illegal_insn = 1'b1;
                 end
-              endcase // acc_req_i.insn.itype.funct3
+              endcase // instr.itype.funct3
             end
           end
 
@@ -3585,13 +3593,13 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         acc_resp_o.resp_valid      = 1'b1;
         acc_resp_o.exception.valid = 1'b1;
         acc_resp_o.exception.cause = riscv::ILLEGAL_INSTR;
-        acc_resp_o.exception.tval  = acc_req_i.insn;
+        acc_resp_o.exception.tval  = instr;
       end
 
       // Check if we need to reshuffle our vector registers involved in the operation
       // This operation is costly when occurs, so avoid it if possible
       if ( ara_req_valid && !acc_resp_o.exception.valid ) begin
-        automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
+        automatic rvv_instruction_t insn = rvv_instruction_t'(instr.instr);
 
         // Is the instruction an in-lane one and could it be subject to reshuffling?
         in_lane_op = ara_req.op inside {[VADD:VMERGE]} || ara_req.op inside {[VREDSUM:VMSBC]} ||
@@ -3634,7 +3642,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       // Reshuffle if at least one of the three registers needs a reshuffle
       if (|reshuffle_req_d) begin
         // Instruction is of one of the RVV types
-        automatic rvv_instruction_t insn = rvv_instruction_t'(acc_req_i.insn.instr);
+        automatic rvv_instruction_t insn = rvv_instruction_t'(instr.instr);
 
         // Stall the interface, and inject a reshuffling instruction
         acc_resp_o.req_ready  = 1'b0;
@@ -3716,7 +3724,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
     // * CSR operations are not considered vector instructions
     if ( acc_resp_o.resp_valid
           & !acc_resp_o.exception.valid
-          & (acc_req_i.insn.itype.opcode != riscv::OpcodeSystem)
+          & (instr.itype.opcode != riscv::OpcodeSystem)
         ) begin
       csr_vstart_d = '0;
     end

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -9,12 +9,13 @@
 
 module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::idx_width; #(
     // RVV Parameters
-    parameter  int unsigned NrLanes    = 1,          // Number of parallel vector lanes
-    parameter  int unsigned VLEN       = 0,
-    parameter  type         ara_req_t  = logic,
-    parameter  type         ara_resp_t = logic,
-    parameter  type         pe_req_t   = logic,
-    parameter  type         pe_resp_t  = logic,
+    parameter  int unsigned NrLanes     = 1,          // Number of parallel vector lanes
+    parameter  int unsigned VLEN        = 0,
+    parameter  type         ara_req_t   = logic,
+    parameter  type         ara_resp_t  = logic,
+    parameter  type         pe_req_t    = logic,
+    parameter  type         pe_resp_t   = logic,
+    parameter  type         exception_t = logic,
     // Dependant parameters. DO NOT CHANGE!
     // Ara has NrLanes + 3 processing elements: each one of the lanes, the vector load unit, the
     // vector store unit, the slide unit, and the mask unit.
@@ -46,7 +47,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     output logic                            pe_scalar_resp_ready_o,
     // Interface with the Address Generation
     input  logic                            addrgen_ack_i,
-    input  ariane_pkg::exception_t          addrgen_exception_i,
+    input  exception_t                      addrgen_exception_i,
     input  vlen_t                           addrgen_exception_vstart_i,
     input  logic                            addrgen_fof_exception_i,
     // Interface with the store unit

--- a/hardware/src/ara_system.sv
+++ b/hardware/src/ara_system.sv
@@ -20,6 +20,14 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
     parameter seg_support_e                     SegSupport         = SegSupportEnable,
     // Ariane configuration
     parameter config_pkg::cva6_cfg_t            CVA6Cfg            = cva6_config_pkg::cva6_cfg,
+    // CVA6-related parameters
+    parameter type                              exception_t        = logic,
+    parameter type                              accelerator_req_t  = logic,
+    parameter type                              accelerator_resp_t = logic,
+    parameter type                              acc_mmu_req_t      = logic,
+    parameter type                              acc_mmu_resp_t     = logic,
+    parameter type                              cva6_to_acc_t      = logic,
+    parameter type                              acc_to_cva6_t      = logic,
     // AXI Interface
     parameter int                      unsigned AxiAddrWidth       = 64,
     parameter int                      unsigned AxiIdWidth         = 6,
@@ -76,12 +84,9 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
   //  Ara and Ariane  //
   //////////////////////
 
-  import acc_pkg::cva6_to_acc_t;
-  import acc_pkg::acc_to_cva6_t;
-
   // Accelerator ports
-  cva6_to_acc_t                         acc_req;
-  acc_to_cva6_t                         acc_resp;
+  cva6_to_acc_t        acc_req;
+  acc_to_cva6_t        acc_resp;
   logic                                 acc_resp_valid;
   logic                                 acc_resp_ready;
   logic                                 acc_cons_en;
@@ -105,8 +110,10 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
 
 `ifdef IDEAL_DISPATCHER
   // Perfect dispatcher to Ara
-  accel_dispatcher_ideal #(
-    .CVA6Cfg          (CVA6Cfg               )
+  accel_dispatcher_ideal i_accel_dispatcher_ideal #(
+    .CVA6Cfg(CVA6Cfg),
+    .cva6_to_acc_t(cva6_to_acc_t),
+    .acc_to_cva6_t(acc_to_cva6_t)
   ) i_accel_dispatcher_ideal (
     .clk_i            (clk_i                 ),
     .rst_ni           (rst_ni                ),
@@ -115,16 +122,20 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
   );
 `else
   cva6 #(
-    .CVA6Cfg          (CVA6Cfg                    ),
-    .cvxif_req_t      (acc_pkg::cva6_to_acc_t     ),
-    .cvxif_resp_t     (acc_pkg::acc_to_cva6_t     ),
-    .axi_ar_chan_t    (ariane_axi_ar_t            ),
-    .axi_aw_chan_t    (ariane_axi_aw_t            ),
-    .axi_w_chan_t     (ariane_axi_w_t             ),
-    .b_chan_t         (ariane_axi_b_t             ),
-    .r_chan_t         (ariane_axi_r_t             ),
-    .noc_req_t        (ariane_axi_req_t           ),
-    .noc_resp_t       (ariane_axi_resp_t          )
+    .CVA6Cfg          (CVA6Cfg           ),
+    .cvxif_req_t      (cva6_to_acc_t     ),
+    .cvxif_resp_t     (acc_to_cva6_t     ),
+    .axi_ar_chan_t    (ariane_axi_ar_t   ),
+    .axi_aw_chan_t    (ariane_axi_aw_t   ),
+    .axi_w_chan_t     (ariane_axi_w_t    ),
+    .b_chan_t         (ariane_axi_b_t    ),
+    .r_chan_t         (ariane_axi_r_t    ),
+    .noc_req_t        (ariane_axi_req_t  ),
+    .noc_resp_t       (ariane_axi_resp_t ),
+    .accelerator_req_t (accelerator_req_t),
+    .accelerator_resp_t(accelerator_resp_t),
+    .acc_mmu_req_t     (acc_mmu_req_t),
+    .acc_mmu_resp_t    (acc_mmu_resp_t)
   ) i_ariane (
     .clk_i            (clk_i                   ),
     .rst_ni           (rst_ni                  ),
@@ -134,14 +145,14 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
     .ipi_i            ('0                      ),
     .time_irq_i       ('0                      ),
     .debug_req_i      ('0                      ),
-    .clic_irq_valid_i ('0                      ),
-    .clic_irq_id_i    ('0                      ),
-    .clic_irq_level_i ('0                      ),
-    .clic_irq_priv_i  (riscv::priv_lvl_t'(2'b0)),
-    .clic_irq_shv_i   ('0                      ),
-    .clic_irq_ready_o (/* empty */             ),
-    .clic_kill_req_i  ('0                      ),
-    .clic_kill_ack_o  (/* empty */             ),
+//    .clic_irq_valid_i ('0                      ),
+//    .clic_irq_id_i    ('0                      ),
+//    .clic_irq_level_i ('0                      ),
+//    .clic_irq_priv_i  (riscv::priv_lvl_t'(2'b0)),
+//    .clic_irq_shv_i   ('0                      ),
+//    .clic_irq_ready_o (/* empty */             ),
+//    .clic_kill_req_i  ('0                      ),
+//    .clic_kill_ack_o  (/* empty */             ),
     .rvfi_probes_o    (/* empty */             ),
     // Accelerator ports
     .cvxif_req_o      (acc_req                 ),
@@ -184,7 +195,7 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
   axi_inval_filter #(
     .MaxTxns    (4                              ),
     .AddrWidth  (AxiAddrWidth                   ),
-    .L1LineWidth(ariane_pkg::DCACHE_LINE_WIDTH/8),
+    .L1LineWidth(CVA6Cfg.DCACHE_LINE_WIDTH/8    ),
     .aw_chan_t  (ara_axi_aw_t                   ),
     .req_t      (ara_axi_req_t                  ),
     .resp_t     (ara_axi_resp_t                 )
@@ -210,22 +221,30 @@ module ara_system import axi_pkg::*; import ara_pkg::*; #(
   );
 
   ara #(
-    .NrLanes     (NrLanes         ),
-    .VLEN        (VLEN            ),
-    .OSSupport   (OSSupport       ),
-    .FPUSupport  (FPUSupport      ),
-    .FPExtSupport(FPExtSupport    ),
-    .FixPtSupport(FixPtSupport    ),
-    .SegSupport  (SegSupport      ),
-    .AxiDataWidth(AxiWideDataWidth),
-    .AxiAddrWidth(AxiAddrWidth    ),
-    .axi_ar_t    (ara_axi_ar_t    ),
-    .axi_r_t     (ara_axi_r_t     ),
-    .axi_aw_t    (ara_axi_aw_t    ),
-    .axi_w_t     (ara_axi_w_t     ),
-    .axi_b_t     (ara_axi_b_t     ),
-    .axi_req_t   (ara_axi_req_t   ),
-    .axi_resp_t  (ara_axi_resp_t  )
+    .NrLanes           (NrLanes           ),
+    .VLEN              (VLEN              ),
+    .OSSupport         (OSSupport         ),
+    .FPUSupport        (FPUSupport        ),
+    .FPExtSupport      (FPExtSupport      ),
+    .FixPtSupport      (FixPtSupport      ),
+    .SegSupport        (SegSupport        ),
+    .CVA6Cfg           (CVA6Cfg           ),
+    .exception_t       (exception_t       ),
+    .accelerator_req_t (accelerator_req_t ),
+    .accelerator_resp_t(accelerator_resp_t),
+    .acc_mmu_req_t     (acc_mmu_req_t     ),
+    .acc_mmu_resp_t    (acc_mmu_resp_t    ),
+    .cva6_to_acc_t     (cva6_to_acc_t     ),
+    .acc_to_cva6_t     (acc_to_cva6_t     ),
+    .AxiDataWidth      (AxiWideDataWidth  ),
+    .AxiAddrWidth      (AxiAddrWidth      ),
+    .axi_ar_t          (ara_axi_ar_t      ),
+    .axi_r_t           (ara_axi_r_t       ),
+    .axi_aw_t          (ara_axi_aw_t      ),
+    .axi_w_t           (ara_axi_w_t       ),
+    .axi_b_t           (ara_axi_b_t       ),
+    .axi_req_t         (ara_axi_req_t     ),
+    .axi_resp_t        (ara_axi_resp_t    )
   ) i_ara (
     .clk_i           (clk_i         ),
     .rst_ni          (rst_ni        ),

--- a/hardware/src/cva6_accel_first_pass_decoder.sv
+++ b/hardware/src/cva6_accel_first_pass_decoder.sv
@@ -7,7 +7,10 @@
 //              instruction, whether it reads scalar registers, and whether
 //              it writes to a destination scalar register
 
-module cva6_accel_first_pass_decoder import rvv_pkg::*; import ariane_pkg::*; (
+module cva6_accel_first_pass_decoder import rvv_pkg::*; import ariane_pkg::*; #(
+    parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
+    parameter type scoreboard_entry_t = logic
+  ) (
     input  logic [31:0]       instruction_i,   // instruction from IF
     input  riscv::xs_t        fs_i,            // floating point extension status
     input  riscv::xs_t        vs_i,            // vector extension status
@@ -154,7 +157,7 @@ module cva6_accel_first_pass_decoder import rvv_pkg::*; import ariane_pkg::*; (
       illegal_instr_o = (is_vfp && (fs_i == riscv::Off)) ? 1'b1 : 1'b0;
 
       // result holds the undecoded instruction
-      instruction_o.result = { {riscv::XLEN-32{1'b0}}, instruction_i[31:0] };
+      instruction_o.result = { {CVA6Cfg.XLEN-32{1'b0}}, instruction_i[31:0] };
       instruction_o.use_imm = 1'b0;
     end
   end

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -868,6 +868,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     // Don't compress classify result
     localparam int unsigned TrueSIMDClass  = 1;
     localparam int unsigned EnableSIMDMask = 1;
+    localparam fpnew_pkg::divsqrt_unit_t DivSqrtSel = fpnew_pkg::PULP;
 
     operation_e fp_op;
     logic fp_opmod;
@@ -1083,6 +1084,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
     fpnew_top #(
       .Features      (FPUFeatures      ),
       .Implementation(FPUImplementation),
+      .DivSqrtSel    (DivSqrtSel       ),
       .TagType       (strb_t           ),
       .TrueSIMDClass (TrueSIMDClass    ),
       .EnableSIMDMask(EnableSIMDMask   )

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -1613,6 +1613,11 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
             narrowing_shuffled_result[15:8]  = unit_out_result[7:0];
             narrowing_shuffled_result[7:0]   = unit_out_result[7:0];
             narrowing_shuffle_be             = !narrowing_select_out_q ? 8'b01010101 : 8'b10101010;
+          end else begin
+            // Default assignment
+            narrowing_shuffled_result[63:32] = unit_out_result[31:0];
+            narrowing_shuffled_result[31:0]  = unit_out_result[31:0];
+            narrowing_shuffle_be             = !narrowing_select_out_q ? 8'b00110011 : 8'b11001100;
           end
           EW16: begin
             narrowing_shuffled_result[63:48] = unit_out_result[31:16];

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -17,6 +17,9 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     parameter type          axi_aw_t     = logic,
     parameter  type         pe_req_t     = logic,
     parameter  type         pe_resp_t    = logic,
+    // CVA6 configuration
+    parameter  config_pkg::cva6_cfg_t CVA6Cfg = cva6_config_pkg::cva6_cfg,
+    parameter  type         exception_t  = logic,
     // Dependant parameters. DO NOT CHANGE!
     localparam type         axi_addr_t   = logic [AxiAddrWidth-1:0],
     localparam type         vlen_t       = logic[$clog2(VLEN+1)-1:0]
@@ -36,23 +39,23 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     // This is everything the MMU can provide, it might be overcomplete for Ara and some signals be useless
     output logic                           mmu_misaligned_ex_o,
     output logic                           mmu_req_o,        // request address translation
-    output logic [riscv::VLEN-1:0]         mmu_vaddr_o,      // virtual address out
+    output logic [CVA6Cfg.VLEN-1:0]        mmu_vaddr_o,      // virtual address out
     output logic                           mmu_is_store_o,   // the translation is requested by a store
     // if we need to walk the page table we can't grant in the same cycle
     // Cycle 0
     input logic                            mmu_dtlb_hit_i,   // sent in the same cycle as the request if translation hits in the DTLB
-    input logic [riscv::PPNW-1:0]          mmu_dtlb_ppn_i,   // ppn (send same cycle as hit)
+    input logic [CVA6Cfg.PPNW-1:0]         mmu_dtlb_ppn_i,   // ppn (send same cycle as hit)
     // Cycle 1
     input  logic                           mmu_valid_i,      // translation is valid
-    input  logic [riscv::PLEN-1:0]         mmu_paddr_i,      // translated address
-    input  ariane_pkg::exception_t         mmu_exception_i,  // address translation threw an exception
+    input  logic [CVA6Cfg.PLEN-1:0]        mmu_paddr_i,      // translated address
+    input  exception_t                     mmu_exception_i,  // address translation threw an exception
     // Interace with the dispatcher
     input  logic                           core_st_pending_i,
     // Interface with the main sequencer
     input  pe_req_t                        pe_req_i,
     input  logic                           pe_req_valid_i,
     input  logic     [NrVInsn-1:0]         pe_vinsn_running_i,
-    output ariane_pkg::exception_t         addrgen_exception_o,
+    output exception_t                     addrgen_exception_o,
     output logic                           addrgen_ack_o,
     output vlen_t                          addrgen_exception_vstart_o,
     output logic                           addrgen_fof_exception_o, // fault-only-first
@@ -201,7 +204,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
   //////////////////////////
   //  Address generation  //
   //////////////////////////
-  ariane_pkg::exception_t mmu_exception_d, mmu_exception_q;
+  exception_t mmu_exception_d, mmu_exception_q;
   logic mmu_req_d;
   logic last_translation_completed;
   logic addrgen_fof_exception_d, addrgen_fof_exception_q;
@@ -343,7 +346,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
 
       ADDRGEN: begin
         // NOTE: indexed are not covered here
-        automatic logic [riscv::VLEN-1:0] vaddr_start;
+        automatic logic [CVA6Cfg.VLEN-1:0] vaddr_start;
 
         case (pe_req_q.op)
           // Unit-stride: address = base + (vstart in elements)
@@ -832,7 +835,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
         if (axi_addrgen_queue_empty || (axi_addrgen_req_o.is_load && axi_addrgen_q.is_load) ||
              (~axi_addrgen_req_o.is_load && ~axi_addrgen_q.is_load)) begin : axi_ax_idle
           if (!axi_addrgen_queue_full && axi_ax_ready) begin : start_req
-            automatic logic [riscv::PLEN-1:0] paddr;
+            automatic logic [CVA6Cfg.PLEN-1:0] paddr;
 
             // Mux target address
             paddr = (en_ld_st_translation_i) ? mmu_paddr_i : axi_addrgen_q.addr;
@@ -953,7 +956,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
             else begin : indexed_data
               // NOTE: address translation is not yet been implemented/tested for indexed
 
-              automatic logic [riscv::PLEN-1:0] idx_final_paddr;
+              automatic logic [CVA6Cfg.PLEN-1:0] idx_final_paddr;
               //////////////////////
               //  Indexed access  //
               //////////////////////
@@ -1055,7 +1058,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
                 axi_addrgen_d.addr = next_addr_strided_temp;
               end : strided
               else begin : indexed // INDEXED ACCESS
-                automatic logic [riscv::PLEN-1:0] idx_final_paddr;
+                automatic logic [CVA6Cfg.PLEN-1:0] idx_final_paddr;
                 // TODO: check if idx_vaddr_valid_q is stable
                 if (idx_vaddr_valid_q) begin : if_idx_vaddr_valid_q
 

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -671,7 +671,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
   endfunction
 
   // Mute MMU request if we are receiving a valid response this cycle
-  assign mmu_req_o = mmu_req_d & ~mmu_valid_i & ~mmu_exception_i.valid;
+  assign mmu_req_o = mmu_req_d & ~mmu_valid_i;
 
   always_comb begin: axi_addrgen
     // Maintain state


### PR DESCRIPTION
Bump CVA6 to `pulp-v2`. 

Todos:
 - [x] Verify Linux Boot
 - [x] Verify PPA
 - [x] Switch back to `pulp-platform`'s CVA6 and FPU

## Changelog

### Changed

- Bump CVA6 to `pulp-v2`
- Re-parametrize the design with parameters from CVA6 `pulp-v2`
- Bump AXI version to a working one

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
