### PR TITLE
[HW] Fix VSTU queue overrun (Issue #369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+ - Fix queue overrun in the store unit retirement logic (#369)
+
  - Fix dump vtrace script for vsetvli instructions without x0 (ideal dispatcher)
  - Fix Pathfinder and FFT performance
  - Stall Ara and wait for ara_idle upon CSR write/read

--- a/apps/riscv-tests/isa/rv64uv/vse32.c
+++ b/apps/riscv-tests/isa/rv64uv/vse32.c
@@ -383,6 +383,25 @@ void TEST_CASE19(void) {
   LVVCMP_U32(19, ALIGNED_I32, LONG_I32);
 }
 
+void TEST_CASE20(void) {
+  uint64_t avl;
+  __asm__ volatile("vsetivli %[A], 1, e32, m1, ta, ma" : [A] "=r"(avl));
+  VLOAD_32(v1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[0]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[1]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[2]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[3]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[4]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[5]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[6]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[7]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[8]));
+  asm volatile("vse32.v v1, (%0)" ::"r"(&ALIGNED_I32[9]));
+
+  // Verify the last one
+  XCMP(20, ALIGNED_I32[9], 1);
+}
+
 int main(void) {
   INIT_CHECK();
   enable_vec();
@@ -407,6 +426,7 @@ int main(void) {
   TEST_CASE17();
   TEST_CASE18();
   TEST_CASE19();
+  TEST_CASE20();
 
   EXIT_CHECK();
 }

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -142,6 +142,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
 
   struct packed {
     pe_req_t [VInsnQueueDepth-1:0] vinsn;
+    vlen_t [VInsnQueueDepth-1:0] pending_b;
 
     // Each instruction can be in one of the three execution phases.
     // - Being accepted (i.e., it is being stored for future execution in this
@@ -165,7 +166,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
 
   // Is the vector instruction queue full?
   logic vinsn_queue_full;
-  assign vinsn_queue_full = (vinsn_queue_q.commit_cnt == VInsnQueueDepth);
+  assign vinsn_queue_full = (vinsn_queue_q.issue_cnt == VInsnQueueDepth);
 
   // Is the vector instruction queue empty?
   logic vinsn_queue_empty;
@@ -361,6 +362,8 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
           axi_w_o.last            = 1'b1;
           // Ask for another burst by the address generator
           axi_addrgen_req_ready_o = 1'b1;
+          // Increment the number of pending B responses for this instruction
+          vinsn_queue_d.pending_b[vinsn_queue_q.issue_pnt] += 1;
           // Reset AXI pointers
           axi_len_d                   = '0;
         end : beats_complete
@@ -427,10 +430,19 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
     if (axi_b_valid_i) begin : axi_b_valid
       // Acknowledge the B beat
       axi_b_ready_o = 1'b1;
+      // Decrement the number of pending B responses for this instruction
+      if (vinsn_commit_valid) begin
+        vinsn_queue_d.pending_b[vinsn_queue_q.commit_pnt] -= 1;
+      end
+      // pragma translate_off
+      assert (vinsn_commit_valid) else $error("Received AXI B response while no instruction is in flight.");
+      // pragma translate_on
+    end : axi_b_valid
 
-      // Mark the vector instruction as being done
-      if (vinsn_commit_valid) begin : instr_done
-        // Signal complete store
+    // Mark the vector instruction as being done
+    if (vinsn_commit_valid &&
+        vinsn_queue_d.pending_b[vinsn_queue_q.commit_pnt] == '0 &&
+        (vinsn_queue_q.commit_pnt != vinsn_queue_q.issue_pnt || vinsn_queue_q.issue_cnt == '0)) begin : instr_done
         store_complete_o = 1'b1;
 
         pe_resp_d.vinsn_done[vinsn_commit.id] = 1'b1;
@@ -443,8 +455,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
         else begin : commit_pnt_increment
           vinsn_queue_d.commit_pnt += 1;
         end : commit_pnt_increment
-      end : instr_done
-    end : axi_b_valid
+    end : instr_done
 
     ////////////////////////
     //  Handle exceptions //
@@ -513,6 +524,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
       end
 
       // Bump pointers and counters of the vector instruction queue
+      vinsn_queue_d.pending_b[vinsn_queue_q.accept_pnt] = '0;
       vinsn_queue_d.accept_pnt += 1;
       vinsn_queue_d.issue_cnt += 1;
       vinsn_queue_d.commit_cnt += 1;

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -429,7 +429,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
       axi_b_ready_o = 1'b1;
 
       // Mark the vector instruction as being done
-      if (vinsn_queue_d.issue_pnt != vinsn_queue_d.commit_pnt) begin : instr_done
+      if (vinsn_commit_valid) begin : instr_done
         // Signal complete store
         store_complete_o = 1'b1;
 


### PR DESCRIPTION
The vstu (Vector Store Unit) module had a bug reported in issue #369  where it would hang if its instruction queue became full of in-flight issued instructions. This occurred because the pointer-based retirement logic (` issue_pnt != commit_pnt` ) erroneously returned false when the circular buffer pointers overlapped.

## Changelog

### Fixed

- This PR replaces the pointer comparison with a check against the vinsn_commit_valid signal, which correctly identifies when instructions are pending in the queue regardless of the full state.

### Added 

- A regression test case (TEST_CASE20) has been added to vse32.c to reproduce the hang by filling the queue with several single-element stores.


## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
