### PR TITLE
Scale whole-register load vstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+ - Scale vstart for whole-register loads
  - Fix dump vtrace script for vsetvli instructions without x0 (ideal dispatcher)
  - Fix Pathfinder and FFT performance
  - Stall Ara and wait for ara_idle upon CSR write/read

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -3073,6 +3073,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
               ara_req_valid  = 1'b1;
 
               // Maximum vector length. VLMAX = nf * VLEN / EW8.
+              ara_req.vstart    <<= ara_req.vtype.vsew;
               ara_req.vtype.vsew = EW8;
               unique case (insn.vmem_type.nf)
                 3'd0: begin


### PR DESCRIPTION
Whole-register loads interpreted `vstart` as a byte count. Scale it by the encoded EEW before the EW8 rewrite.

Verification: Verilator elaboration.