### PR TITLE
[hardware] :bug: Fix vrgather out-of-range index hang in the mask unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Force cheshire's sim scripts re-generation
  - Fix u-boot to support RVV-linux
  - Fixed src emul check for vector integer extension operation
+ - Fix hang when a vrgather/vrgatherei16 index is out of range
 
 ### Added
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -1264,7 +1264,11 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
       // VID does not require any operand, while VRGATHER/VCOMPRESS's ALU operand is just preprocessed to get the indices.
       // Therefore, VRGATHER/VCOMPRESS's operand are special. Only the vd operand works in the MASKU ALU.
       if (!result_queue_full && (&masku_operand_alu_valid || vinsn_issue.op inside {VID,[VRGATHER:VCOMPRESS]})
-                             && (&masku_operand_vd_valid  || (!vinsn_issue.use_vd_op && !(vinsn_issue.op inside {[VRGATHER:VCOMPRESS]})))
+                             // FIX (vrgather OOB hang): an out-of-range VRGATHER/VRGATHEREI16 index reads 0
+                             // (RVV 1.0 §16.4) and the masku never requests vd data for it, so the original
+                             // &masku_operand_vd_valid gate waited forever. Waive vd-valid when the index is OOB.
+                             && (&masku_operand_vd_valid  || (!vinsn_issue.use_vd_op && !(vinsn_issue.op inside {[VRGATHER:VCOMPRESS]}))
+                                                          || (vrgat_idx_oor_q && (vinsn_issue.op inside {VRGATHER,VRGATHEREI16})))
                              && (&masku_operand_m_valid   || vinsn_issue.vm || vinsn_issue.op inside {[VMADC:VMSBC]})
                              && (!vrgat_idx_fifo_empty    || !(vinsn_issue.op inside {[VRGATHER:VCOMPRESS]}))) begin
 


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

### Problem

A `vrgather`/`vrgatherei16` with an index past the end of the source vector must
read 0 for that element (RVV 1.0 §16.4), and the mask unit correctly never requests
vd data for it. But the mask unit's issue gate still waited on
`&masku_operand_vd_valid`, so the gather never issued, the mask unit spun forever,
and the cva6 host stalled on the accelerator handshake until reset.

Minimal reproducer (`NrLanes=2, VLEN=512`, so VLMAX = VLEN/SEW = 64 at e8):

```
vsetivli x0, 8, e8, m1, ta, ma
li   t1, 200            # 200 >= VLMAX (64) -> out of range
vmv.v.x v8, t1          # all gather indices = 200 (OOB)
vid.v   v16             # source = [0,1,2,...]
vrgather.vv v24, v16, v8   # hangs
```

### Fix

Waive the `vd_valid` wait in the issue gate when the index is out of range
(`vrgat_idx_oor_q`), for `VRGATHER`/`VRGATHEREI16`. The result path already
substitutes 0 for out-of-range elements, so no vd data is needed. Other ops are
unaffected.

## Changelog

### Fixed

 - Fix hang when a vrgather/vrgatherei16 index is out of range

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed
