### PR TITLE
[hardware] :bug: Fix vrgather/vcompress + vmv.x.s MaskB deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Force cheshire's sim scripts re-generation
  - Fix u-boot to support RVV-linux
  - Fixed src emul check for vector integer extension operation
+ - Fix deadlock when a vrgather/vrgatherei16/vcompress is followed by vmv.x.s/vfmv.f.s
 
 ### Added
 

--- a/hardware/src/lane/lane_sequencer.sv
+++ b/hardware/src/lane/lane_sequencer.sv
@@ -243,6 +243,11 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   // Running instructions
   logic [NrVInsn-1:0] vinsn_done_d, vinsn_done_q;
   logic [NrVInsn-1:0] vinsn_running_d, vinsn_running_q;
+  // Per-vinsn flag: running vrgather/vrgatherei16/vcompress that use the
+  // ad-hoc MaskB channel.
+  logic [NrVInsn-1:0] vinsn_uses_maskb_adhoc_d, vinsn_uses_maskb_adhoc_q;
+  logic               any_maskb_adhoc_running;
+  assign any_maskb_adhoc_running = |(vinsn_running_q & vinsn_uses_maskb_adhoc_q);
 
   // VFU operation
   vfu_operation_t vfu_operation_d;
@@ -265,6 +270,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
   always_comb begin: sequencer
     // Running loops
     vinsn_running_d = vinsn_running_q & pe_vinsn_running_i;
+    // Maintain the maskb-adhoc bitmap; bits go inert as vinsn_running clears.
+    vinsn_uses_maskb_adhoc_d = vinsn_uses_maskb_adhoc_q;
 
     // Ready to accept a new request, by default
     pe_req_ready = 1'b1;
@@ -314,8 +321,13 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
             operand_request_valid_o[MaskM]);
         end
         VFU_None : begin
-          // VRGATHER/VCOMPRESS use the MaskB opqueue with non-traditional request scheme
-          pe_req_ready = !(operand_request_valid_o[MaskB]) && ((vrgat_state_q == IDLE) && !masku_vrgat_req_valid_q);
+          // Bar VFU_None acceptance while a vrgather/vcompress is still
+          // running in this lane, closing the window where vmv.x.s could grab
+          // MaskB before masku_vrgat_req_valid_q propagates.
+          pe_req_ready = !(operand_request_valid_o[MaskB])
+                      && (vrgat_state_q == IDLE)
+                      && !masku_vrgat_req_valid_q
+                      && !any_maskb_adhoc_running;
         end
         default:;
       endcase
@@ -363,6 +375,8 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
 
       // Mark the vector instruction as running
       vinsn_running_d[pe_req.id] = (vfu_operation_d.vfu != VFU_None) ? 1'b1 : 1'b0;
+      // Record whether this vinsn uses the ad-hoc MaskB channel.
+      vinsn_uses_maskb_adhoc_d[pe_req.id] = (pe_req.op inside {[VRGATHER:VCOMPRESS]});
 
       // Mute request if the instruction runs in the lane and the vl is zero.
       // Exception: during a reduction, all the lanes must cooperate anyway.
@@ -956,6 +970,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
     if (!rst_ni) begin
       vinsn_done_q    <= '0;
       vinsn_running_q <= '0;
+      vinsn_uses_maskb_adhoc_q <= '0;
 
       vfu_operation_o       <= '0;
       vfu_operation_valid_o <= 1'b0;
@@ -968,6 +983,7 @@ module lane_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::
     end else begin
       vinsn_done_q    <= vinsn_done_d;
       vinsn_running_q <= vinsn_running_d;
+      vinsn_uses_maskb_adhoc_q <= vinsn_uses_maskb_adhoc_d;
 
       vfu_operation_o       <= vfu_operation_d;
       vfu_operation_valid_o <= vfu_operation_valid_d;


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

### Problem

A `vrgather`/`vrgatherei16`/`vcompress` immediately followed by a `vmv.x.s`
(or `vfmv.f.s`) that reads its result deadlocks the lane. Both instructions use
the per-lane ad-hoc MaskB operand channel. There is a brief window, before the
gather claims the channel (`masku_vrgat_req_valid_q` still low and the gather
FSM still `IDLE`), in which the `VFU_None` path accepts the `vmv.x.s`. The scalar
move takes MaskB and waits for the gather's result, while the gather waits for
the MaskB channel the move is holding. The lane never retires and the cva6 host
stalls on the accelerator handshake until reset.

### Fix

Add a per-vinsn bitmap marking running `vrgather`/`vrgatherei16`/`vcompress`
(the ops that use the ad-hoc MaskB channel), and bar `VFU_None` acceptance while
any such instruction is in flight in the lane. The scalar move then waits until
the gather has released the channel. Only the `VFU_None` acceptance gate changes;
other paths are untouched.

## Changelog

### Fixed

 - Fix deadlock when a vrgather/vrgatherei16/vcompress is followed by vmv.x.s/vfmv.f.s

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed
