### PR TITLE
[hw][dispatcher] Tag full vd..vd+nf for segment loads/stores

### DIFF
--- a/apps/seg_test/main.c
+++ b/apps/seg_test/main.c
@@ -1,0 +1,64 @@
+// Regression test for the per-vreg EEW tracker on segment loads.
+//
+// `vlseg4e16.v v8, (rs1)` writes 4 destination vregs (v8..v11). The
+// dispatcher must tag all 4 destinations with EEW=16 so a subsequent
+// read at EEW=16 does not see a tracker mismatch and reshuffle the
+// data. This test stores v8..v11 back to memory and checks the
+// elements bit-for-bit.
+
+#include <stdint.h>
+#ifdef SPIKE
+#include <stdio.h>
+#else
+#include "printf.h"
+#endif
+
+// 16 int16 inputs, viewed as 4 segments of 4 elements:
+//   segment 0: in_buf[0..3]
+//   segment 1: in_buf[4..7]
+//   segment 2: in_buf[8..11]
+//   segment 3: in_buf[12..15]
+// vlseg4e16 demuxes by element-within-segment:
+//   v8  = {in[0],  in[4],  in[8],  in[12]}
+//   v9  = {in[1],  in[5],  in[9],  in[13]}
+//   v10 = {in[2],  in[6],  in[10], in[14]}
+//   v11 = {in[3],  in[7],  in[11], in[15]}
+static const int16_t in_buf[16] = {
+     1,  2,  3,  4,
+    11, 12, 13, 14,
+    21, 22, 23, 24,
+    31, 32, 33, 34,
+};
+
+int main(void) {
+  int16_t v8_out[4], v9_out[4], v10_out[4], v11_out[4];
+  int fail = 0;
+
+  printf("=== seg_test ===\n");
+
+  asm volatile ("vsetivli x0, 4, e16, m1, ta, ma");
+
+  asm volatile ("vlseg4e16.v v8, (%0)" :: "r"(in_buf) : "memory");
+  asm volatile ("vse16.v v8,  (%0)"   :: "r"(v8_out)  : "memory");
+  asm volatile ("vse16.v v9,  (%0)"   :: "r"(v9_out)  : "memory");
+  asm volatile ("vse16.v v10, (%0)"   :: "r"(v10_out) : "memory");
+  asm volatile ("vse16.v v11, (%0)"   :: "r"(v11_out) : "memory");
+
+  printf("element  v8  v9  v10 v11\n");
+  for (int i = 0; i < 4; i++) {
+    printf("  [%d]    %d  %d  %d  %d\n",
+           i, v8_out[i], v9_out[i], v10_out[i], v11_out[i]);
+    int base = i == 0 ? 1 : i == 1 ? 11 : i == 2 ? 21 : 31;
+    if (v8_out[i]  != base + 0) fail++;
+    if (v9_out[i]  != base + 1) fail++;
+    if (v10_out[i] != base + 2) fail++;
+    if (v11_out[i] != base + 3) fail++;
+  }
+
+  if (fail == 0)
+    printf("*** seg_test PASS ***\n");
+  else
+    printf("*** seg_test FAIL: %d mismatches ***\n", fail);
+
+  return fail;
+}

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -3697,40 +3697,34 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
       end
     end
 
-    // Update the EEW
+    // Update the EEW.
+    // For segment loads/stores, the destination spans (nf+1) groups of
+    // EMUL consecutive vregs. Without this, only the base EMUL group is
+    // tagged and subsequent reads of vd+EMUL..vd+EMUL*(nf+1)-1 see the
+    // reset-default EW8 and trigger a spurious on-read EEW reshuffle.
+    // Constraint EMUL*(nf+1) <= 8 is already enforced upstream, so the
+    // loop bound of 8 covers all legal cases.
     if (ara_req_valid_d && ara_req.use_vd && ara_req_ready_i) begin
+      automatic int unsigned regs_per_emul;
+      automatic int unsigned regs_to_tag;
+      automatic logic        is_seg_mem_op;
       unique case (ara_req.emul)
-        LMUL_1: begin
-          for (int i = 0; i < 1; i++) begin
-            eew_d[ara_req.vd + i]       = ara_req.vtype.vsew;
-            eew_valid_d[ara_req.vd + i] = 1'b1;
-          end
-        end
-        LMUL_2: begin
-          for (int i = 0; i < 2; i++) begin
-            eew_d[ara_req.vd + i]       = ara_req.vtype.vsew;
-            eew_valid_d[ara_req.vd + i] = 1'b1;
-          end
-        end
-        LMUL_4: begin
-          for (int i = 0; i < 4; i++) begin
-            eew_d[ara_req.vd + i]       = ara_req.vtype.vsew;
-            eew_valid_d[ara_req.vd + i] = 1'b1;
-          end
-        end
-        LMUL_8: begin
-          for (int i = 0; i < 8; i++) begin
-            eew_d[ara_req.vd + i]       = ara_req.vtype.vsew;
-            eew_valid_d[ara_req.vd + i] = 1'b1;
-          end
-        end
-        default: begin // EMUL < 1
-          for (int i = 0; i < 1; i++) begin
-            eew_d[ara_req.vd + i]       = ara_req.vtype.vsew;
-            eew_valid_d[ara_req.vd + i] = 1'b1;
-          end
-        end
+        LMUL_1:  regs_per_emul = 1;
+        LMUL_2:  regs_per_emul = 2;
+        LMUL_4:  regs_per_emul = 4;
+        LMUL_8:  regs_per_emul = 8;
+        default: regs_per_emul = 1; // EMUL < 1
       endcase
+      is_seg_mem_op = (ara_req.op inside {VLE, VLSE, VLXE, VSE, VSSE, VSXE})
+                   && (ara_req.nf != 3'b000);
+      regs_to_tag = is_seg_mem_op ? regs_per_emul * (int'(ara_req.nf) + 1)
+                                  : regs_per_emul;
+      for (int i = 0; i < 8; i++) begin
+        if (i < regs_to_tag) begin
+          eew_d[ara_req.vd + i]       = ara_req.vtype.vsew;
+          eew_valid_d[ara_req.vd + i] = 1'b1;
+        end
+      end
     end
 
     // Any valid non-config instruction is a NOP if vl == 0, with some exceptions,


### PR DESCRIPTION
The per-vreg EEW tracker (eew_d[]) is updated when an instruction writes a destination vreg, but the existing loop only iterates over EMUL consecutive registers. Segment loads/stores write (NF+1)*EMUL consecutive vregs (vd, vd+1, ..., vd+nf at each EMUL group), so all but the base vd were left at the reset-default EW8.

Fix: when the op is a segment load/store (VLE/VLSE/VLXE/VSE/VSSE/VSXE with nf != 0), extend the tracker update loop to cover (nf+1)*EMUL consecutive vregs.

The bug was hidden in the existing rv64uv segment tests because VCLEAR (used as a defensive reset before each test) does `vmv.v.i v_reg, 0` at the test's vsew, which side-effects the EEW tracker into the matching state for v_reg. Tests that lack this pre-tagging surface the bug.

Description of PR that completes issue here...

## Changelog

### Fixed

- Description of changes

### Added

- Description of changes

### Changed

- Description of changes

## Checklist

- [ ] Automated tests pass
- [ ] Changelog updated
- [ ] Code style guideline is observed

Please check our [contributing guidelines](CONTRIBUTING.md) before opening a Pull Request.
