### PR TITLE
[HW] Fix osum reduction counter bumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Fix sldu/addrgen synchronization
  - Reset `vfirst`/`vcpop` accumulator when a new instruction starts
  - Fix wrong `eew` for mask comparisons in lane sequencer
+ - Fix bug in ordered reductions
 
 ### Added
 

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -2104,8 +2104,6 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
         // Finish this instruction if the last result is acknowledged
         // In the case of vl=0, wait until the redundant data is acknowledged
         if (!(lane_id_i == '0) && to_process_cnt_d == '0 && ((vinsn_processing_q.vl == '0) ? !first_op_q : red_hs_synch_q)) begin
-          // Give the done to the main sequencer
-          commit_cnt_d = '0;
           mfpu_state_d = MFPU_WAIT;
         end else if ((lane_id_i == '0) && sldu_mfpu_valid_q && to_process_cnt_d == '0) begin
           // Lane 0 should wait for the final result
@@ -2124,7 +2122,6 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
             result_queue_write_pnt_d = result_queue_write_pnt_q + 1;
 
           sldu_mfpu_ready_d = 1'b1;
-          commit_cnt_d = '0;
           mfpu_state_d = MFPU_WAIT;
         end
       end


### PR DESCRIPTION
Fix bug in ordered reductions.

## Changelog

### Fixed

- Prevent double bump of `insn_queue.commit_cnt` after an ordered reduction.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed