### PR TITLE
[hardware] :bug: Fix false illegal on unaligned widening reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Force cheshire's sim scripts re-generation
  - Fix u-boot to support RVV-linux
  - Fixed src emul check for vector integer extension operation
+ - Fix false illegal-instruction on a widening reduction (vwredsum/vwredsumu) with an unaligned vd
 
 ### Added
 

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -931,18 +931,27 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
 
                 // Instructions with an integer LMUL have extra constraints on the registers they can
                 // access.
-                unique case (ara_req.emul)
-                  LMUL_2: if ((insn.varith_type.rs1 & 5'b00001) != 5'b00000 ||
-                        (insn.varith_type.rs2 & 5'b00001) != 5'b00000 ||
-                        (insn.varith_type.rd & 5'b00001) != 5'b00000) illegal_insn = 1'b1;
-                  LMUL_4: if ((insn.varith_type.rs1 & 5'b00011) != 5'b00000 ||
-                        (insn.varith_type.rs2 & 5'b00011) != 5'b00000 ||
-                        (insn.varith_type.rd & 5'b00011) != 5'b00000) illegal_insn = 1'b1;
-                  LMUL_8: if ((insn.varith_type.rs1 & 5'b00111) != 5'b00000 ||
-                        (insn.varith_type.rs2 & 5'b00111) != 5'b00000 ||
-                        (insn.varith_type.rd & 5'b00111) != 5'b00000) illegal_insn = 1'b1;
-                  default:;
-                endcase
+                if (ara_req.op inside {VWREDSUMU, VWREDSUM}) begin
+                  unique case (csr_vtype_q.vlmul)
+                    LMUL_2: if ((insn.varith_type.rs2 & 5'b00001) != 5'b00000) illegal_insn = 1'b1;
+                    LMUL_4: if ((insn.varith_type.rs2 & 5'b00011) != 5'b00000) illegal_insn = 1'b1;
+                    LMUL_8: if ((insn.varith_type.rs2 & 5'b00111) != 5'b00000) illegal_insn = 1'b1;
+                    default:;
+                  endcase
+                end else begin
+                  unique case (ara_req.emul)
+                    LMUL_2: if ((insn.varith_type.rs1 & 5'b00001) != 5'b00000 ||
+                          (insn.varith_type.rs2 & 5'b00001) != 5'b00000 ||
+                          (insn.varith_type.rd & 5'b00001) != 5'b00000) illegal_insn = 1'b1;
+                    LMUL_4: if ((insn.varith_type.rs1 & 5'b00011) != 5'b00000 ||
+                          (insn.varith_type.rs2 & 5'b00011) != 5'b00000 ||
+                          (insn.varith_type.rd & 5'b00011) != 5'b00000) illegal_insn = 1'b1;
+                    LMUL_8: if ((insn.varith_type.rs1 & 5'b00111) != 5'b00000 ||
+                          (insn.varith_type.rs2 & 5'b00111) != 5'b00000 ||
+                          (insn.varith_type.rd & 5'b00111) != 5'b00000) illegal_insn = 1'b1;
+                    default:;
+                  endcase
+                end
 
                 // Instruction is invalid if the vtype is invalid
                 if (csr_vtype_q.vill) illegal_insn = 1'b1;


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

### Problem

A widening reduction `vwredsum.vs`/`vwredsumu.vs` whose destination is not aligned
to the *widened* LMUL is legal RVV, but ara's dispatcher rejects it as illegal.
The register-alignment check keys on `ara_req.emul` (the widened LMUL) and applies
it to vs1, vd, and vs2. But a widening reduction's vd and vs1 are single 2*SEW
elements (EMUL=1, no group-alignment constraint), and vs2 is the source vector at
the original `vlmul`. So a legal unaligned-vd reduction trips `illegal_insn`, the
op is never issued, no completion returns, and the hart spins on the accelerator
handshake until reset.

### Fix

For `VWREDSUM`/`VWREDSUMU`, check only vs2 against the original `vlmul`; drop the
alignment check on the single-element vd and vs1. Other ops are unchanged.

## Changelog

### Fixed

 - Fix false illegal-instruction on a widening reduction (vwredsum/vwredsumu) with an unaligned vd

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed
