### PR TITLE
[HW] Fixes for the dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix vector slicing bug in operand requesters
  - Fix legality check for allowed registers in dispatcher
  - Remove a couple of latches
+ - Fix dispatcher state change upon vector CSR instruction
+ - Force a reshuffle when `vl == vlmax && vstart > 0`
 
 ### Added
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -3522,7 +3522,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
         // During a vstore, if vstart > 0, reshuffle immediately not to complicate operand fetch stage
         reshuffle_req_d = {ara_req.use_vs1 && (ara_req.eew_vs1    != eew_q[ara_req.vs1]) && eew_valid_q[ara_req.vs1] && (in_lane_op || (is_vstore && (csr_vstart_q != '0))),
                            ara_req.use_vs2 && (ara_req.eew_vs2    != eew_q[ara_req.vs2]) && eew_valid_q[ara_req.vs2] && in_lane_op,
-                           ara_req.use_vd  && (ara_req.vtype.vsew != eew_q[ara_req.vd ]) && eew_valid_q[ara_req.vd ] && csr_vl_q != ((VLENB << ara_req.emul[1:0]) >> ara_req.vtype.vsew)};
+                           ara_req.use_vd  && (ara_req.vtype.vsew != eew_q[ara_req.vd ]) && eew_valid_q[ara_req.vd ] && !(csr_vstart_q == 0 && (csr_vl_q == ((VLENB << ara_req.emul[1:0]) >> ara_req.vtype.vsew)))};
         // Mask out requests if they refer to the same register!
         reshuffle_req_d &= {
           (insn.varith_type.rs1 != insn.varith_type.rs2) && (insn.varith_type.rs1 != insn.varith_type.rd),

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -3260,7 +3260,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
             //       E.g., CSRs vxrm and vxsat have no influence on-non fixed-point instructions, it could be read and written safely when no fixed-point operation is running.
             //       By better analyzing the spec, more of optimizations of such can be made. For the sake of simplicity, the current implementation treats CSR ops as one block.
             // Just always go to WAIT_IDLE for at least one cycle (if there is a vinsn before the CSR one, it can be that ara_idle_i is still deasserted when the CSR is here).
-            if (!state_qq != WAIT_IDLE) begin
+            if (state_qq != WAIT_IDLE) begin
               state_d = WAIT_IDLE;
               acc_resp_o.req_ready = 1'b0;
             end else begin


### PR DESCRIPTION
Generic round of fixes.

## Changelog

### Fixed

 - Fix dispatcher state change upon vector CSR instruction
 - Force a reshuffle when `vl == vlmax && vstart > 0`

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed