### PR TITLE
[SW] Add support for `rvv-bench`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,7 @@
 [submodule "cheshire/sw/cva6-sdk"]
 	path = cheshire/sw/cva6-sdk
 	url = https://github.com/pulp-platform/cva6-sdk.git
+[submodule "apps/rvv-bench"]
+	path = apps/rvv-bench
+	url = https://github.com/camel-cdr/rvv-bench.git
+	update = none

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Add Cheshire Linux FPGA flow for vcu128 and vcu118
  - Add RVV tests to be used with Cheshire's stub and specific debug environment.
  - Add ara-cheshire bender flow for vcs
+ - Add support for `rvv-bench` instruction benchmarking/verification
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ Currently, the following kernels support automatic VCD dumping: `fmatmul`, `fcon
 
 We also provide Synopsys Spyglass linting scripts in the hardware/spyglass. Run make lint in the hardware folder, with a specific MemPool configuration, to run the tests associated with the lint_rtl target.
 
+### Support for `rvv-bench`
+
+To run `rvv-bench` instructions benchmark, execute:
+
+```bash
+make rvv-bench
+make -C apps bin/rvv
+make -C hardware simv app=rvv
+```
+
 ## FPGA implementation and Linux flow
 
 Ara supports Cheshire's FPGA flow and can be currently implemented on VCU128 and VCU118 in bare-metal and with Linux. The tested configuration is with 2 lanes.


### PR DESCRIPTION
Add support for [rvv-bench](https://github.com/camel-cdr/rvv-bench) instruction benchmark.
Instructions from https://github.com/camel-cdr/rvv-bench/issues/17.

## Changelog

### Added

- Add support for `rvv-bench` instruction benchmark.

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed