### PR TITLE
Forward exceptions from segment micro-ops

### DIFF
--- a/hardware/src/segment_sequencer.sv
+++ b/hardware/src/segment_sequencer.sv
@@ -179,8 +179,10 @@ module segment_sequencer import ara_pkg::*; import rvv_pkg::*; #(
           if (ara_resp_valid_i) begin
             // If exception, stop the execution and forward it to CVA6
             if (ara_resp_i.exception.valid) begin
-              ara_resp_d = ara_resp_i;
-              state_d    = SEGMENT_MICRO_OPS_END;
+              ara_req_valid_o = 1'b0;
+              segment_cnt_en  = 1'b0;
+              ara_resp_d      = ara_resp_i;
+              state_d         = SEGMENT_MICRO_OPS_END;
             // If no exception, continue with the micro ops
             end else begin
               // If over - stop in the next cycle

--- a/hardware/src/segment_sequencer.sv
+++ b/hardware/src/segment_sequencer.sv
@@ -176,8 +176,11 @@ module segment_sequencer import ara_pkg::*; import rvv_pkg::*; #(
           end
 
           // Wait for an answer from Ara's backend
-          if (ara_resp_valid_i) begin            // If exception, stop the execution
+          if (ara_resp_valid_i) begin
+            // If exception, stop the execution and forward it to CVA6
             if (ara_resp_i.exception.valid) begin
+              ara_resp_d = ara_resp_i;
+              state_d    = SEGMENT_MICRO_OPS_END;
             // If no exception, continue with the micro ops
             end else begin
               // If over - stop in the next cycle
@@ -195,8 +198,12 @@ module segment_sequencer import ara_pkg::*; import rvv_pkg::*; #(
           ara_resp_valid_o = 1'b0;
           // Stop injecting micro instructions
           ara_req_valid_o  = 1'b0;
-          // Wait for idle to give the final load/store_complete
-          if (ara_idle_i && ara_req_ready_i) begin
+          // A previously issued micro operation can still report an exception
+          if (ara_resp_valid_i && ara_resp_i.exception.valid) begin
+            ara_resp_d = ara_resp_i;
+            state_d    = SEGMENT_MICRO_OPS_END;
+          // Otherwise, wait for idle to give the final load/store_complete
+          end else if (ara_idle_i && ara_req_ready_i) begin
             state_d = SEGMENT_MICRO_OPS_END;
           end
         end


### PR DESCRIPTION
A backend exception from a segment micro-op was discarded because response forwarding is suppressed while sequencing, while the exception arm was empty. This could leave the dispatcher waiting indefinitely after the backend stopped accepting work.

Capture the exception response and end segment sequencing immediately. Also monitor responses while draining previously issued micro-ops so an exception from the last outstanding operation is not lost.

Verification: a standalone Verilator testbench covers nf=2/3/8, exceptions on the first/middle/last micro-op, a backend that stops responding after the fault, plus a backend that deasserts ready. All 11 scenarios complete with the expected response.