### PR TITLE
[hardware] :bug: Zero-extend the vslideup.vi/vslidedown.vi immediate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Force cheshire's sim scripts re-generation
  - Fix u-boot to support RVV-linux
  - Fixed src emul check for vector integer extension operation
+ - Zero-extend the unsigned vslideup.vi/vslidedown.vi immediate
 
 ### Added
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1224,7 +1224,9 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   end
                   6'b001110: begin
                     ara_req.op            = ara_pkg::VSLIDEUP;
-                    ara_req.stride        = {{ELEN{insn.varith_type.rs1[19]}}, insn.varith_type.rs1};
+                    // vslideup.vi/vslidedown.vi take an UNSIGNED 5-bit immediate
+                    // (V-spec 16.3.1/16.3.2); it must be zero-extended, not sign-extended.
+                    ara_req.stride        = {{ELEN{1'b0}}, insn.varith_type.rs1};
                     ara_req.eew_vs2       = csr_vtype_q.vsew;
                     // Encode vslideup/vslide1up on the use_scalar_op field
                     ara_req.use_scalar_op = 1'b0;
@@ -1236,7 +1238,8 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                   end
                   6'b001111: begin
                     ara_req.op            = ara_pkg::VSLIDEDOWN;
-                    ara_req.stride        = {{ELEN{insn.varith_type.rs1[19]}}, insn.varith_type.rs1};
+                    // Unsigned 5-bit immediate (V-spec 16.3.2): zero-extend it.
+                    ara_req.stride        = {{ELEN{1'b0}}, insn.varith_type.rs1};
                     ara_req.eew_vs2       = csr_vtype_q.vsew;
                     // Encode vslidedown/vslide1down on the use_scalar_op field
                     ara_req.use_scalar_op = 1'b0;


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

The Ara dispatcher sign-extends the 5-bit immediate of vslideup.vi and
vslidedown.vi (ara_req.stride = {{ELEN{rs1[19]}}, rs1}). The RISC-V vector spec
makes this immediate unsigned (16.3.1 and 16.3.2). For an immediate of 16 or
more the sign bit is set, so a small positive slide offset becomes a large
negative one, the slide moves the whole vector out of range and returns all
zeros, and the result diverges from Spike.

## Changelog

### Fixed

The fix zero-extends the immediate for the two slide cases (ara_req.stride =
{{ELEN{1'b0}}, rs1}). The signed scalar_op used by the other OPIVI instructions
is left unchanged, since their immediate is signed.

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed

