### PR TITLE
[HW] Optimize timing-critical address calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Refactor the MASKU
  - The MASKU always receives balanced payloads from the lanes
  - Remove FPU support for opqueues that do not need it
+ - Pre-calculate timing-critical addresses before addrgen stage
 
 ## 3.0.0 - 2023-09-08
 

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -295,9 +295,9 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
         && !result_queue_full) begin : axi_r_beat_read
       // Bytes valid in the current R beat
       // If non-unit strided load, we do not progress within the beat
-      automatic shortint unsigned lower_byte = beat_lower_byte(axi_addrgen_req_i.addr,
+      automatic logic [idx_width(AxiDataWidth/8)-1:0] lower_byte = beat_lower_byte(axi_addrgen_req_i.addr,
         axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, axi_len_q);
-      automatic shortint unsigned upper_byte = beat_upper_byte(axi_addrgen_req_i.addr,
+      automatic logic [idx_width(AxiDataWidth/8)-1:0] upper_byte = beat_upper_byte(axi_addrgen_req_i.addr,
         axi_addrgen_req_i.size, axi_addrgen_req_i.len, BURST_INCR, AxiDataWidth/8, axi_len_q);
 
       // Is there a vector instruction ready to be issued?


### PR DESCRIPTION
Optimize `addrgen` stage for better timing.

## Changelog

### Changed

- Pre-calculate some critical addresses to ease timing

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed