### PR TITLE
[HW] Fix `vfirst` and mask comparison `EEW`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Make addrgen wait for index address before making an MMU request
  - Fix typos in lane sequencer
  - Fix sldu/addrgen synchronization
+ - Reset `vfirst`/`vcpop` accumulator when a new instruction starts
+ - Fix wrong `eew` for mask comparisons in lane sequencer
 
 ### Added
 

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -762,7 +762,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
           // Integer comparisons run on the ALU and then get reshuffled and masked in the MASKU
           if (pe_req.op inside {[VMSEQ:VMSBC],[VRGATHER:VRGATHEREI16]}) begin
             // These source regs contain non-mask vectors.
-            operand_request[AluA].eew = pe_req.op == VRGATHEREI16 ? EW16 : pe_req.vtype.vsew;
+            operand_request[AluA].eew = pe_req.op == VRGATHEREI16 ? EW16 : pe_req.eew_vs1;
             operand_request[AluA].vl  = pe_req.vl / NrLanes;
             if ((operand_request[AluA].vl * NrLanes) != pe_req.vl)
               operand_request[AluA].vl += 1;

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -1304,7 +1304,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
         // Request new input (by completing ready-valid handshake) once all slices have been processed
         // Alu input is accessed in different widths
         // VRGATHER and VCOMPRESS handle the ALU operand for the index generation before the MASKU ALU gets the operands
-        if (((in_ready_cnt_q == in_ready_threshold_q) || (issue_cnt_d == '0)) && !(vinsn_issue.op inside {[VRGATHER:VCOMPRESS]})) begin
+        if ((((in_ready_cnt_q == in_ready_threshold_q) || (issue_cnt_d == '0)) && !(vinsn_issue.op inside {[VRGATHER:VCOMPRESS]})) || (!vfirst_empty && (vinsn_issue.op == VFIRST))) begin
           in_ready_cnt_clr = 1'b1;
           if (vinsn_issue.op != VID) begin
             masku_operand_alu_ready = '1;
@@ -1312,7 +1312,7 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
         end
         // Mask is always accessed at bit level
         // VMADC, VMSBC handle masks in the mask queue
-        if (((in_m_ready_cnt_q == in_m_ready_threshold_q) || (issue_cnt_d == '0)) && !(vinsn_issue.op inside {[VMADC:VMSBC]})) begin
+        if ((((in_m_ready_cnt_q == in_m_ready_threshold_q) || (issue_cnt_d == '0)) && !(vinsn_issue.op inside {[VMADC:VMSBC]})) || (!vfirst_empty && (vinsn_issue.op == VFIRST))) begin
           in_m_ready_cnt_clr = 1'b1;
           if (!vinsn_issue.vm) begin
             masku_operand_m_ready = '1;
@@ -1586,6 +1586,8 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             out_valid_threshold_d  = ((NrLanes*DataWidth/8/ViotaParallelism) >> pe_req_i.vtype.vsew[1:0])-1;
           end
           VCPOP: begin
+            popcount_d = '0;
+
             // Mask to scalar
             delta_elm_d = VcpopParallelism;
 
@@ -1594,6 +1596,8 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
             out_valid_threshold_d  = '0;
           end
           VFIRST: begin
+            vfirst_count_d = '0;
+
             // Mask to scalar
             delta_elm_d = VfirstParallelism;
 


### PR DESCRIPTION
Fix `vfirst`/`vcpop` in masku and mask-comparison EEW in lane seq.

## Changelog

### Fixed

- Fix `vfirst`/`vcpop` state initialization 
- Fix mask-comparison `eew` in lane seq.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed