### PR TITLE
[HW] Fix flushing upon load-related exceptions

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -6,16 +6,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build HTML
       uses: ammaraskar/sphinx-action@master
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: html-docs
         path: docs/build/html/
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Solve type-conversion warnings about type  - Indexed loads need to wait for operand requesters ready in sequencer
  - Drop sequencer `pe_req_valid` in case of exception
  - Reworked STU exception flush engine
+ - Correctly flush the backend pipeline upon indexed load exceptions
+ - Make addrgen wait for index address before making an MMU request
+ - Fix typos in lane sequencer
 
 ### Added
 

--- a/cheshire/sw/include/rvv_test.h
+++ b/cheshire/sw/include/rvv_test.h
@@ -24,21 +24,29 @@
 #define _VSETVLI(vl,avl)          _VSETVLI_64(vl, avl)
 #define _VLD(vreg,address_load)  __VLD(vreg,64,address_load)
 #define _VST(vreg,address_store) __VST(vreg,64,address_store)
+#define _VLD_IDX(vd,vs2,address_load)  __VLD_IDX(vd,vs2,64,address_load)
+#define _VST_IDX(vs1,vs2,address_store) __VST_IDX(vs1,vs2,64,address_store)
 #elif EEW == 32
 #define _DTYPE                   __DTYPE(32)
 #define _VSETVLI(vl,avl)          _VSETVLI_32(vl, avl)
 #define _VLD(vreg,address_load)  __VLD(vreg,32,address_load)
 #define _VST(vreg,address_store) __VST(vreg,32,address_store)
+#define _VLD_IDX(vd,vs2,address_load)  __VLD_IDX(vd,vs2,32,address_load)
+#define _VST_IDX(vs1,vs2,address_store) __VST_IDX(vs1,vs2,32,address_store)
 #elif EEW == 16
 #define _DTYPE                   __DTYPE(16)
 #define _VSETVLI(vl,avl)          _VSETVLI_16(vl, avl)
 #define _VLD(vreg,address_load)  __VLD(vreg,16,address_load)
 #define _VST(vreg,address_store) __VST(vreg,16,address_store)
+#define _VLD_IDX(vd,vs2,address_load)  __VLD_IDX(vd,vs2,16,address_load)
+#define _VST_IDX(vs1,vs2,address_store) __VST_IDX(vs1,vs2,16,address_store)
 #elif EEW == 8
 #define _DTYPE                   __DTYPE(8)
 #define _VSETVLI(vl,avl)          _VSETVLI_8(vl, avl)
 #define _VLD(vreg,address_load)  __VLD(vreg,8,address_load)
 #define _VST(vreg,address_store) __VST(vreg,8,address_store)
+#define _VLD_IDX(vd,vs2,address_load)  __VLD_IDX(vd,vs2,8,address_load)
+#define _VST_IDX(vs1,vs2,address_store) __VST_IDX(vs1,vs2,8,address_store)
 #else
 #error "ERROR: No EEW was defined. Please specify one in [8,16,32,64]."
 #endif
@@ -49,6 +57,8 @@
 #define __DTYPE(eew)                  uint##eew##_t
 #define __VLD(vreg,eew,address_load)  asm volatile ("vle"#eew".v "#vreg", (%0)"  : "+&r"(address_load));
 #define __VST(vreg,eew,address_store) asm volatile ("vse"#eew".v "#vreg", (%0)"  : "+&r"(address_store));
+#define __VLD_IDX(vd,vs2,eew,address_load)  asm volatile ("vluxei"#eew".v "#vd", (%0), "#vs2 : "+&r"(address_load));
+#define __VST_IDX(vs1,vs2,eew,address_store) asm volatile ("vsuxei"#eew".v "#vs1", (%0), "#vs2 : "+&r"(address_store));
 
 ///////////////////////
 // Reshuffle helpers //

--- a/cheshire/sw/include/rvv_test.h
+++ b/cheshire/sw/include/rvv_test.h
@@ -182,11 +182,14 @@ volatile uint64_t ret_cnt;
   #define RVV_TEST_AVL(EEW) (VLMAX / (EEW))
 #endif
 
+#ifndef _ENABLE_RVV_
+#define _ENABLE_RVV_
 void enable_rvv() {
   // Enalbe RVV by seting MSTATUS.VS
   asm volatile (" li      t0, %0       " :: "i"(MSTATUS_VS));
   asm volatile (" csrs    mstatus, t0" );
 }
+#endif
 
 uint64_t reset_v_state ( uint64_t avl ) {
     uint64_t vl_local = 0;

--- a/cheshire/sw/include/vector_util.h
+++ b/cheshire/sw/include/vector_util.h
@@ -33,10 +33,13 @@ void stop_timer() { timer += get_cycle_count(); }
 // Get the value of the timer
 int64_t get_timer() { return timer; }
 
+#ifndef _ENABLE_RVV_
+#define _ENABLE_RVV_
 inline void enable_rvv() {
   asm volatile ("li t0, %0" :: "i"(MSTATUS_VS));
   asm volatile ("csrs mstatus, t0" );
 }
+#endif
 
 inline int similarity_check(double a, double b, double threshold) {
   double diff = a - b;

--- a/cheshire/sw/src/tests/body/rvv_test_mmu_stub_idx_ld_comprehensive.c.body
+++ b/cheshire/sw/src/tests/body/rvv_test_mmu_stub_idx_ld_comprehensive.c.body
@@ -1,0 +1,303 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Matteo Perotti  <mperotti@iis.ee.ethz.ch>
+// Vincenzo Maisto <vincenzo.maisto2@unina.it>
+
+#include "regs/cheshire.h"
+#include "dif/clint.h"
+#include "dif/uart.h"
+#include "params.h"
+#include "util.h"
+#include "encoding.h"
+#include "rvv_test.h"
+
+#include "cheshire_util.h"
+
+#if (EXTENSIVE_TEST == 1)
+#define VL_LIMIT_LOW      ELMMAX + 1
+#define VL_LIMIT_HIGH     0
+#define VSTART_LIMIT_LOW  vl + 1
+#define VSTART_LIMIT_HIGH 0
+#else
+#define VL_LIMIT_LOW      3*ARA_NR_LANES + 1
+#define VL_LIMIT_HIGH     ELMMAX - (3*ARA_NR_LANES + 1)
+#define VSTART_LIMIT_LOW  2*ARA_NR_LANES + 1
+#define VSTART_LIMIT_HIGH vl - 2*ARA_NR_LANES - 1
+#endif
+
+#define INIT_NONZERO_VAL_V0 99
+#define INIT_NONZERO_VAL_V8 67
+
+// Derived parameters
+#define param_stub_ex { param_stub_ex_ctrl ? 1 : 0; }
+
+uint64_t stub_req_rsp_lat = param_stub_req_rsp_lat;
+
+_DTYPE* start_addr_vec [ELMMAX];
+
+int main(void) {
+    cheshire_start();
+
+    // Clean the exception variable
+    RVV_TEST_CLEAN_EXCEPTION();
+
+    // This initialization is controlled through "defines" in the various
+    // derived tests.
+    INIT_RVV_TEST_SOC_REGFILE;
+    VIRTUAL_MEMORY_ON;
+    STUB_EX_ON;
+
+    // Vector configuration parameters and variables
+    uint64_t avl_original = RVV_TEST_AVL(64);
+    uint64_t vl, vstart_read;
+    vcsr_dump_t vcsr_state = {0};
+
+    // Helper variables and arrays
+    _DTYPE array_load [ELMMAX];
+    _DTYPE array_load_rev [ELMMAX];
+    _DTYPE array_load_idx [ELMMAX];
+    _DTYPE array_store_0 [ELMMAX];
+    _DTYPE array_store_1 [ELMMAX];
+    _DTYPE* address_load = array_load;
+    _DTYPE* address_load_rev = array_load_rev;
+    _DTYPE* address_load_idx = array_load_idx;
+    _DTYPE* address_store_0 = array_store_0;
+    _DTYPE* address_store_1 = array_store_1;
+
+    // Enalbe RVV
+    enable_rvv();
+    vcsr_dump ( vcsr_state );
+
+    //////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////
+    // START OF TESTS
+    //////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////
+
+    //////////////////////////////////////////////////////////////////
+    // TEST: Exception generation and non-zero vstart: vector store
+    //////////////////////////////////////////////////////////////////
+
+    // Loop through different avl, from 0 to avlmax
+    for (uint64_t avl = 1; (avl <= VL_LIMIT_LOW || avl >= VL_LIMIT_HIGH) && avl <= ELMMAX + 1; avl++) {
+      // Reset vl, vstart, reset exceptions.
+      RVV_TEST_INIT(vl, avl);
+
+      // Loop over vstart values. Also test vstart > vl.
+      for (uint64_t vstart_val = 0; (vstart_val <= VSTART_LIMIT_LOW || vstart_val >= VSTART_LIMIT_HIGH) && vstart_val < vl; vstart_val++) {
+        // Reset vl, vstart, reset exceptions.
+        RVV_TEST_INIT(vl, avl);
+
+        // Decide latency for next STUB req-rsp
+        switch (param_stub_req_rsp_lat_ctrl) {
+          // Fixed STUB req-rsp latency
+          case 0:
+            STUB_REQ_RSP_LAT(stub_req_rsp_lat);
+          break;
+          // Random STUB req-rsp latency (minimum value should be 1)
+          case 1:
+            STUB_REQ_RSP_LAT((stub_req_rsp_lat++ % MAX_LAT_P2) + 1);
+          break;
+          default:
+            cheshire_end();
+            return RET_CODE_WRONG_CASE;
+        }
+
+        // Init memory
+        for (uint64_t i = 0; i < vl; i++) {
+          address_store_0[i] = INIT_NONZERO_VAL_ST;
+          address_store_1[i] = INIT_NONZERO_VAL_ST;
+        }
+        for (uint64_t i = 0; i < vl; i++) {
+          address_load[i] = vl + vstart_val + i + MAGIC_NUM;
+        }
+        for (uint64_t i = 0; i < vl; i++) {
+          address_load_rev[vl-1-i] = vl + vstart_val + i + MAGIC_NUM;
+        }
+        for (uint64_t i = 0; i < vl; i++) {
+          // The idx vector is a byte vector
+          address_load_idx[i] = (vl-1-i) * (EEW/8);
+        }
+        // Init VRF (use v0)
+        asm volatile("vmv.v.x v0, %0" :: "r" (INIT_NONZERO_VAL_V0));
+        asm volatile("vmv.v.x v8, %0" :: "r" (INIT_NONZERO_VAL_V8));
+
+        // Get information about the next axi transfer
+        unsigned int addrgen_req = vl - vstart_val;
+        addrgen_req = vl - vstart_val;
+        for (int i = 0; i < vl; i++)
+          start_addr_vec[i] = address_load + (vl-1-i);
+
+        // Load the index vector
+        STUB_EX_OFF;
+        _VLD(v24,address_load_idx)
+        STUB_EX_ON;
+
+        // Setup STUB behavior
+        uint64_t ex_lat;
+        switch (param_stub_ex_ctrl) {
+          // No exceptions
+          case 0:
+            ex_lat = addrgen_req;
+            STUB_EX_OFF;
+          break;
+          // Always exceptions at every request
+          case 1:
+            ex_lat = 0;
+            STUB_EX_ON;
+            STUB_NO_EX_LAT(ex_lat);
+          break;
+          // Random exceptions
+          case 2:
+            // If ex_lat == axi_log->bursts, no exception for this transaction!
+            ex_lat = pseudo_rand(addrgen_req);
+            STUB_EX_ON;
+            STUB_NO_EX_LAT(ex_lat);
+          break;
+          default:
+            cheshire_end();
+            return RET_CODE_WRONG_CASE;
+        }
+
+        *rf_rvv_debug_reg = vl;
+        *rf_rvv_debug_reg = vstart_val;
+        *rf_rvv_debug_reg = ex_lat;
+        *rf_rvv_debug_reg = start_addr_vec[vstart_val + ex_lat];
+
+        // Setup vstart
+        asm volatile("csrs vstart, %0" :: "r"(vstart_val));
+
+        // Load indexed
+        _VLD_IDX(v0,v24,address_load)
+
+        // Get information about the next vstart
+        uint64_t vstart_post_ex = vstart_val + ex_lat;
+
+        *rf_rvv_debug_reg = 0x44444444;
+
+        // Check for illegal new vstart values
+        RVV_TEST_ASSERT(vstart_post_ex >= vstart_val && (vstart_post_ex < vl || (ex_lat == addrgen_req && vstart_post_ex == vl)))
+
+        *rf_rvv_debug_reg = 0x55555555;
+
+        // Check if we had an exception on this transaction
+        if (param_stub_ex_ctrl == 1 || (param_stub_ex_ctrl == 2 && ex_lat < addrgen_req)) {
+          // Check that the new vstart is correct
+          vstart_read = -1;
+          asm volatile("csrr %0, vstart" : "=r"(vstart_read));
+          ASSERT_EQ(vstart_read, vstart_post_ex)
+          *rf_rvv_debug_reg = 0x66666666;
+          // Check the exception
+          RVV_TEST_ASSERT_EXCEPTION_EXTENDED(1, start_addr_vec[vstart_val + ex_lat], CAUSE_LOAD_PAGE_FAULT)
+          RVV_TEST_CLEAN_EXCEPTION()
+
+          // Restart the instruction on another reg, or just load everything in v8 too.
+          // Then, store everything from v8
+          STUB_EX_OFF;
+          _VLD_IDX(v8, v24, address_load)
+          _VST(v8, address_store_1)
+          STUB_EX_ON;
+
+          *rf_rvv_debug_reg = 0xffffffff;
+
+          // Pre-body check v8
+          for (uint64_t i = 0; i < vstart_val; i++) {
+            ASSERT_EQ(address_store_1[i], INIT_NONZERO_VAL_V8)
+          }
+
+          *rf_rvv_debug_reg = 0xeeeeeeee;
+
+          // Body check 0
+          for (uint64_t i = vstart_val; i < vstart_post_ex; i++) {
+            *rf_rvv_debug_reg = i;
+            *rf_rvv_debug_reg = address_store_1[i];
+            *rf_rvv_debug_reg = INIT_NONZERO_VAL_V8;
+            ASSERT_EQ(address_store_1[i], INIT_NONZERO_VAL_V8)
+          }
+
+          *rf_rvv_debug_reg = 0xdddddddd;
+
+          // Body check 1
+          for (uint64_t i = vstart_post_ex; i < vl; i++) {
+            ASSERT_EQ(address_store_1[i], address_load_rev[i])
+          }
+
+          *rf_rvv_debug_reg = 0xcccccccc;
+        }
+
+        // Check that vstart was reset at zero
+        vstart_read = -1;
+
+        *rf_rvv_debug_reg = 0xbbbbbbbb;
+
+        asm volatile("csrr %0, vstart" : "=r"(vstart_read));
+        ASSERT_EQ(vstart_read, 0)
+        // Check that there was no exception
+        RVV_TEST_ASSERT_EXCEPTION(0)
+        RVV_TEST_CLEAN_EXCEPTION()
+
+        *rf_rvv_debug_reg = 0xaaaaaaaa;
+
+        // Store back the values of v0
+        STUB_EX_OFF;
+        _VST(v0, address_store_0)
+        STUB_EX_ON;
+
+        // Pre-body check v0
+        for (uint64_t i = 0; i < vstart_val; i++) {
+          ASSERT_EQ(address_store_0[i], INIT_NONZERO_VAL_V0)
+        }
+
+        *rf_rvv_debug_reg = 0x99999999;
+
+        // Body check 0
+        for (uint64_t i = vstart_val; i < vstart_post_ex; i++) {
+          ASSERT_EQ(address_store_0[i], address_load_rev[i])
+        }
+
+        *rf_rvv_debug_reg = 0x88888888;
+
+        // Body check 1
+        for (uint64_t i = vstart_post_ex; i < vl; i++) {
+          ASSERT_EQ(address_store_0[i], INIT_NONZERO_VAL_V0)
+        }
+
+        *rf_rvv_debug_reg = 0x77777777;
+
+        // Clean-up
+        RVV_TEST_CLEANUP();
+
+        // Jump from limit low to limit high if limit high is higher than low
+        if ((VSTART_LIMIT_LOW) < (VSTART_LIMIT_HIGH))
+          if (vstart_val == VSTART_LIMIT_LOW)
+            vstart_val = VSTART_LIMIT_HIGH;
+
+        ret_cnt++;
+      }
+
+      // Jump from limit low to limit high if limit high is higher than low
+      if ((VL_LIMIT_LOW) < (VL_LIMIT_HIGH))
+        if (avl == VL_LIMIT_LOW)
+          avl = VL_LIMIT_HIGH;
+    }
+
+    // Clean-up the SoC CSRs
+    RESET_SOC_CSR;
+
+    //////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////
+    // END OF TESTS
+    //////////////////////////////////////////////////////////////////
+    //////////////////////////////////////////////////////////////////
+
+#if (PRINTF == 1)
+    printf("Test SUCCESS!\r\n");
+#endif
+
+    cheshire_end();
+
+    // If we did not return before, the test passed
+    return RET_CODE_SUCCESS;
+}

--- a/cheshire/sw/src/tests/rvv_test_mmu_stub_idx_ld_comprehensive_page_fault_var_lat_var_ex.c
+++ b/cheshire/sw/src/tests/rvv_test_mmu_stub_idx_ld_comprehensive_page_fault_var_lat_var_ex.c
@@ -1,0 +1,16 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Matteo Perotti  <mperotti@iis.ee.ethz.ch>
+// Vincenzo Maisto <vincenzo.maisto2@unina.it>
+
+// Tunable parameters
+// param_stub_ex_ctrl. 0: no exceptions, 1: always exceptions, 2: random exceptions
+#define param_stub_ex_ctrl 2
+
+// param_stub_req_rsp_lat_ctrl. 0: fixed latency (== param_stub_req_rsp_lat), 1: random latency (max == param_stub_req_rsp_lat)
+#define param_stub_req_rsp_lat_ctrl 1
+#define param_stub_req_rsp_lat      10
+
+#include "rvv_test_mmu_stub_idx_ld_comprehensive.c.body"

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -185,8 +185,8 @@ module ara import ara_pkg::*; #(
   logic      [NrLanes-1:0]      vxsat_flag;
   vxrm_t     [NrLanes-1:0]      alu_vxrm;
   // Flush support for store exceptions
-  logic stu_ex_flush_lane, stu_ex_flush_done;
-  logic [NrLanes-1:0] stu_ex_flush_stu;
+  logic lsu_ex_flush_lane, lsu_ex_flush_done;
+  logic [NrLanes-1:0] lsu_ex_flush_stu;
 
   ara_dispatcher #(
     .NrLanes   (NrLanes   ),
@@ -214,8 +214,8 @@ module ara import ara_pkg::*; #(
     .fflags_ex_i       (fflags_ex       ),
     .fflags_ex_valid_i (fflags_ex_valid ),
     // Flush support
-    .stu_ex_flush_o     (stu_ex_flush_lane),
-    .stu_ex_flush_done_i(stu_ex_flush_done),
+    .lsu_ex_flush_o     (lsu_ex_flush_lane),
+    .lsu_ex_flush_done_i(lsu_ex_flush_done),
     // Interface with the Vector Store Unit
     .core_st_pending_o (core_st_pending ),
     .load_complete_i   (load_complete   ),
@@ -238,7 +238,7 @@ module ara import ara_pkg::*; #(
   ariane_pkg::exception_t          addrgen_exception;
   vlen_t                           addrgen_exception_vstart;
   logic                            addrgen_fof_exception;
-  logic                            stu_current_burst_exception;
+  logic                            lsu_current_burst_exception;
   logic              [NrLanes-1:0] alu_vinsn_done;
   logic              [NrLanes-1:0] mfpu_vinsn_done;
   // Interface with the operand requesters
@@ -295,7 +295,7 @@ module ara import ara_pkg::*; #(
     .addrgen_exception_i   (addrgen_exception        ),
     .addrgen_exception_vstart_i(addrgen_exception_vstart),
     .addrgen_fof_exception_i(addrgen_fof_exception),
-    .stu_current_burst_exception_i(stu_current_burst_exception)
+    .lsu_current_burst_exception_i(lsu_current_burst_exception)
   );
 
   // Scalar move support
@@ -374,8 +374,8 @@ module ara import ara_pkg::*; #(
       .fflags_ex_o                     (fflags_ex[lane]                     ),
       .fflags_ex_valid_o               (fflags_ex_valid[lane]               ),
       // Support for store exception flush
-      .stu_ex_flush_i                  (stu_ex_flush_lane                   ),
-      .stu_ex_flush_o                  (stu_ex_flush_stu[lane]              ),
+      .lsu_ex_flush_i                  (lsu_ex_flush_lane                   ),
+      .lsu_ex_flush_o                  (lsu_ex_flush_stu[lane]              ),
       // Interface with the sequencer
       .pe_req_i                        (pe_req                              ),
       .pe_req_valid_i                  (pe_req_valid                        ),
@@ -505,8 +505,8 @@ module ara import ara_pkg::*; #(
     .store_complete_o           (store_complete                                        ),
     .store_pending_o            (store_pending                                         ),
     // STU exception support
-    .stu_ex_flush_i             (|stu_ex_flush_stu                                     ),
-    .stu_ex_flush_done_o        (stu_ex_flush_done                                     ),
+    .lsu_ex_flush_i             (|lsu_ex_flush_stu                                     ),
+    .lsu_ex_flush_done_o        (lsu_ex_flush_done                                     ),
     // Interface with the sequencer
     .pe_req_i                   (pe_req                                                ),
     .pe_req_valid_i             (pe_req_valid                                          ),
@@ -517,7 +517,7 @@ module ara import ara_pkg::*; #(
     .addrgen_exception_o        (addrgen_exception                                     ),
     .addrgen_exception_vstart_o (addrgen_exception_vstart                              ),
     .addrgen_fof_exception_o    (addrgen_fof_exception                                 ),
-    .stu_current_burst_exception_o (stu_current_burst_exception),
+    .lsu_current_burst_exception_o (lsu_current_burst_exception),
     // Interface with the Mask unit
     .mask_i                     (mask                                                  ),
     .mask_valid_i               (mask_valid                                            ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -49,8 +49,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     output logic     [4:0]                                 fflags_ex_o,
     output logic                                           fflags_ex_valid_o,
     // Support for store exception flush
-    input  logic                                           stu_ex_flush_i,
-    output logic                                           stu_ex_flush_o,
+    input  logic                                           lsu_ex_flush_i,
+    output logic                                           lsu_ex_flush_o,
     // Interface with the sequencer
     input  `STRUCT_PORT_BITS(pe_req_t_bits)                pe_req_i,
     input  logic                                           pe_req_valid_i,
@@ -223,8 +223,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic                                       mask_b_cmd_pop;
 
   // Support for store exception flush
-  logic stu_ex_flush_op_req_d, stu_ex_flush_op_req_q;
-  `FF(stu_ex_flush_op_req_q, stu_ex_flush_op_req_d, 1'b0, clk_i, rst_ni);
+  logic lsu_ex_flush_op_req_d, lsu_ex_flush_op_req_q;
+  `FF(lsu_ex_flush_op_req_q, lsu_ex_flush_op_req_d, 1'b0, clk_i, rst_ni);
 
   // Additional signals to please Verilator's hierarchical verilation
   pe_req_t  pe_req;
@@ -249,8 +249,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .pe_req_ready_o         (pe_req_ready_o       ),
     .pe_resp_o              (pe_resp              ),
     // Support for store exception flush
-    .stu_ex_flush_i         (stu_ex_flush_i       ),
-    .stu_ex_flush_o         (stu_ex_flush_op_req_d),
+    .lsu_ex_flush_i         (lsu_ex_flush_i       ),
+    .lsu_ex_flush_o         (lsu_ex_flush_op_req_d),
     // Interface with the operand requesters
     .operand_request_o      (operand_request      ),
     .operand_request_valid_o(operand_request_valid),
@@ -306,8 +306,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   // To the slide unit (reductions)
   logic                                       sldu_result_gnt_opqueues;
   // Support for store exception flush
-  logic                                       stu_ex_flush_op_queues_d, stu_ex_flush_op_queues_q;
-  `FF(stu_ex_flush_op_queues_q, stu_ex_flush_op_queues_d, 1'b0, clk_i, rst_ni);
+  logic                                       lsu_ex_flush_op_queues_d, lsu_ex_flush_op_queues_q;
+  `FF(lsu_ex_flush_op_queues_q, lsu_ex_flush_op_queues_d, 1'b0, clk_i, rst_ni);
 
   operand_requester #(
     .NrLanes              (NrLanes              ),
@@ -326,8 +326,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .operand_request_valid_i  (operand_request_valid   ),
     .operand_request_ready_o  (operand_request_ready   ),
     // Support for store exception flush
-    .stu_ex_flush_i           (stu_ex_flush_op_req_q   ),
-    .stu_ex_flush_o           (stu_ex_flush_op_queues_d),
+    .lsu_ex_flush_i           (lsu_ex_flush_op_req_q   ),
+    .lsu_ex_flush_o           (lsu_ex_flush_op_queues_d),
     // Interface with the VRF
     .vrf_req_o                (vrf_req                 ),
     .vrf_addr_o               (vrf_addr                ),
@@ -445,8 +445,8 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .operand_queue_cmd_i              (operand_queue_cmd                  ),
     .operand_queue_cmd_valid_i        (operand_queue_cmd_valid            ),
     // Support for store exception flush
-    .stu_ex_flush_i                   (stu_ex_flush_op_queues_q           ),
-    .stu_ex_flush_o                   (stu_ex_flush_o                     ),
+    .lsu_ex_flush_i                   (lsu_ex_flush_op_queues_q           ),
+    .lsu_ex_flush_o                   (lsu_ex_flush_o                     ),
     // Interface with the Lane Sequencer
     .mask_b_cmd_pop_o                 (mask_b_cmd_pop                     ),
     // Interface with the VFUs

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -26,8 +26,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
     output logic                                          pe_req_ready_o,
     output pe_resp_t                                      pe_resp_o,
     // Support for store exception flush
-    input  logic                                          stu_ex_flush_i,
-    output logic                                          stu_ex_flush_o,
+    input  logic                                          lsu_ex_flush_i,
+    output logic                                          lsu_ex_flush_o,
     // Interface with the operand requester
     output operand_request_cmd_t [NrOperandQueues-1:0]    operand_request_o,
     output logic                 [NrOperandQueues-1:0]    operand_request_valid_o,
@@ -52,7 +52,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   `include "common_cells/registers.svh"
 
   // STU exception support
-  `FF(stu_ex_flush_o, stu_ex_flush_i, 1'b0, clk_i, rst_ni);
+  `FF(lsu_ex_flush_o, lsu_ex_flush_i, 1'b0, clk_i, rst_ni);
 
   ////////////////////////////
   //  Register the request  //
@@ -78,7 +78,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   ) i_pe_req_register (
     .clk_i     (clk_i             ),
     .rst_ni    (rst_ni            ),
-    .clr_i     (stu_ex_flush_o    ),
+    .clr_i     (lsu_ex_flush_o    ),
     .testmode_i(1'b0              ),
     .data_i    (pe_req_i          ),
     .valid_i   (pe_req_valid_i_msk),
@@ -156,8 +156,12 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
       end
     end
 
-    // Flush upon store
-    if (stu_ex_flush_o) operand_request_valid_d[StA] = 1'b0;
+    // Flush upon mem op with VRF access (st, idx ld, masked mem op)
+    if (lsu_ex_flush_o) begin
+      operand_request_valid_d[StA]           = 1'b0;
+      operand_request_valid_d[SlideAddrGenA] = 1'b0;
+      operand_request_valid_d[MaskM]         = 1'b0;
+    end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin: p_operand_request_ff

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -298,12 +298,12 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             operand_request_valid_o[MaskM]);
         end
         VFU_LoadUnit : pe_req_ready = !(operand_request_valid_o[MaskM] ||
-            (pe_req_i.op == VLXE && operand_request_valid_o[SlideAddrGenA]));
+            (pe_req.op == VLXE && operand_request_valid_o[SlideAddrGenA]));
         VFU_SlideUnit: pe_req_ready = !(operand_request_valid_o[SlideAddrGenA]);
         VFU_StoreUnit: begin
           pe_req_ready = !(operand_request_valid_o[StA] ||
             operand_request_valid_o[MaskM] ||
-            (pe_req_i.op == VSXE && operand_request_valid_o[SlideAddrGenA]));
+            (pe_req.op == VSXE && operand_request_valid_o[SlideAddrGenA]));
         end
         VFU_MaskUnit : begin
           pe_req_ready = !(operand_request_valid_o[AluA] ||
@@ -548,24 +548,24 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
 
           // Load indexed
           operand_request[SlideAddrGenA] = '{
-            id       : pe_req_i.id,
-            vs       : pe_req_i.vs2,
-            eew      : pe_req_i.eew_vs2,
-            conv     : pe_req_i.conversion_vs2,
+            id       : pe_req.id,
+            vs       : pe_req.vs2,
+            eew      : pe_req.eew_vs2,
+            conv     : pe_req.conversion_vs2,
             target_fu: MFPU_ADDRGEN,
-            vl       : pe_req_i.vl / NrLanes,
-            scale_vl : pe_req_i.scale_vl,
+            vl       : pe_req.vl / NrLanes,
+            scale_vl : pe_req.scale_vl,
             vstart   : vfu_operation_d.vstart,
-            vtype    : pe_req_i.vtype,
-            hazard   : pe_req_i.hazard_vs2 | pe_req_i.hazard_vd,
+            vtype    : pe_req.vtype,
+            hazard   : pe_req.hazard_vs2 | pe_req.hazard_vd,
             cvt_resize: CVT_SAME,
             default  : '0
           };
           // Since this request goes outside of the lane, we might need to request an
           // extra operand regardless of whether it is valid in this lane or not.
-          if (operand_request[SlideAddrGenA].vl * NrLanes != pe_req_i.vl)
+          if (operand_request[SlideAddrGenA].vl * NrLanes != pe_req.vl)
             operand_request[SlideAddrGenA].vl += 1;
-          operand_request_push[SlideAddrGenA] = pe_req_i.op == VLXE;
+          operand_request_push[SlideAddrGenA] = pe_req.op == VLXE;
         end
 
         VFU_StoreUnit : begin
@@ -615,24 +615,24 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
           // Store indexed
           // TODO: add vstart support here
           operand_request[SlideAddrGenA] = '{
-            id       : pe_req_i.id,
-            vs       : pe_req_i.vs2,
-            eew      : pe_req_i.eew_vs2,
-            conv     : pe_req_i.conversion_vs2,
+            id       : pe_req.id,
+            vs       : pe_req.vs2,
+            eew      : pe_req.eew_vs2,
+            conv     : pe_req.conversion_vs2,
             target_fu: MFPU_ADDRGEN,
-            vl       : pe_req_i.vl / NrLanes,
-            scale_vl : pe_req_i.scale_vl,
+            vl       : pe_req.vl / NrLanes,
+            scale_vl : pe_req.scale_vl,
             vstart   : vfu_operation_d.vstart,
-            vtype    : pe_req_i.vtype,
-            hazard   : pe_req_i.hazard_vs2 | pe_req_i.hazard_vd,
+            vtype    : pe_req.vtype,
+            hazard   : pe_req.hazard_vs2 | pe_req.hazard_vd,
             cvt_resize: CVT_SAME,
             default  : '0
           };
           // Since this request goes outside of the lane, we might need to request an
           // extra operand regardless of whether it is valid in this lane or not.
-          if (operand_request[SlideAddrGenA].vl * NrLanes != pe_req_i.vl)
+          if (operand_request[SlideAddrGenA].vl * NrLanes != pe_req.vl)
             operand_request[SlideAddrGenA].vl += 1;
-          operand_request_push[SlideAddrGenA] = pe_req_i.op == VSXE;
+          operand_request_push[SlideAddrGenA] = pe_req.op == VSXE;
         end
 
         VFU_SlideUnit: begin

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -25,8 +25,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     input  operand_queue_cmd_t [NrOperandQueues-1:0] operand_queue_cmd_i,
     input  logic               [NrOperandQueues-1:0] operand_queue_cmd_valid_i,
     // Support for store exception flush
-    input  logic                                     stu_ex_flush_i,
-    output logic                                     stu_ex_flush_o,
+    input  logic                                     lsu_ex_flush_i,
+    output logic                                     lsu_ex_flush_o,
     // Interface with the Lane Sequencer
     output logic                                     mask_b_cmd_pop_o,
     // Interface with the VFUs
@@ -57,7 +57,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   `include "common_cells/registers.svh"
 
   // STU flush support
-  `FF(stu_ex_flush_o, stu_ex_flush_i, 1'b0, clk_i, rst_ni);
+  `FF(lsu_ex_flush_o, lsu_ex_flush_i, 1'b0, clk_i, rst_ni);
 
   ///////////
   //  ALU  //
@@ -225,7 +225,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_st_mask_a (
     .clk_i                    (clk_i                         ),
     .rst_ni                   (rst_ni                        ),
-    .flush_i                  (stu_ex_flush_o                ),
+    .flush_i                  (lsu_ex_flush_o                ),
     .lane_id_i                (lane_id_i                     ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[StA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[StA]),
@@ -270,7 +270,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_slide_addrgen_a (
     .clk_i                    (clk_i                                                       ),
     .rst_ni                   (rst_ni                                                      ),
-    .flush_i                  (stu_ex_flush_o                                              ),
+    .flush_i                  (lsu_ex_flush_o                                              ),
     .lane_id_i                (lane_id_i                                                   ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[SlideAddrGenA]                          ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[SlideAddrGenA]                    ),
@@ -328,7 +328,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   ) i_operand_queue_mask_m (
     .clk_i                    (clk_i                           ),
     .rst_ni                   (rst_ni                          ),
-    .flush_i                  (stu_ex_flush_o                  ),
+    .flush_i                  (lsu_ex_flush_o                  ),
     .lane_id_i                (lane_id_i                       ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MaskM]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MaskM]),

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -1016,7 +1016,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
             end : indexed_data
 
             // Ask the MMU for an address translation if virtual memory is enabled
-            if (en_ld_st_translation_i) begin : translation_req
+            if (en_ld_st_translation_i && ((state_q != ADDRGEN_IDX_OP) || idx_vaddr_valid_q)) begin : translation_req
               // Request an address translation
               mmu_req_d           = 1'b1;
               mmu_vaddr_o         = (state_q == ADDRGEN_IDX_OP) ? idx_final_vaddr_q : axi_addrgen_q.addr;

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -67,7 +67,9 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     input  elen_t            [NrLanes-1:0] addrgen_operand_i,
     input  target_fu_e       [NrLanes-1:0] addrgen_operand_target_fu_i,
     input  logic             [NrLanes-1:0] addrgen_operand_valid_i,
-    output logic                           addrgen_operand_ready_o
+    output logic                           addrgen_operand_ready_o,
+    // Indexed LSU exception support
+    input  logic                           lsu_ex_flush_i
   );
 
   localparam unsigned DataWidth = $bits(elen_t);
@@ -178,12 +180,17 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
   logic      idx_vaddr_valid_d, idx_vaddr_valid_q;
   logic      idx_vaddr_ready_d, idx_vaddr_ready_q;
 
+  // Exception support
+  // This flush should be done after the backend has been flushed, too
+  logic lsu_ex_flush_q;
+
   // Break the path from the VRF to the AXI request
-  spill_register #(
+  spill_register_flushable #(
     .T(axi_addr_t)
   ) i_addrgen_idx_op_spill_reg (
     .clk_i  (clk_i           ),
     .rst_ni (rst_ni          ),
+    .flush_i(lsu_ex_flush_q  ),
     .valid_i(idx_vaddr_valid_d),
     .ready_o(idx_vaddr_ready_q),
     .data_i (idx_final_vaddr_d),
@@ -556,6 +563,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
       lookahead_addr_e_q         <= '0;
       lookahead_addr_se_q        <= '0;
       lookahead_len_q            <= '0;
+      lsu_ex_flush_q             <= 1'b0;
     end else begin
       state_q                    <= state_d;
       pe_req_q                   <= pe_req_d;
@@ -570,6 +578,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
       lookahead_addr_e_q         <= lookahead_addr_e_d;
       lookahead_addr_se_q        <= lookahead_addr_se_d;
       lookahead_len_q            <= lookahead_len_d;
+      lsu_ex_flush_q             <= lsu_ex_flush_i;
     end
   end
 

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -49,7 +49,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     output ariane_pkg::exception_t  addrgen_exception_o,
     output vlen_t                   addrgen_exception_vstart_o,
     output logic                    addrgen_fof_exception_o,
-    output logic                    stu_current_burst_exception_o,
+    output logic                    lsu_current_burst_exception_o,
     // Interface with the lanes
     // Store unit operands
     input  elen_t     [NrLanes-1:0] stu_operand_i,
@@ -61,8 +61,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     input  logic      [NrLanes-1:0] addrgen_operand_valid_i,
     output logic                    addrgen_operand_ready_o,
     // STU exception support
-    input  logic                    stu_ex_flush_i,
-    output logic                    stu_ex_flush_done_o,
+    input  logic                    lsu_ex_flush_i,
+    output logic                    lsu_ex_flush_done_o,
     // Interface with the Mask unit
     input  strb_t     [NrLanes-1:0] mask_i,
     input  logic      [NrLanes-1:0] mask_valid_i,
@@ -97,10 +97,17 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     input  logic      [NrLanes-1:0] ldu_result_final_gnt_i
   );
 
+  `include "common_cells/registers.svh"
+
   logic load_complete, store_complete;
   logic addrgen_illegal_load, addrgen_illegal_store;
   assign load_complete_o  = load_complete;
   assign store_complete_o = store_complete;
+
+  logic stu_current_burst_exception, ldu_current_burst_exception;
+  assign lsu_current_burst_exception_o = stu_current_burst_exception | ldu_current_burst_exception;
+
+  `FF(lsu_ex_flush_done_o, lsu_ex_flush_i, 1'b0, clk_i, rst_ni);
 
   ///////////////////
   //  Definitions  //
@@ -184,6 +191,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .axi_addrgen_req_valid_o    (axi_addrgen_req_valid      ),
     .ldu_axi_addrgen_req_ready_i(ldu_axi_addrgen_req_ready  ),
     .stu_axi_addrgen_req_ready_i(stu_axi_addrgen_req_ready  ),
+    .lsu_ex_flush_i             (lsu_ex_flush_i             ),
 
     // CSR input
     .en_ld_st_translation_i,
@@ -226,6 +234,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .pe_vinsn_running_i     (pe_vinsn_running_i        ),
     .pe_req_ready_o         (pe_req_ready_o[OffsetLoad]),
     .pe_resp_o              (pe_resp_o[OffsetLoad]     ),
+    .ldu_current_burst_exception_o (ldu_current_burst_exception),
     // Interface with the address generator
     .axi_addrgen_req_i      (axi_addrgen_req           ),
     .axi_addrgen_req_valid_i(axi_addrgen_req_valid     ),
@@ -242,7 +251,8 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .ldu_result_wdata_o     (ldu_result_wdata_o        ),
     .ldu_result_be_o        (ldu_result_be_o           ),
     .ldu_result_gnt_i       (ldu_result_gnt_i          ),
-    .ldu_result_final_gnt_i (ldu_result_final_gnt_i    )
+    .ldu_result_final_gnt_i (ldu_result_final_gnt_i    ),
+    .lsu_ex_flush_i         (lsu_ex_flush_i            )
   );
 
   /////////////////////////
@@ -278,7 +288,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .pe_vinsn_running_i     (pe_vinsn_running_i         ),
     .pe_req_ready_o         (pe_req_ready_o[OffsetStore]),
     .pe_resp_o              (pe_resp_o[OffsetStore]     ),
-    .stu_current_burst_exception_o (stu_current_burst_exception_o),
+    .stu_current_burst_exception_o (stu_current_burst_exception),
     // Interface with the address generator
     .axi_addrgen_req_i      (axi_addrgen_req            ),
     .axi_addrgen_req_valid_i(axi_addrgen_req_valid      ),
@@ -292,8 +302,7 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .stu_operand_i          (stu_operand_i              ),
     .stu_operand_valid_i    (stu_operand_valid_i        ),
     .stu_operand_ready_o    (stu_operand_ready_o        ),
-    .stu_ex_flush_i         (stu_ex_flush_i             ),
-    .stu_ex_flush_done_o    (stu_ex_flush_done_o        )
+    .lsu_ex_flush_i         (lsu_ex_flush_i             )
   );
 
   //////////////////


### PR DESCRIPTION
Fix indexed loads with virtual memory.

## Changelog

### Fixed

- Correctly flush the backend pipeline upon indexed load exceptions.
- Make addrgen wait for index address before making an MMU request.
- Fix typos in lane sequencer.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed