### PR TITLE
[hardware] :bug: Fix vrgather deadlock on staggered lane handshakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Force cheshire's sim scripts re-generation
  - Fix u-boot to support RVV-linux
  - Fixed src emul check for vector integer extension operation
+ - Fix vrgather deadlock when the lanes accept the broadcast index request on different cycles
 
 ### Added
 

--- a/hardware/src/masku/masku.sv
+++ b/hardware/src/masku/masku.sv
@@ -556,15 +556,16 @@ module masku import ara_pkg::*; import rvv_pkg::*; #(
     for (int lane = 0; lane < NrLanes; lane++) begin
       // Valid address request if the address fifo is not empty and if the valid is not masked
       masku_vrgat_req_valid_o[lane] = ~vrgat_req_fifo_empty & ~vrgat_req_valid_mask_q[lane];
-      // Mask the next valid on this lane if the lane is handshaking
-      vrgat_req_valid_mask_d[lane] = masku_vrgat_req_ready_i[lane];
+      // Mask the next valid on this lane once it has actually handshaked (valid and ready), held until the request pops
+      if (masku_vrgat_req_valid_o[lane] & masku_vrgat_req_ready_i[lane])
+        vrgat_req_valid_mask_d[lane] = 1'b1;
     end
 
-    // Don't mask if all the lanes have handshaked
-    if (&masku_vrgat_req_ready_i) vrgat_req_valid_mask_d = '0;
-
-    // Pop the current address if all the lanes have handshaked it
-    if (&(masku_vrgat_req_ready_i | vrgat_req_valid_mask_q) && ~vrgat_req_fifo_empty) vrgat_req_fifo_pop = 1'b1;
+    // Pop the current address once every lane has handshaked it, then release the mask for the next request
+    if (&vrgat_req_valid_mask_d && ~vrgat_req_fifo_empty) begin
+      vrgat_req_fifo_pop     = 1'b1;
+      vrgat_req_valid_mask_d = '0;
+    end
   end
 
   // Overflow after 16-bits


### PR DESCRIPTION
Hello, here is a pull request for a bug I found.

### Problem

The mask unit issues each `vrgather`/`vrgatherei16` index request as a broadcast to
all lanes and pops it from the request FIFO once every lane has handshaked it. The
per-lane mask that records which lanes already took the current request is written
wrong on two counts:

- it keys on `masku_vrgat_req_ready_i[lane]` alone, which is the lane spill's
  "has room" signal and is high even when no valid request is being offered, so it
  can mask a lane that never actually handshaked; and
- it is a 1-cycle memory, not held.

The lanes handshake several cycles apart (their MaskB command counters drift), so the
mask unit can re-offer the same un-popped head to a lane that already accepted it.
That lane double-accepts, its MaskB counter desyncs from the other lane, the
"all lanes acked in one cycle" pop condition never lines up, the request FIFO fills,
index generation stalls, and the vrgather deadlocks. Only reset recovers.

### Fix

Latch each lane's real handshake (`valid && ready`) and hold the mask sticky until the
whole broadcast request pops, then release it for the next request.

## Changelog

### Fixed

 - Fix vrgather deadlock when the lanes accept the broadcast index request on different cycles

## Checklist

- [ ] Automated tests pass
- [x] Changelog updated
- [ ] Code style guideline is observed
