### PR TITLE
[hardware] :bug: Fix NP2 slide hang on chunk-aligned stride

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Force cheshire's sim scripts re-generation
  - Fix u-boot to support RVV-linux
  - Fixed src emul check for vector integer extension operation
+ - Fix slide unit hang when the slide offset is a whole-chunk multiple
 
 ### Added
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -267,14 +267,26 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
   // NP2 Slide support
   logic is_stride_np2;
-  logic [idx_width(idx_width(VLENB << 3)):0] sldu_popc;
+  logic [idx_width(idx_width(8*NrLanes)):0] sldu_popc;
 
-  // Is the stride power of two?
+  // The SLDU's p2_stride_gen only resolves the WITHIN-CHUNK portion of the slide
+  // offset (it is idx_width(8*NrLanes) bits wide, matching one VRF chunk); the
+  // chunk-level portion of the stride is handled by the slide operand addressing.
+  // is_stride_np2 must therefore be computed on exactly that within-chunk offset
+  // (element stride truncated to the generator width). Computing it on the full
+  // stride wrongly sends pure chunk-shift offsets (whose low bits are zero, e.g.
+  // vslidedown by 48/96, or a sign-extended .vi imm >= 16) into the NP2 path,
+  // where p2_stride_gen reports popcount 0 and SLIDE_NP2_RUN's popc == 1 exit is
+  // never reached, hanging the slide unit forever.
+  logic [idx_width(8*NrLanes)-1:0] sldu_stride_chunk;
+  assign sldu_stride_chunk = (ara_req.stride >> csr_vtype_q.vsew);
+
+  // Is the within-chunk stride a power of two?
   popcount #(
-    .INPUT_WIDTH (idx_width(VLENB << 3))
+    .INPUT_WIDTH (idx_width(8*NrLanes))
   ) i_np2_stride (
-    .data_i    (ara_req.stride[idx_width(VLENB << 3)-1:0]  ),
-    .popcount_o(sldu_popc                                  )
+    .data_i    (sldu_stride_chunk),
+    .popcount_o(sldu_popc        )
   );
 
   assign is_stride_np2 = sldu_popc > 1;


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

## Problem

`vslidedown`/`vslideup` with an offset that is a whole-chunk multiple
hangs the slide unit permanently. Examples at VLEN 4096, NrLanes 2:
offset 48 or 96, or a `.vi` slide with a sign-extended immediate of 16
or more.

The dispatcher computes `is_stride_np2` from the popcount of the full
slide offset (`ara_req.stride[idx_width(VLENB << 3)-1:0]`), but the
SLDU's `p2_stride_gen` only resolves the within-chunk part of the offset
(`idx_width(8*NrLanes)` bits). A pure chunk-shift has all-zero
within-chunk bits, so the generator reports popcount 0. When the full
popcount is greater than one the instruction is sent to the NP2 path,
and `SLIDE_NP2_RUN` waits for `p2_stride_gen_popc_q == 1`, which never
happens. The slide unit stalls forever with no architectural error, so
unprivileged code can wedge the accelerator.

## Fix

Compute `is_stride_np2` on the within-chunk offset that `p2_stride_gen`
actually processes (the element stride shifted down by `vsew` and
truncated to the generator width). Chunk-level slides then take the
regular power-of-two path.

The same variable underlies issue #340: its offset 514 = 32*16 + 2 has a
nonzero within-chunk part, so the generator still terminates but on the
wrong decomposition, giving a wrong result instead of a hang. Both cases
share this one fix.

Fixes #340

## Changelog

### Fixed

 - Fix slide unit hang when the slide offset is a whole-chunk multiple

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed
