### PR TITLE
[hardware] :bug: Raise illegal_insn for reserved VWXUNARY0 encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Force cheshire's sim scripts re-generation
  - Fix u-boot to support RVV-linux
  - Fixed src emul check for vector integer extension operation
+ - Raise illegal-instruction for reserved VWXUNARY0 sub-op encodings (were silently hanging)
 
 ### Added
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -1510,7 +1510,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                         ara_req.op      = ara_pkg::VFIRST;
                         ara_req.eew_vs2 = eew_q[ara_req.vs2];
                       end
-                      default :;
+                      default: illegal_insn = 1'b1;
                     endcase
 
                     ara_req.use_vd     = 1'b0;


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

### Problem

Ara's VWXUNARY0 decoder tells the three defined sub-ops apart by the rs1 field:

```
case (insn.varith_type.rs1)
  5'b00000: ... // vmv.x.s
  5'b10000: ... // vcpop.m
  5'b10001: ... // vfirst.m
  default :;    // <-- reserved encodings absorbed silently
endcase
```

RVV 1.0 §16.1 marks any other rs1 value as reserved. Because the default arm does
nothing, the instruction still runs the rest of the OPMVV header with
`ara_req_valid` asserted and reaches the lanes as a malformed request (`op`
defaults to `VADD`, `vfu = VFU_Alu`). The lanes accept it but never produce the
scalar response, so the cva6 host stalls on the accelerator handshake until reset.
An unprivileged reserved encoding wedges the accelerator.

### Fix

Raise `illegal_insn` in the default arm, as the spec requires. Valid code is
unaffected.

Related to the VWXUNARY0 handling in #467, but a distinct fix (that PR addresses
`use_vs1`; this one traps the reserved encodings).

## Changelog

### Fixed

 - Raise illegal-instruction for reserved VWXUNARY0 sub-op encodings (were silently hanging)

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed
