### PR TITLE
[cheshire] Enhance documentation for Ara integration under Cheshire SoC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Switch to a better buildroot mirror
  - CI frees up space in the runner before building a toolchain
  - Update documentation
+ - Enhance Cheshire's documentation for better workflow integration with Ara
 
 ## 3.0.0 - 2023-09-08
 

--- a/cheshire/README.md
+++ b/cheshire/README.md
@@ -40,6 +40,10 @@ cd ${ARA_ROOT}
 
 ## FPGA and OS flow
 
+> [!WARNING]
+> Ensure that your `$PATH` variable includes ONLY those binaries listed above as well as default system's binaries. Your `$PATH` should look something like follows:
+> `/path/to/RISCV>=11.2.0:/path/to/bender:/path/to/cmake>= 3.24.0/:/path/to/python>= 3.11:/bin:/usr/bin:etc`
+
 ### LINUX-RVV Kernels
 Compile kernels to be run on the FPGA under Linux (this will also install the buildroot toolchain)
 

--- a/cheshire/README.md
+++ b/cheshire/README.md
@@ -89,7 +89,7 @@ cd ${ARA_ROOT}/cheshire
 make ara-chs-xilinx-program
 ```
 
-For more information, see Cheshire's documentation (https://pulp-platform.github.io/cheshire/tg/xilinx).
+Every output will be in `cheshire/target/xilinx` directory. For more information, see Cheshire's documentation (https://pulp-platform.github.io/cheshire/tg/xilinx).
 
 ### Example
 

--- a/cheshire/README.md
+++ b/cheshire/README.md
@@ -4,6 +4,27 @@ Ara can be synthesized on a VCU128 FPGA and boot Linux through the Cheshire SoC.
 
 Our entry point is to generate a custom `add_sources.vcu128.tcl` file with specific Ara targets, copy this file into the Cheshire directory, and then use the default Cheshire compile flow, which will use our provided TCL file
 
+## Requirements
+From Cheshire's [web documentation](https://pulp-platform.github.io/cheshire/gs/#dependencies), ensure you have the next dependencies:
+
+- GNU make >= 3.82
+- CMake >= 3.24.0
+- Python >= 3.11
+- Bender >= 0.27.1
+- RISCV GCC >= 11.2.0
+
+> [!TIP]
+> Check [Bender](https://github.com/pulp-platform/bender) repository to install it
+
+For Python dependencies, it is highly recommended to create a virtual environment and install all packages listed in `requirements.txt`
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+
+pip install -r requirements.txt
+```
+
 ## How to Use
 
 Ara should be instantiated as a submodule of Cheshire. This means that the Ara repo should be downloaded through `bender checkout` from the Cheshire directory. Then, Ara's path can be retrived using `bender path ara`.

--- a/cheshire/README.md
+++ b/cheshire/README.md
@@ -64,6 +64,8 @@ cd ${ARA_ROOT}/cheshire/sw
 make linux-img
 
 # Generate Cheshire's Linux img
+export VIVADO="/path/to/Vivado/20XX.X/bin/vivado"
+
 cd ${ARA_ROOT}/cheshire
 make ara-chs-image
 ```

--- a/cheshire/README.md
+++ b/cheshire/README.md
@@ -27,10 +27,10 @@ pip install -r requirements.txt
 
 ## How to Use
 
-Ara should be instantiated as a submodule of Cheshire. This means that the Ara repo should be downloaded through `bender checkout` from the Cheshire directory. Then, Ara's path can be retrived using `bender path ara`.
+Ara should be instantiated as a submodule of Cheshire. This means that the Ara repo should be downloaded through `bender checkout` from the Cheshire directory, more specifically, the `mp/ara-pulp-v2` branch, which includes the CVA6 connected to the Ara. Then, Ara's path can be retrived using `bender path ara`.
 
 ```bash
-git clone git@github.com:pulp-platform/cheshire.git
+git clone --branch=mp/ara-pulp-v2 https://github.com/pulp-platform/cheshire.git
 cd cheshire
 git checkout ${COMMIT}
 bender checkout

--- a/cheshire/requirements.txt
+++ b/cheshire/requirements.txt
@@ -15,7 +15,7 @@ mkdocs-material
 markdown-grid-tables
 tclint==0.4.2
 flatdict>=4.1.0
-setuptools<81
+setuptools==80
 peakrdl>=1.5.0
 peakrdl-rawheader>=0.2.3
 dataclasses

--- a/cheshire/requirements.txt
+++ b/cheshire/requirements.txt
@@ -1,6 +1,6 @@
-# University Institute of Applied Microelectronics
-#       https://www.iuma.ulpgc.es/
+# University Institute of Applied Microelectronics (https://www.iuma.ulpgc.es/)
 # Author: Jorge López Viera
+# Created: 20/05/2026
 # This file includes the Python's dependencies for
 # both the Cheshire and Ara
 

--- a/cheshire/requirements.txt
+++ b/cheshire/requirements.txt
@@ -1,0 +1,28 @@
+# University Institute of Applied Microelectronics
+#       https://www.iuma.ulpgc.es/
+# Author: Jorge López Viera
+# This file includes the Python's dependencies for
+# both the Cheshire and Ara
+
+requests
+hjson
+mako
+pyyaml
+tabulate
+yapf
+mkdocs
+mkdocs-material
+markdown-grid-tables
+tclint==0.4.2
+flatdict>=4.1.0
+setuptools<81
+peakrdl>=1.5.0
+peakrdl-rawheader>=0.2.3
+dataclasses
+gitpython
+jsonref
+jsonschema
+yamlfmt
+numpy
+matplotlib
+scikit-learn


### PR DESCRIPTION
Recently, trying to get Ara working under Cheshire SoC, I've stumbled upon some problems that I solve here.

1. Python's dependencies. Both, Ara and Cheshire, use their own Python packages, then I see it useful to have them all gathered in one file as I've done in `requirements.txt` ([69554ce36341311a61554eee3364314b303c1c90](https://github.com/pulp-platform/ara/commit/69554ce36341311a61554eee3364314b303c1c90))
2. Documentation. Because of this, I've had to be navigating between their documentations, which can be quite annoying and confusing some times; then, I've listed all the steps involved in compiling both platforms ([a07bab0a6553c6473c58d49e7e6c9edaece960f4](https://github.com/pulp-platform/ara/commit/a07bab0a6553c6473c58d49e7e6c9edaece960f4)). Furthermore, I've specified the branch that includes the Ara inside Cheshire's repository ([ffc8f7c5112b8abb8ec857c5c1cf1d1a5a0bd861](https://github.com/pulp-platform/ara/commit/ffc8f7c5112b8abb8ec857c5c1cf1d1a5a0bd861)); other branches would show the next error right after executing `bender path ara`

```bash
Error: Dependency `ara` does not exist. Did you forget to add it to the manifest?
```

## Changelog

### Changed

Cheshire documentation focusing on dependencies and workflow

## Checklist

- [ ] Automated tests pass
- [ x] Changelog updated
- [ ] Code style guideline is observed
