### PR TITLE
[HW] :bug: Fix synchronization between lanes and sldu/addrgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Correctly flush the backend pipeline upon indexed load exceptions
  - Make addrgen wait for index address before making an MMU request
  - Fix typos in lane sequencer
+ - Fix sldu/addrgen synchronization
 
 ### Added
 

--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -316,8 +316,8 @@ module ara import ara_pkg::*; #(
   logic      [NrLanes-1:0]                     stu_operand_ready;
   // Slide unit/address generation operands
   elen_t     [NrLanes-1:0]                     sldu_addrgen_operand;
-  target_fu_e[NrLanes-1:0]                     sldu_addrgen_operand_target_fu;
-  logic      [NrLanes-1:0]                     sldu_addrgen_operand_valid;
+  logic      [NrLanes-1:0]                     sldu_operand_valid;
+  logic      [NrLanes-1:0]                     addrgen_operand_valid;
   logic      [NrLanes-1:0]                     sldu_operand_ready;
   sldu_mux_e                                   sldu_mux_sel;
   logic                                        addrgen_operand_ready;
@@ -407,8 +407,8 @@ module ara import ara_pkg::*; #(
       .stu_operand_ready_i             (stu_operand_ready[lane]             ),
       // Interface with the slide/address generation unit
       .sldu_addrgen_operand_o          (sldu_addrgen_operand[lane]          ),
-      .sldu_addrgen_operand_target_fu_o(sldu_addrgen_operand_target_fu[lane]),
-      .sldu_addrgen_operand_valid_o    (sldu_addrgen_operand_valid[lane]    ),
+      .sldu_operand_valid_o            (sldu_operand_valid[lane]            ),
+      .addrgen_operand_valid_o         (addrgen_operand_valid[lane]         ),
       .addrgen_operand_ready_i         (addrgen_operand_ready               ),
       .sldu_mux_sel_i                  (sldu_mux_sel                        ),
       .sldu_operand_ready_i            (sldu_operand_ready[lane]            ),
@@ -530,8 +530,7 @@ module ara import ara_pkg::*; #(
     .stu_operand_ready_o        (stu_operand_ready                                     ),
     // Address Generation
     .addrgen_operand_i          (sldu_addrgen_operand                                  ),
-    .addrgen_operand_target_fu_i(sldu_addrgen_operand_target_fu                        ),
-    .addrgen_operand_valid_i    (sldu_addrgen_operand_valid                            ),
+    .addrgen_operand_valid_i    (addrgen_operand_valid                                 ),
     .addrgen_operand_ready_o    (addrgen_operand_ready                                 ),
     // CSR input
     .en_ld_st_translation_i     (acc_mmu_en_q                                          ),
@@ -579,8 +578,7 @@ module ara import ara_pkg::*; #(
     .pe_resp_o               (pe_resp[NrLanes+OffsetSlide]     ),
     // Interface with the lanes
     .sldu_operand_i          (sldu_addrgen_operand             ),
-    .sldu_operand_target_fu_i(sldu_addrgen_operand_target_fu   ),
-    .sldu_operand_valid_i    (sldu_addrgen_operand_valid       ),
+    .sldu_operand_valid_i    (sldu_operand_valid               ),
     .sldu_operand_ready_o    (sldu_operand_ready               ),
     .sldu_result_req_o       (sldu_result_req                  ),
     .sldu_result_addr_o      (sldu_result_addr                 ),

--- a/hardware/src/lane/lane.sv
+++ b/hardware/src/lane/lane.sv
@@ -220,7 +220,9 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
   logic                                       mfpu_ready;
   logic                 [NrVInsn-1:0]         mfpu_vinsn_done;
   // Interface with the MaskB operand queue (VRGATHER/VCOMPRESS)
-  logic                                       mask_b_cmd_pop;
+  logic                                       mask_b_cmd_pop_d, mask_b_cmd_pop_q;
+  `FF(mask_b_cmd_pop_q, mask_b_cmd_pop_d, 1'b0, clk_i, rst_ni);
+
 
   // Support for store exception flush
   logic lsu_ex_flush_op_req_d, lsu_ex_flush_op_req_q;
@@ -258,7 +260,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .alu_vinsn_done_o       (alu_vinsn_done_o     ),
     .mfpu_vinsn_done_o      (mfpu_vinsn_done_o    ),
     // Interface with the Operand Queue
-    .mask_b_cmd_pop_i       (mask_b_cmd_pop       ),
+    .mask_b_cmd_pop_i       (mask_b_cmd_pop_q     ),
     // Interface with the VFUs
     .vfu_operation_o        (vfu_operation        ),
     .vfu_operation_valid_o  (vfu_operation_valid  ),
@@ -450,7 +452,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
     .lsu_ex_flush_i                   (lsu_ex_flush_op_queues_q           ),
     .lsu_ex_flush_o                   (lsu_ex_flush_o                     ),
     // Interface with the Lane Sequencer
-    .mask_b_cmd_pop_o                 (mask_b_cmd_pop                     ),
+    .mask_b_cmd_pop_o                 (mask_b_cmd_pop_d                   ),
     // Interface with the Lane
     .sldu_addrgen_cmd_pop_o           (sldu_addrgen_cmd_pop               ),
     // Interface with the VFUs
@@ -584,7 +586,7 @@ module lane import ara_pkg::*; import rvv_pkg::*; #(
 
   ara_op_e vfu_operation_op_q;
   logic vfu_operation_valid_q;
-  logic sldu_operand_opqueues_valid, addrgen_operand_opqueues_valid;
+  logic sldu_operand_opqueues_valid;
 
   // Selector FIFO to enforce instruction order
   fifo_v3 #(

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -57,7 +57,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   //////////////////////
 
   operand_queue_cmd_t cmd;
-  logic               cmd_pop, cmd_pop_q;
+  logic               cmd_pop;
 
   fifo_v3 #(
     .DEPTH(CmdBufDepth        ),
@@ -79,7 +79,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   // If this is the MaskB opqueue, propagate the
   // pop information for the cmd buffer
   if (AccessCmdPop)
-    assign cmd_pop_o = cmd_pop_q;
+    assign cmd_pop_o = cmd_pop;
   else
     assign cmd_pop_o = 1'b0;
 
@@ -133,10 +133,8 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
   always_ff @(posedge clk_i or negedge rst_ni) begin: p_ibuf_usage_ff
     if (!rst_ni) begin
       ibuf_usage_q <= '0;
-      cmd_pop_q    <= 1'b0;
     end else begin
       ibuf_usage_q <= ibuf_usage_d;
-      cmd_pop_q    <= cmd_pop;
     end
   end
 

--- a/hardware/src/lane/operand_queue.sv
+++ b/hardware/src/lane/operand_queue.sv
@@ -14,7 +14,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     parameter  int           unsigned NrSlaves            = 1,
     parameter  int           unsigned NrLanes             = 0,
     parameter  int           unsigned VLEN                = 0,
-    parameter  bit                    IsVrgatherOpqueue   = 0,
+    parameter  bit                    AccessCmdPop        = 0,
     // Support for floating-point data types
     parameter  fpu_support_e          FPUSupport          = FPUSupportHalfSingleDouble,
     // Supported conversions
@@ -39,7 +39,7 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
     input  operand_queue_cmd_t                operand_queue_cmd_i,
     input  logic                              operand_queue_cmd_valid_i,
     // Interface with the Lane Sequencer
-    output logic                              mask_b_cmd_pop_o,
+    output logic                              cmd_pop_o,
     // Interface with the Vector Register File
     input  elen_t                             operand_i,
     input  logic                              operand_valid_i,
@@ -78,10 +78,10 @@ module operand_queue import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
 
   // If this is the MaskB opqueue, propagate the
   // pop information for the cmd buffer
-  if (IsVrgatherOpqueue)
-    assign mask_b_cmd_pop_o = cmd_pop_q;
+  if (AccessCmdPop)
+    assign cmd_pop_o = cmd_pop_q;
   else
-    assign mask_b_cmd_pop_o = 1'b0;
+    assign cmd_pop_o = 1'b0;
 
   //////////////
   //  Buffer  //

--- a/hardware/src/lane/operand_queues_stage.sv
+++ b/hardware/src/lane/operand_queues_stage.sv
@@ -29,6 +29,8 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     output logic                                     lsu_ex_flush_o,
     // Interface with the Lane Sequencer
     output logic                                     mask_b_cmd_pop_o,
+    // Interface with the Lane
+    output logic                                     sldu_addrgen_cmd_pop_o,
     // Interface with the VFUs
     // ALU
     output elen_t              [1:0]                 alu_operand_o,
@@ -46,8 +48,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     output elen_t                                    sldu_addrgen_operand_o,
     output target_fu_e                               sldu_addrgen_operand_target_fu_o,
     output logic                                     sldu_addrgen_operand_valid_o,
-    input  logic                                     addrgen_operand_ready_i,
-    input  logic                                     sldu_operand_ready_i,
+    input  logic                                     sldu_addrgen_operand_ready_i,
     // Mask unit
     output elen_t              [1:0]                 mask_operand_o,
     output logic               [1:0]                 mask_operand_valid_o,
@@ -82,7 +83,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .lane_id_i                (lane_id_i                      ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[AluA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[AluA]),
-    .mask_b_cmd_pop_o         (/* Unused */                   ),
+    .cmd_pop_o                (/* Unused */                   ),
     .operand_i                (operand_i[AluA]                ),
     .operand_valid_i          (operand_valid_i[AluA]          ),
     .operand_issued_i         (operand_issued_i[AluA]         ),
@@ -112,7 +113,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .lane_id_i                (lane_id_i                      ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[AluB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[AluB]),
-    .mask_b_cmd_pop_o         (/* Unused */                   ),
+    .cmd_pop_o                (/* Unused */                   ),
     .operand_i                (operand_i[AluB]                ),
     .operand_valid_i          (operand_valid_i[AluB]          ),
     .operand_issued_i         (operand_issued_i[AluB]         ),
@@ -144,7 +145,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUA]),
-    .mask_b_cmd_pop_o         (/* Unused */                      ),
+    .cmd_pop_o                (/* Unused */                      ),
     .operand_i                (operand_i[MulFPUA]                ),
     .operand_valid_i          (operand_valid_i[MulFPUA]          ),
     .operand_issued_i         (operand_issued_i[MulFPUA]         ),
@@ -172,7 +173,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUB]),
-    .mask_b_cmd_pop_o         (/* Unused */                      ),
+    .cmd_pop_o                (/* Unused */                      ),
     .operand_i                (operand_i[MulFPUB]                ),
     .operand_valid_i          (operand_valid_i[MulFPUB]          ),
     .operand_issued_i         (operand_issued_i[MulFPUB]         ),
@@ -200,7 +201,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .lane_id_i                (lane_id_i                         ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MulFPUC]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MulFPUC]),
-    .mask_b_cmd_pop_o         (/* Unused */                      ),
+    .cmd_pop_o                (/* Unused */                      ),
     .operand_i                (operand_i[MulFPUC]                ),
     .operand_valid_i          (operand_valid_i[MulFPUC]          ),
     .operand_issued_i         (operand_issued_i[MulFPUC]         ),
@@ -229,7 +230,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .lane_id_i                (lane_id_i                     ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[StA]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[StA]),
-    .mask_b_cmd_pop_o         (/* Unused */                  ),
+    .cmd_pop_o                (/* Unused */                  ),
     .operand_i                (operand_i[StA]                ),
     .operand_valid_i          (operand_valid_i[StA]          ),
     .operand_issued_i         (operand_issued_i[StA]         ),
@@ -244,45 +245,30 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
    *  Slide Unit  *
    ****************/
 
-  // This operand queue is common to slide unit and addrgen.
-  // Since it's shared, we should be sure not to sample a
-  // spurious ready from the wrong unit, i.e., when we are
-  // feeding the addrgen, we don't want spurious readies from
-  // the slide unit. The units should be responsible for avoiding
-  // sampling wrong data, but spurious ready signals can happen in
-  // specific corner cases. Fixing this without impacting timing is
-  // hard, so we just mask the ready signals here as well to avoid
-  // bugs.
-  logic sldu_operand_ready_filtered;
-  logic addrgen_operand_ready_filtered;
-  assign sldu_operand_ready_filtered = sldu_operand_ready_i &
-    (sldu_addrgen_operand_target_fu_o == ALU_SLDU);
-  assign addrgen_operand_ready_filtered = addrgen_operand_ready_i &
-    (sldu_addrgen_operand_target_fu_o == MFPU_ADDRGEN);
-
   operand_queue #(
     .CmdBufDepth        (VlduInsnQueueDepth   ),
     .DataBufDepth       (2                    ),
+    .AccessCmdPop       (1'b1                 ),
     .FPUSupport         (FPUSupportNone       ),
     .NrLanes            (NrLanes              ),
     .VLEN               (VLEN                 ),
     .operand_queue_cmd_t(operand_queue_cmd_t  )
   ) i_operand_queue_slide_addrgen_a (
-    .clk_i                    (clk_i                                                       ),
-    .rst_ni                   (rst_ni                                                      ),
-    .flush_i                  (lsu_ex_flush_o                                              ),
-    .lane_id_i                (lane_id_i                                                   ),
-    .operand_queue_cmd_i      (operand_queue_cmd_i[SlideAddrGenA]                          ),
-    .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[SlideAddrGenA]                    ),
-    .mask_b_cmd_pop_o         (/* Unused */                                                ),
-    .operand_i                (operand_i[SlideAddrGenA]                                    ),
-    .operand_valid_i          (operand_valid_i[SlideAddrGenA]                              ),
-    .operand_issued_i         (operand_issued_i[SlideAddrGenA]                             ),
-    .operand_queue_ready_o    (operand_queue_ready_o[SlideAddrGenA]                        ),
-    .operand_o                (sldu_addrgen_operand_o                                      ),
-    .operand_target_fu_o      (sldu_addrgen_operand_target_fu_o                            ),
-    .operand_valid_o          (sldu_addrgen_operand_valid_o                                ),
-    .operand_ready_i          (addrgen_operand_ready_filtered | sldu_operand_ready_filtered)
+    .clk_i                    (clk_i                                   ),
+    .rst_ni                   (rst_ni                                  ),
+    .flush_i                  (lsu_ex_flush_o                          ),
+    .lane_id_i                (lane_id_i                               ),
+    .operand_queue_cmd_i      (operand_queue_cmd_i[SlideAddrGenA]      ),
+    .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[SlideAddrGenA]),
+    .cmd_pop_o                (sldu_addrgen_cmd_pop_o                  ),
+    .operand_i                (operand_i[SlideAddrGenA]                ),
+    .operand_valid_i          (operand_valid_i[SlideAddrGenA]          ),
+    .operand_issued_i         (operand_issued_i[SlideAddrGenA]         ),
+    .operand_queue_ready_o    (operand_queue_ready_o[SlideAddrGenA]    ),
+    .operand_o                (sldu_addrgen_operand_o                  ),
+    .operand_target_fu_o      (sldu_addrgen_operand_target_fu_o        ),
+    .operand_valid_o          (sldu_addrgen_operand_valid_o            ),
+    .operand_ready_i          (sldu_addrgen_operand_ready_i            )
   );
 
   /////////////////
@@ -292,7 +278,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
   operand_queue #(
     .CmdBufDepth        (MaskuInsnQueueDepth + VrgatherOpQueueBufDepth ),
     .DataBufDepth       (MaskuInsnQueueDepth + VrgatherOpQueueBufDepth ),
-    .IsVrgatherOpqueue  (1'b1                                          ),
+    .AccessCmdPop       (1'b1                                          ),
     .FPUSupport         (FPUSupportNone                                ),
     .SupportIntExt2     (1'b1                                          ),
     .SupportIntExt4     (1'b1                                          ),
@@ -307,7 +293,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .lane_id_i                (lane_id_i                       ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MaskB]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MaskB]),
-    .mask_b_cmd_pop_o         (mask_b_cmd_pop_o                ),
+    .cmd_pop_o                (mask_b_cmd_pop_o                ),
     .operand_i                (operand_i[MaskB]                ),
     .operand_valid_i          (operand_valid_i[MaskB]          ),
     .operand_issued_i         (operand_issued_i[MaskB]         ),
@@ -332,7 +318,7 @@ module operand_queues_stage import ara_pkg::*; import rvv_pkg::*; import cf_math
     .lane_id_i                (lane_id_i                       ),
     .operand_queue_cmd_i      (operand_queue_cmd_i[MaskM]      ),
     .operand_queue_cmd_valid_i(operand_queue_cmd_valid_i[MaskM]),
-    .mask_b_cmd_pop_o         (/* Unused */                    ),
+    .cmd_pop_o                (/* Unused */                    ),
     .operand_i                (operand_i[MaskM]                ),
     .operand_valid_i          (operand_valid_i[MaskM]          ),
     .operand_issued_i         (operand_issued_i[MaskM]         ),

--- a/hardware/src/lane/vector_fus_stage.sv
+++ b/hardware/src/lane/vector_fus_stage.sv
@@ -40,6 +40,9 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     output logic           [NrVInsn-1:0]      alu_vinsn_done_o,
     output logic                              mfpu_ready_o,
     output logic           [NrVInsn-1:0]      mfpu_vinsn_done_o,
+    // Interface with the lane
+    output logic                              alu_red_complete_o,
+    output logic                              fpu_red_complete_o,
     // Interface with the operand queues
     input  elen_t          [1:0]              alu_operand_i,
     input  logic           [1:0]              alu_operand_valid_i,
@@ -118,6 +121,8 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .vfu_operation_valid_i(vfu_operation_valid_i          ),
     .alu_ready_o          (alu_ready_o                    ),
     .alu_vinsn_done_o     (alu_vinsn_done_o               ),
+    // Interface with the lane
+    .alu_red_complete_o   (alu_red_complete_o             ),
     // Interface with the operand queues
     .alu_operand_i        (alu_operand_i                  ),
     .alu_operand_valid_i  (alu_operand_valid_i            ),
@@ -172,6 +177,8 @@ module vector_fus_stage import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg
     .vfu_operation_valid_i(vfu_operation_valid_i           ),
     .mfpu_ready_o         (mfpu_ready_o                    ),
     .mfpu_vinsn_done_o    (mfpu_vinsn_done_o               ),
+    // Interface with the lane
+    .fpu_red_complete_o   (fpu_red_complete_o              ),
     // Interface with the operand queues
     .mfpu_operand_i       (mfpu_operand_i                  ),
     .mfpu_operand_valid_i (mfpu_operand_valid_i            ),

--- a/hardware/src/sldu/sldu.sv
+++ b/hardware/src/sldu/sldu.sv
@@ -29,7 +29,6 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
     output pe_resp_t               pe_resp_o,
     // Interface with the lanes
     input  elen_t    [NrLanes-1:0] sldu_operand_i,
-    input  target_fu_e [NrLanes-1:0] sldu_operand_target_fu_i,
     input  logic     [NrLanes-1:0] sldu_operand_valid_i,
     output logic     [NrLanes-1:0] sldu_operand_ready_o,
     output logic     [NrLanes-1:0] sldu_result_req_o,
@@ -167,7 +166,6 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
   elen_t [NrLanes-1:0] sldu_operand;
   logic  [NrLanes-1:0] sldu_operand_valid;
   logic  [NrLanes-1:0] sldu_operand_ready;
-  target_fu_e [NrLanes-1:0] sldu_operand_target_fu_d, sldu_operand_target_fu_q;
 
   // Don't handshake if the operands target the addrgen!
   // Moreover, when computing NP2 slides, loop over the same data!
@@ -188,6 +186,11 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
 
   logic slide_np2_buf_valid_d, slide_np2_buf_valid_q;
 
+  // There are multiple transmitters (TX) (OpQueue, ALU, FPU, SLDU-NP2) and receivers (RX) (SLDU, ADDRGEN).
+  // Hypotheses:
+  // - When valid is asserted on the RX, data cannot change anymore until the handshake happens.
+  // - When valid is received by RX, then DATA is targeting that RX only.
+  // Data and handshakes signals are controlled upstream (TX side) so that this Hypotheses hold.
 
   for (genvar l = 0; l < NrLanes; l++) begin
     spill_register #(
@@ -207,26 +210,13 @@ module sldu import ara_pkg::*; import rvv_pkg::*; #(
                              ? sldu_operand_i[l]
                              : result_queue_q[NP2_BUFFER_PNT][l].wdata;
 
-    assign sldu_operand_valid_d[l] = (sldu_operand_target_fu_q[l] == ALU_SLDU)
-                                   ? (np2_loop_mux_sel_q == NP2_EXT_SEL
-                                     ? sldu_operand_valid_i[l]
-                                     : slide_np2_buf_valid_q)
+    assign sldu_operand_valid_d[l] = np2_loop_mux_sel_q == NP2_EXT_SEL
+                                   ? sldu_operand_valid_i[l]
+                                   : slide_np2_buf_valid_q;
+
+    assign sldu_operand_ready_o[l] = np2_loop_mux_sel_q == NP2_EXT_SEL
+                                   ? sldu_operand_ready_q[l]
                                    : 1'b0;
-
-    assign sldu_operand_ready_o[l] = (sldu_operand_target_fu_q[l] == ALU_SLDU)
-                                   ? (np2_loop_mux_sel_q == NP2_EXT_SEL
-                                     ? sldu_operand_ready_q[l]
-                                     : 1'b0)
-                                   : 1'b0;
-  end
-
-  assign sldu_operand_target_fu_d = sldu_operand_target_fu_i;
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)
-      sldu_operand_target_fu_q <= target_fu_e'(1'b0);
-    else
-      sldu_operand_target_fu_q <= sldu_operand_target_fu_d;
   end
 
   //////////////////////////

--- a/hardware/src/vlsu/addrgen.sv
+++ b/hardware/src/vlsu/addrgen.sv
@@ -65,7 +65,6 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
     input  logic                           stu_axi_addrgen_req_ready_i,
     // Interface with the lanes (for scatter/gather operations)
     input  elen_t            [NrLanes-1:0] addrgen_operand_i,
-    input  target_fu_e       [NrLanes-1:0] addrgen_operand_target_fu_i,
     input  logic             [NrLanes-1:0] addrgen_operand_valid_i,
     output logic                           addrgen_operand_ready_o,
     // Indexed LSU exception support
@@ -435,7 +434,7 @@ module addrgen import ara_pkg::*; import rvv_pkg::*; #(
         // Handle handshake and data between VRF and spill register
         // We accept all the incoming data, without any checks
         // since Ara stalls on an indexed memory operation
-        if (&addrgen_operand_valid & addrgen_operand_target_fu_i[0] == MFPU_ADDRGEN) begin
+        if (&addrgen_operand_valid) begin
 
           // Valid data for the spill register
           idx_vaddr_valid_d = 1'b1;

--- a/hardware/src/vlsu/vldu.sv
+++ b/hardware/src/vlsu/vldu.sv
@@ -53,7 +53,6 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     input  logic             [NrLanes-1:0] ldu_result_final_gnt_i,
     // LSU exception support
     input  logic                           lsu_ex_flush_i,
-    output logic                           lsu_ex_flush_done_o,
     // Interface with the Mask unit
     input  strb_t            [NrLanes-1:0] mask_i,
     input  logic             [NrLanes-1:0] mask_valid_i,
@@ -86,7 +85,7 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
     ) i_vldu_mask_register (
       .clk_i     (clk_i           ),
       .rst_ni    (rst_ni          ),
-      .flush_i   (ldu_ex_flush_q  ),
+      .flush_i   (lsu_ex_flush_q  ),
       .data_o    (mask_q[l]       ),
       .valid_o   (mask_valid_q[l] ),
       .ready_i   (mask_ready_d    ),
@@ -679,7 +678,6 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
       first_payload_byte_q          <= '0;
       vrf_word_byte_cnt_q           <= '0;
       lsu_ex_flush_q                <= lsu_ex_flush_i;
-      lsu_ex_flush_done_o           <= lsu_ex_flush_q;
       ldu_current_burst_exception_o <= 1'b0;
       ldu_ex_state_q                <= IDLE;
       first_result_queue_read_q     <= 1'b0;
@@ -696,7 +694,6 @@ module vldu import ara_pkg::*; import rvv_pkg::*; #(
       first_payload_byte_q          <= first_payload_byte_d;
       vrf_word_byte_cnt_q           <= vrf_word_byte_cnt_d;
       lsu_ex_flush_q                <= lsu_ex_flush_i;
-      lsu_ex_flush_done_o           <= lsu_ex_flush_q;
       ldu_current_burst_exception_o <= ldu_current_burst_exception_d;
       ldu_ex_state_q                <= ldu_ex_state_d;
       first_result_queue_read_q     <= first_result_queue_read_d;

--- a/hardware/src/vlsu/vlsu.sv
+++ b/hardware/src/vlsu/vlsu.sv
@@ -57,7 +57,6 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     output logic      [NrLanes-1:0] stu_operand_ready_o,
     // Address generation operands
     input  elen_t     [NrLanes-1:0] addrgen_operand_i,
-    input  target_fu_e[NrLanes-1:0] addrgen_operand_target_fu_i,
     input  logic      [NrLanes-1:0] addrgen_operand_valid_i,
     output logic                    addrgen_operand_ready_o,
     // STU exception support
@@ -183,7 +182,6 @@ module vlsu import ara_pkg::*; import rvv_pkg::*; #(
     .addrgen_illegal_store_o    (addrgen_illegal_store      ),
     // Interface with the lanes
     .addrgen_operand_i          (addrgen_operand_i          ),
-    .addrgen_operand_target_fu_i(addrgen_operand_target_fu_i),
     .addrgen_operand_valid_i    (addrgen_operand_valid_i    ),
     .addrgen_operand_ready_o    (addrgen_operand_ready_o    ),
     // Interface with the load/store units


### PR DESCRIPTION
There are three transmitters (TXs) that can send data to two receivers (RXs).

```
TXs:
 1) sldu/addrgen opqueue
 2) alu
 3) vmfpu
RXs:
 1) SLDU
 2) ADDRGEN
```

This is because the sldu/addrgen opqueue is shared and reductions pass through the SLDU. 
The previous control logic was flawed and indexed memory operations + reductions could not work together.

Now, we have changed some hypotheses: the RXs always receive a valid from the lanes only if the data is targeting them. 

We have two valid lines, one for the addrgen, and one for the sldu. This simplifies the logic in the SLDU.
 
In each lane, the selector logic to stream the correct valids/readies is controlled by a FIFO containing the selectors in program order, therefore serializing the requests correctly.

## Changelog

### Fixed

- Fix sldu/addrgen synchronization

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed