### PR TITLE
[HW] Iteration_cnt_d should update when result_queue not full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Bump upload and delete artifact actions
  - Fix synthesis-unfriendly constructs
  - Fix vector slicing bug in operand requesters
+ - Fix the iteration_cnt_d update even when result_queue is full
 
 ### Added
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -358,7 +358,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
 
   // iteration count for masked instrctions
   always_comb begin
-    if (vinsn_issue_valid && (&masku_operand_alu_valid || &masku_operand_vs2_seq_valid)) begin
+    if (vinsn_issue_valid && (&masku_operand_alu_valid || &masku_operand_vs2_seq_valid) && !result_queue_full) begin
       iteration_count_d = iteration_count_q + 1'b1;
     end else begin
       iteration_count_d = iteration_count_q;


### PR DESCRIPTION
Description of PR that completes issue here...

## Changelog

### Fixed

- iteration_cnt_d should update only when result_queue is not full, or the result for vid operation will miss since the queue is not ready. 

### Added

- Description of changes

### Changed

- Description of changes

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
