### PR TITLE
Fix csrrwi vcsr readback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+ - Return the full vcsr value from csrrwi
  - Fix dump vtrace script for vsetvli instructions without x0 (ideal dispatcher)
  - Fix Pathfinder and FFT performance
  - Stall Ara and wait for ara_idle upon CSR write/read

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -3505,7 +3505,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       // logic [19:15] rs1; So, LSB is [15]
                       csr_vxrm_d            = vxrm_t'(acc_req_i.rs1[2:1]);
                       csr_vxsat_d           = vxsat_e'(acc_req_i.rs1[0]);
-                      acc_resp_o.result = csr_vxsat_q;
+                      acc_resp_o.result = {csr_vxrm_q, csr_vxsat_q};
                     end
                     default: illegal_insn = 1'b1;
                   endcase

--- a/hardware/src/ara_dispatcher.sv
+++ b/hardware/src/ara_dispatcher.sv
@@ -3505,7 +3505,7 @@ module ara_dispatcher import ara_pkg::*; import rvv_pkg::*; #(
                       // logic [19:15] rs1; So, LSB is [15]
                       csr_vxrm_d            = vxrm_t'(acc_req_i.rs1[2:1]);
                       csr_vxsat_d           = vxsat_e'(acc_req_i.rs1[0]);
-                      acc_resp_o.result = {csr_vxrm_q, csr_vxsat_q};
+                      acc_resp_o.result = vlen_t'({csr_vxrm_q, csr_vxsat_q});
                     end
                     default: illegal_insn = 1'b1;
                   endcase


### PR DESCRIPTION
`csrrwi vcsr` returned only `vxsat`. Return the full CSR.

Verification: Verilator elaboration.