### PR TITLE
fix(vstu): Compare counters instead of pointers in B handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  - Force cheshire's sim scripts re-generation
  - Fix u-boot to support RVV-linux
  - Fixed src emul check for vector integer extension operation
+ - Fix VSTU queue overrun due to pointer comparison
 
 ### Added
 

--- a/hardware/src/vlsu/vstu.sv
+++ b/hardware/src/vlsu/vstu.sv
@@ -429,7 +429,7 @@ module vstu import ara_pkg::*; import rvv_pkg::*; #(
       axi_b_ready_o = 1'b1;
 
       // Mark the vector instruction as being done
-      if (vinsn_queue_d.issue_pnt != vinsn_queue_d.commit_pnt) begin : instr_done
+      if (vinsn_queue_d.issue_cnt != vinsn_queue_d.commit_cnt) begin : instr_done
         // Signal complete store
         store_complete_o = 1'b1;
 


### PR DESCRIPTION
This PR fixes a subtle bug in the vector store unit, which can deadlock Ara if all store instructions in the queue are issued before any of them get committed.

## Changelog

### Fixed

- Instead of comparing the ringbuffer pointers for pending issues and pending commits, this compares the respective counter values. Since the counters are one bit larger than the pointers, this covers the case where `issue_pnt` is `VInsnQueueDepth` instructions ahead of `commit_pnt` (i.e., `issue_pnt == commit_pnt` but `issue_cnt == '0` and `commit_cnt == VInsnQueueDepth`).

## Checklist

- [x] Automated tests pass
- [x] Changelog updated
- [x] Code style guideline is observed
