### PR TITLE
Check VLEN against the minimum VRF address stride

### DIFF
--- a/hardware/src/ara.sv
+++ b/hardware/src/ara.sv
@@ -681,4 +681,9 @@ module ara import ara_pkg::*; #(
   if (VLEN != 2**$clog2(VLEN))
     $error("[ara] The vector length must be a power of two.");
 
+  // Each vector register occupies vlenb / NrLanes / 8 addresses per lane, where
+  // the 8 is the lane datapath width in bytes. That stride must be non-zero.
+  if (VLEN < 64 * NrLanes)
+    $error("[ara] VLEN must be greater than or equal to 64 * NrLanes.");
+
 endmodule : ara


### PR DESCRIPTION
## Summary

Add a configuration check for VLEN/NrLanes combinations that produce a zero vector-register address stride.

Ara's vector-register addressing uses `vaddr = vid * (vlenb / NrLanes / 8)` with `vlenb = VLEN / 8`, so the per-register stride is `VLEN / (64 * NrLanes)` and must be non-zero.

For example `VLEN=128, NrLanes=4` currently satisfies the existing VLEN checks and reports `vlenb = 16`, but `16 / 4 / 8 = 0`, so all architectural vector registers map to the same VRF address. Reproduced by writing distinct values into `v0, v1, v2, v3, v8, v16, v31` before storing any of them: all seven read back the value written last (`v31`). Elaboration is clean and `vlenb` reads correctly, so nothing currently reports the problem.

The check requires `VLEN >= 64 * NrLanes` so the unsupported configuration is diagnosed explicitly. Consistent with the neighbouring parameter checks this uses `$error`; note Ara's Verilator flow passes `-Wno-fatal`, so like the existing checks it emits a diagnostic rather than halting the build.

### Boundary checks

| VLEN | NrLanes | stride | result |
|---|---|---|---|
| 128 | 2 | 1 | valid, unchanged |
| 256 | 4 | 1 | valid, unchanged |
| 512 | 8 | 1 | valid, unchanged |
| 2048 | 2 | 16 | valid, unchanged (stock config) |
| 128 | 4 | 0 | diagnosed |
| 256 | 8 | 0 | diagnosed |