### PR TITLE
[HW] Prevent multipliers from getting spurious valid signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Reset `vfirst`/`vcpop` accumulator when a new instruction starts
  - Fix wrong `eew` for mask comparisons in lane sequencer
  - Fix bug in ordered reductions
+ - Avoid spurious valids to the simd multipliers
 
 ### Added
 

--- a/hardware/src/lane/vmfpu.sv
+++ b/hardware/src/lane/vmfpu.sv
@@ -510,7 +510,7 @@ module vmfpu import ara_pkg::*; import rvv_pkg::*; import fpnew_pkg::*;
   always_comb begin
     // Only one SIMD Multiplier receives the request
     vmul_simd_in_valid                           = '0;
-    vmul_simd_in_valid[vinsn_issue_q.vtype.vsew] = vmul_in_valid;
+    vmul_simd_in_valid[vinsn_issue_q.vtype.vsew] = clkgate_en_q & vmul_in_valid;
     vmul_in_ready                                = clkgate_en_q & vmul_simd_in_ready[vinsn_issue_q.vtype.vsew];
 
     // Saturation flag


### PR DESCRIPTION
Avoid spurious valids to the multipliers.

## Changelog

### Fixed

- Avoid spurious valids to the multipliers.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed