### PR TITLE
[hardware] Forward the fault-only-first flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+ - Forward the fault-only-first flag from the dispatcher to the processing elements
  - Fix dump vtrace script for vsetvli instructions without x0 (ideal dispatcher)
  - Fix Pathfinder and FFT performance
  - Stall Ara and wait for ara_idle upon CSR write/read

--- a/hardware/src/ara_sequencer.sv
+++ b/hardware/src/ara_sequencer.sv
@@ -466,6 +466,7 @@ module ara_sequencer import ara_pkg::*; import rvv_pkg::*; import cf_math_pkg::i
               vl            : ara_req_i.vl,
               vstart        : ara_req_i.vstart,
               vtype         : ara_req_i.vtype,
+              fault_only_first : ara_req_i.fault_only_first,
               hazard_vd     : pe_req_d.hazard_vd,
               hazard_vm     : pe_req_d.hazard_vm,
               hazard_vs1    : pe_req_d.hazard_vs1,


### PR DESCRIPTION
Forward `fault_only_first` into the PE request. The omitted field was zeroed by `default: '0`, disabling the existing fault-only-first handling added in #380.

Validation: syntax and diff checks; full-core simulation not rerun. Changelog updated.