### PR TITLE
[hardware] Fix parametrization on NrVRFBanks

### DIFF
--- a/hardware/include/ara_pkg.sv
+++ b/hardware/include/ara_pkg.sv
@@ -925,7 +925,6 @@ typedef struct packed {
   } opqueue_e;
 
   // Each lane has eight VRF banks
-  // NOTE: values != 8 are not supported
   localparam int unsigned NrVRFBanksPerLane = 8;
 
   // Find the starting address (in bytes) of a vector register chunk of vid
@@ -934,10 +933,10 @@ typedef struct packed {
     // Each vector register spans multiple words in each bank in each lane
     // The start address is the same in every lane
     // Therefore, within each lane, each vector register chunk starts on a given offset
-    vaddr = vid * (vlenb / NrLanes / NrVRFBanksPerLane);
-    // NOTE: the only extensively tested configuration of Ara keeps:
-    //        - (VLEN / NrLanes) constant to 1024;
-    //        - NrVRFBanksPerLane always equal to 8.
+    vaddr = vid * (vlenb / NrLanes / 8);
+    // NOTE: For the extensively tested configuration of Ara keeps:
+    //        - (VLEN / NrLanes) to 1024;
+    //        - NrVRFBanksPerLane equal to 8.
     //        Given so, each vector register will span 2 words across all the banks and lanes,
     //        therefore, vaddr = vid * 16
   endfunction: vaddr


### PR DESCRIPTION
### Fixed

bug in address generation to work for different numbers of VRF banks per lane

### Changed

changed ```vaddr``` macro to generate the start address. The operand requestor handles mapping requests to the correct bank.
